### PR TITLE
#191

### DIFF
--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/PortfolioOverview.module.scss
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/PortfolioOverview.module.scss
@@ -1,5 +1,9 @@
 @import "~@microsoft/sp-office-ui-fabric-core/dist/sass/SPFabricCore.scss";
 
+[class^="mainContent"]{
+  position: relative !important;
+}
+
 .portfolioOverview {
   margin: 15px 0 0 0;
   .container {


### PR DESCRIPTION
#191 

Fixed position of portfolio overview detailslist by adding:
```scss
[class^="mainContent"]{
  position: relative !important;
}
```

The root cause was that the ScrollablePane didn't follow the specs by having an explicit height and position: relative. 
https://developer.microsoft.com/en-us/fabric#/controls/web/scrollablepane