### PR TITLE
Changed Portfolio status view columns from "comments" to "status" 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Every change is marked with Pull Request ID.
 
 - Avoiding overwrite of portfolio views, columns, column configuration and insights graphs on update
 
+## Changed
+
+- Changed Portfolio status view columns from "comments" to "status" 
 ## 1.2.6 - 03.03.2021
 
 ## Added

--- a/Templates/Portfolio/Objects/Lists/Portefoljevisninger.xml
+++ b/Templates/Portfolio/Objects/Lists/Portefoljevisninger.xml
@@ -50,7 +50,7 @@
             <pnp:DataValue FieldName="GtSearchQuery">DepartmentId:{{sitecollectionid}} NOT GtProjectLifecycleStatusOWSCHCS="Avsluttet" ContentTypeId:0x0100805E9E4FEAAB4F0EABAB2600D30DB70C*</pnp:DataValue>
             <pnp:DataValue FieldName="GtPortfolioIsDefaultView">False</pnp:DataValue>
             <pnp:DataValue FieldName="GtPortfolioFabricIcon">BarChart4</pnp:DataValue>
-            <pnp:DataValue FieldName="GtPortfolioColumns">1,7,8,9,22,26,24,20,28,19</pnp:DataValue>
+            <pnp:DataValue FieldName="GtPortfolioColumns">1,7,8,9,21,25,23,19,27</pnp:DataValue>
             <pnp:DataValue FieldName="GtPortfolioRefiners">5,6,7,8,9</pnp:DataValue>
             <pnp:DataValue FieldName="GtPortfolioGroupBy" />
         </pnp:DataRow>


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [x] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [x] Check the commit's or even all commits' message 
- [x] Remember: Add PR description to [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the ID that matches this PR

### Description

There existed an ID mismatch between the Project column list and the Portfolio views list, this changes to the status columns.

### How to test

- [ ] 1. Apply template.
- [ ] 2. Check Portfolio status view.

PS: The template has "Skip" as default update behavior. This is intentional and was changed only 3 weeks ago. Manually fixing the issues may be as efficient as a template change.


### Relevant issues (if applicable)
#445 

💔Thank you!
