### PR TITLE
Added innerHTML to enable newline

### DIFF
--- a/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/StatusElement/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/StatusElement/index.tsx
@@ -11,6 +11,9 @@ export const StatusElement = ({
   iconSize = 30,
   iconColor
 }: IStatusElementProps) => {
+  
+  // Replace \n with corresponding HTML tag to enable newlines in the comment.
+  const htmlComment = {__html: comment.replace(/\n/g,"<br />")};
   return (
     <div className={styles.statusElement}>
       <div className={styles.container}>
@@ -20,7 +23,7 @@ export const StatusElement = ({
         <div className={styles.statusContent}>
           <div className={styles.statusElementLabel}>{label}</div>
           <div className={styles.statusElementValue}>{value}</div>
-          <div className={styles.statusElementComment}>{comment}</div>
+          <div className={styles.statusElementComment} dangerouslySetInnerHTML={htmlComment}></div>
         </div>
       </div>
     </div>

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/StatusElement/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/StatusElement/index.tsx
@@ -11,9 +11,6 @@ export const StatusElement = ({
   iconSize = 30,
   iconColor
 }: IStatusElementProps) => {
-  
-  // Replace \n with corresponding HTML tag to enable newlines in the comment.
-  const htmlComment = {__html: comment.replace(/\n/g,"<br />")};
   return (
     <div className={styles.statusElement}>
       <div className={styles.container}>
@@ -23,7 +20,7 @@ export const StatusElement = ({
         <div className={styles.statusContent}>
           <div className={styles.statusElementLabel}>{label}</div>
           <div className={styles.statusElementValue}>{value}</div>
-          <div className={styles.statusElementComment} dangerouslySetInnerHTML={htmlComment}></div>
+          <div className={styles.statusElementComment} dangerouslySetInnerHTML={{ __html: comment.replace(/\n/g, '<br />') }}></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [x] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [x] Check the commit's or even all commits' message 
- [x] Check your code additions will fail linting checks
- [x] Remember: Add PR description to [Changelog](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the ID that matches this PR

### Description

When users tried to apply new lines in "Overordnet status", the lines would get ignored. This results in bad formatting on longer texts. The regex will replace every \n with a HTML <br/>, to display a new line.

### How to test

Navigate to project status --> write a text containing new lines. Voilà.


### Relevant issues (if applicable)
Reported in the Assist portal #3406

💔Thank you!
