### PR TITLE
Update and fix handling of disabling new report button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added new group "Porteføljeinnsyn" granting users in this group insight into all projects in the portfolio
 - Added "Porteføljeinnsyn" button on configuration page for adding users to the group
 - Ability to change view in portfolio overview
+- Handling of unpublished reports have been improved. Not possible to create new reports while having unpublished report.
 
 
 ### Added

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/index.tsx
@@ -109,7 +109,7 @@ export class ProjectStatus extends React.Component<IProjectStatusProps, IProject
         key: getId('NewStatusReport'),
         name: strings.NewStatusReportModalHeaderText,
         iconProps: { iconName: 'NewFolder' },
-        disabled: !!data.reports.filter((report) => report.moderationStatus.indexOf("Publisert")).length,
+        disabled: data.reports.filter((report) => report.moderationStatus.indexOf("Publisert")).length !== 0 ? true : false,
         onClick: this._redirectNewStatusReport.bind(this),
       },
       {

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/index.tsx
@@ -109,7 +109,7 @@ export class ProjectStatus extends React.Component<IProjectStatusProps, IProject
         key: getId('NewStatusReport'),
         name: strings.NewStatusReportModalHeaderText,
         iconProps: { iconName: 'NewFolder' },
-        disabled: !selectedReport || selectedReport.moderationStatus !== strings.GtModerationStatus_Choice_Published,
+        disabled: !!data.reports.filter((report) => report.moderationStatus.indexOf("Publisert")).length,
         onClick: this._redirectNewStatusReport.bind(this),
       },
       {


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [X] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [X] Check the commit's or even all commits' message 
- [X] Check your code additions will fail linting checks
- [X] Remember: After/before PR is closed, add PR description to [Changelog](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md)

### Description

Disable the button "Ny statusrapport" when a report is unpublished. Also when navigating between other reports while having an unpublished report.

### How to test:

1. Create a new report.
2. The button "Ny statusrapport" will stay disabled until you publish the report.
3. The button will also be disabled if you navigate between other reports while having an unpublished report
4. Create a new report and the button should be disabeled once again
5. Select an older published report.
6. Verify that the button "Ny statusrapport" stays disabled

### Related issues
Closed #295