### PR TITLE
Read-only access to portfolio overview

### DIFF
--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/RenderItemColumn/index.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/RenderItemColumn/index.tsx
@@ -48,9 +48,10 @@ export function renderItemColumn(item: IFetchDataForViewItemResult, column: Proj
             return (
                 <span>
                     <a href={item.Path} rel='noopener noreferrer' target='_blank'>{colValue}</a>
-                    <span
+                    {item.Path && <span
                         style={{ cursor: 'pointer', marginLeft: 8 }}
                         onClick={() => { onUpdateState({ showProjectInfo: item }) }}> <Icon iconName='OpenInNewWindow' /></span>
+                    }
                 </span >
             )
         }

--- a/SharePointFramework/PortfolioWebParts/src/data/index.ts
+++ b/SharePointFramework/PortfolioWebParts/src/data/index.ts
@@ -91,7 +91,7 @@ export class DataAdapter {
      * @memberof DataAdapter
      */
     public async fetchDataForView(view: PortfolioOverviewView, configuration: IPortfolioConfiguration, siteId: string): Promise<IFetchDataForViewItemResult[]> {
-        let isCurrentUserInManagerGroup = await this._isUserInGroup("Portfolio Managers");
+        let isCurrentUserInManagerGroup = await this._isUserInGroup(strings.PortfolioManagerGroupName);
         if (isCurrentUserInManagerGroup) {
             return await this.fetchDataForManagerView(view, configuration, siteId);
         }

--- a/SharePointFramework/PortfolioWebParts/src/loc/mystrings.d.ts
+++ b/SharePointFramework/PortfolioWebParts/src/loc/mystrings.d.ts
@@ -105,6 +105,7 @@ declare interface IPortfolioWebPartsStrings {
   ViewNotFoundMessage: string;
   ViewsListNameLabel: string;
   ProjectsListName: string;
+  PortfolioManagerGroupName: string;
 }
 
 declare module 'PortfolioWebPartsStrings' {

--- a/SharePointFramework/PortfolioWebParts/src/loc/nb-no.js
+++ b/SharePointFramework/PortfolioWebParts/src/loc/nb-no.js
@@ -102,6 +102,7 @@ define([], function () {
     ViewNotFoundMessage: 'Finner ikke angitt visning.',
     ViewsListNameLabel: 'Visninger',
     SelectedColumnsLabel: 'Felter',
-    ProjectsListName: 'Prosjekter'
+    ProjectsListName: 'Prosjekter',
+    PortfolioManagerGroupName: 'Porteføljeinnsikt'
   }
 });


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [x] Check the commit's or even all commits' message 
- [x] Check your code additions will fail linting checks
- [x] Remember: After PR is closed, add PR description to [Changelog](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md)

### Description

Added functionality: if someone is in the group "Porteføljeinnsyn" they will be able to view all projects in the portfolio on PortfolioOverview. User is not able to enter project, only view data in Porteføljeoversikt

### How to test

Add user to "Porteføljeinnsyn" group. 
View "Porteføljeoversikt"

### Relevant issues (if applicable)
#243 
💔Thank you!
