### PR TITLE
Added "default" option for project extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Every change is marked with Pull Request ID.
 
+## 1.2.4 - 
+
+## Added
+
+- Added "default" option for extensions, similar to list content
+
+
 ## 1.2.3 - 2020-10-07
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Every change is marked with Pull Request ID.
 
-## 1.2.4 - 
+## 1.2.4 - TBA
 
 ## Added
 

--- a/SharePointFramework/ProjectExtensions/src/components/TemplateSelectDialog/ExtensionsSection/index.tsx
+++ b/SharePointFramework/ProjectExtensions/src/components/TemplateSelectDialog/ExtensionsSection/index.tsx
@@ -1,7 +1,7 @@
 import { stringIsNullOrEmpty } from '@pnp/common'
 import { Toggle } from 'office-ui-fabric-react/lib/Toggle'
 import * as React from 'react'
-import { ProjectTemplate } from '../../../models'
+import { ProjectExtension } from '../../../models'
 import styles from './ExtensionsSection.module.scss'
 import { IExtensionsSectionProps } from './IExtensionsSectionProps'
 
@@ -13,15 +13,14 @@ export const ExtensionsSection = (props: IExtensionsSectionProps) => {
      * @param {ProjectTemplate} extension Extension
      * @param {boolean} checked Checked
      */
-    const onChange = (extension: ProjectTemplate, checked: boolean): void => {
+    const onChange = (extension: ProjectExtension, checked: boolean): void => {
         let selectedExtensions = []
         if (checked) selectedExtensions = [extension, ...props.selectedExtensions]
         else selectedExtensions = props.selectedExtensions.filter(ext => extension.text !== ext.text)
         props.onChange(selectedExtensions)
     }
 
-    const selectedKeys = props.selectedExtensions.map(lc => lc.key)
-
+    const selectedKeys = props.selectedExtensions.map(ext => ext.key)
 
     return (
         <div className={styles.extensionsSection}>

--- a/SharePointFramework/ProjectExtensions/src/components/TemplateSelectDialog/index.tsx
+++ b/SharePointFramework/ProjectExtensions/src/components/TemplateSelectDialog/index.tsx
@@ -27,7 +27,7 @@ export class TemplateSelectDialog extends React.Component<ITemplateSelectDialogP
         super(props)
         this.state = {
             selectedTemplate: this._getDefaultTemplate(),
-            selectedExtensions: [],
+            selectedExtensions: props.data.extensions.filter(ext => ext.isDefault),
             selectedListContentConfig: props.data.listContentConfig.filter(lcc => lcc.isDefault),
             settings: new ProjectSetupSettings().useDefault(),
         }

--- a/SharePointFramework/ProjectExtensions/src/models/ProjectExtension.ts
+++ b/SharePointFramework/ProjectExtensions/src/models/ProjectExtension.ts
@@ -1,9 +1,33 @@
 import { Web } from '@pnp/sp'
-import { ProjectTemplate, IProjectTemplateSPItem } from './ProjectTemplate'
+import { IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown'
+import { TypedHash } from '@pnp/common'
+import { Schema } from 'sp-js-provisioning'
 
-export class ProjectExtension extends ProjectTemplate {
-    constructor(spItem: IProjectTemplateSPItem, web: Web) {
-        super(spItem, web)
-        this.key = `projectextension_${this.id}`
+export interface IProjectExtension {
+    Id: number;
+    FieldValuesAsText?: TypedHash<string>;
+    key: string;
+    GtExtensionDefault?: boolean;
+    File?: { UniqueId: string; Name: string; Title: string; ServerRelativeUrl: string };
+}
+
+export class ProjectExtension implements IDropdownOption {
+    public key: string;
+    public text: string;
+    public isDefault: boolean;
+    public subText: string;
+    public serverRelativeUrl: string;
+
+    constructor(spItem: IProjectExtension, public web: Web) {
+        this.key = `projecttemplate_${spItem.Id}`
+        this.text = spItem.File.Title
+        this.isDefault = spItem.GtExtensionDefault
+        this.subText = spItem.FieldValuesAsText.GtDescription
+        this.serverRelativeUrl = spItem.File.ServerRelativeUrl
+    }
+
+    public async getSchema(): Promise<Schema> {
+        return await this.web.getFileByServerRelativeUrl(this.serverRelativeUrl).getJSON()
     }
 }
+

--- a/Templates/Portfolio/Objects/Lists/Prosjekttillegg.xml
+++ b/Templates/Portfolio/Objects/Lists/Prosjekttillegg.xml
@@ -13,6 +13,7 @@
                 <FieldRef Name="Title" />
                 <FieldRef Name="GtDescription" />
                 <FieldRef Name="Modified" />
+                <FieldRef Name="GtExtensionDefault" />
             </ViewFields>
             <RowLimit Paged="TRUE">30</RowLimit>
             <Aggregations Value="Off" />
@@ -21,6 +22,7 @@
     </pnp:Views>
     <pnp:FieldRefs>
         <pnp:FieldRef ID="c3beecea-c0e5-4d18-9b45-3c7d7949bee4" Name="GtDescription" />
+        <pnp:FieldRef ID="7ec0bc7a-f644-4ddb-86e0-5c8d70e3c16a" Name="GtExtensionDefault" />
     </pnp:FieldRefs>
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="Objects/Lists/Security/DefaultSecurity.xml" />
 </pnp:ListInstance>

--- a/Templates/Portfolio/Objects/SiteFields.xml
+++ b/Templates/Portfolio/Objects/SiteFields.xml
@@ -180,4 +180,5 @@
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="Objects/SiteFields/GtCategory.xml" />
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="Objects/SiteFields/GtChecklist.xml" />
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="Objects/SiteFields/GtAttachments.xml" />
+    <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="Objects/SiteFields/GtExtensionDefault.xml" />
 </pnp:SiteFields>

--- a/Templates/Portfolio/Objects/SiteFields/GtExtensionDefault.xml
+++ b/Templates/Portfolio/Objects/SiteFields/GtExtensionDefault.xml
@@ -1,0 +1,3 @@
+<Field Description="{resource:SiteFields_GtExtensionDefault_Description}" DisplayName="resource:SiteFields_GtExtensionDefault_DisplayName" Group="{resource:SiteFields_Portfolio_Group}" ID="{7ec0bc7a-f644-4ddb-86e0-5c8d70e3c16a}" Name="GtExtensionDefault" StaticName="GtExtensionDefault" Type="Boolean">
+    <Default>0</Default>
+</Field>

--- a/Templates/Portfolio/Resources.no-NB.resx
+++ b/Templates/Portfolio/Resources.no-NB.resx
@@ -1471,6 +1471,12 @@
   <data name="SiteFields_GtProjectLifecycleStatus_Description" xml:space="preserve">
     <value />
   </data>
+  <data name="SiteFields_GtExtensionDefault_Description" xml:space="preserve">
+    <value>Velges som standard</value>
+  </data>
+  <data name="SiteFields_GtExtensionDefault_DisplayName" xml:space="preserve">
+    <value>Standard</value>
+  </data>
   <data name="ProjectPhases_GoToChecklist2" xml:space="preserve">
     <value>Gå til &lt;a href="{0" target="_blank"&gt;fasesjekklisten&lt;/a&gt; (åpnes i ny fane)</value>
   </data>


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [x] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [x] Check the commit's or even all commits' message 
- [x] Check your code additions will fail linting checks
- [x] Remember: Add PR description to [Changelog](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the ID that matches this PR

### Description

Adds the option to have extensions be on as default, similarly to List content. Reworks ProjectExtension class.

### How to test

1. Add an extension.
2. Set as default.
3. Create project

Example:

Closes #327 

💔Thank you!
