### PR TITLE
Fixed view selector availability for non-admin users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Descriptions on configuration page
 - Added new group "Porteføljeinnsyn" granting users in this group insight into all projects in the portfolio
 - Added "Porteføljeinnsyn" button on configuration page for adding users to the group
+- Ability to change view in portfolio overview
+
 
 ### Added
 - Show only benefits (gevinster) that are toggled as "Show at portfolio level" #268

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/PortfolioOverviewCommands/index.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/PortfolioOverviewCommands/index.tsx
@@ -65,7 +65,7 @@ export class PortfolioOverviewCommands extends React.Component<IPortfolioOvervie
                 name: this.props.currentView.title,
                 iconProps: { iconName: 'List' },
                 itemType: ContextualMenuItemType.Header,
-                data: { isVisible: this.props.pageContext.legacyPageContext.isSiteAdmin && this.props.showViewSelector },
+                data: { isVisible: this.props.showViewSelector },
                 subMenuProps: {
                     items: [
                         {


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [x] Check the commit's or even all commits' message 
- [x] Check your code additions will fail linting checks
- [x] Remember: After PR is closed, add PR description to [Changelog](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md)

### Description

Removed admin-only access to view selector in Portfolio Overview.
Please refuse PR if this was is as intended.

### How to test

Have a regular user view Portfolio Overview to see if he/she can choose view

### Relevant issues (if applicable)
Closes #304 

💔Thank you!
