### PR TITLE
Fix for install script to avoid GitHub CI as install command for all installation logging

### DIFF
--- a/Install/Install.ps1
+++ b/Install/Install.ps1
@@ -400,7 +400,7 @@ $InstallEntry = @{
     InstallCommand   = $MyInvocation.Line.Substring(2);
 }
 
-if ($null -ne $CI) {
+if (-not [string]::IsNullOrEmpty($CI)) {
     $InstallEntry.InstallCommand = "GitHub CI";
 }
 


### PR DESCRIPTION
### Your checklist for this pull request
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [x] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [x] Check the commit's or even all commits' message 
- [x] Check your code additions will fail linting checks
- [x] Remember: Add PR description to [Changelog](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the ID that matches this PR

### Description
Fix for install script to avoid GitHub CI as install command for all installation logging.

### Relevant issues (if applicable)
Closes #360