### PR TITLE
Template Standardmal: Disabling content types for Prosjektlogg

### DIFF
--- a/Templates/Portfolio/Prosjektmaler/Standardmal.txt
+++ b/Templates/Portfolio/Prosjektmaler/Standardmal.txt
@@ -897,7 +897,7 @@
             "Title": "Prosjektlogg",
             "Description": "",
             "Template": 100,
-            "ContentTypesEnabled": true,
+            "ContentTypesEnabled": false,
             "RemoveExistingContentTypes": true,
             "ContentTypeBindings": [
                 {


### PR DESCRIPTION
Disabling content types for Prosjektlogg in [Standardmal](https://github.com/Puzzlepart/prosjektportalen365/pull/249/files#diff-f4177faed03dc21b416722536f720b22).