### PR TITLE
Overwrite configuration page to add links on update #425

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,13 @@ Every change is marked with Pull Request ID.
 
 ## Fixed
 
-- Avoiding overwrite of portfolio views, columns, column configuration and insights graphs on update
+- Avoiding overwrite of portfolio views, columns, column configuration and insights graphs on update #440
 - Overwriting configuration page to support new configuration links on update #425
 
 ## Changed
 
-- Changed Portfolio status view columns from "comments" to "status" 
-
+- Changed Portfolio status view columns from "comments" to "status" #451
+- Improved project properties sync and fetching  #444 #449
 
 ## 1.2.6 - 03.03.2021
 
@@ -41,7 +41,7 @@ Every change is marked with Pull Request ID.
 - Copying for documents to new projects #399
 - Fixes issues with more than one status report template #400
 - Fixed issues with missing projects on the front page #364
-- Fixed support for latest PnP PowerShell #377 
+- Fixed support for latest PnP PowerShell #377
 
 ## 1.2.4 - 30.11.2020
 

--- a/Templates/Portfolio/Objects/ClientSidePages/Konfigurasjon.xml
+++ b/Templates/Portfolio/Objects/ClientSidePages/Konfigurasjon.xml
@@ -1,4 +1,4 @@
-<pnp:ClientSidePage PageName="{resource:ClientSidePages_Configuration_PageName}" Layout="Home" Overwrite="false" EnableComments="false" Title="{resource:ClientSidePages_Configuration_Title}" xmlns:pnp="http://schemas.dev.office.com/PnP/2018/05/ProvisioningSchema">
+<pnp:ClientSidePage PageName="{resource:ClientSidePages_Configuration_PageName}" Layout="Home" Overwrite="true" EnableComments="false" Title="{resource:ClientSidePages_Configuration_Title}" xmlns:pnp="http://schemas.dev.office.com/PnP/2018/05/ProvisioningSchema">
     <pnp:Sections>
         <pnp:Section Order="1" Type="OneColumn">
             <pnp:Controls>


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [X] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [X] Check the commit's or even all commits' message 
- [X] Check if your code additions will fail linting checks
- [X] Remember: Add PR description to [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the ID that matches this PR

### Description

Solves #425 - overwriting the configuration page on upgrade 

### How to test

Please describe how someone else can test this PR. In the form of a numbered list and checkboxes for Jan when the testing period occurs.

Example:

- [ ] 1. Have a site with pre 1.2.6 release installed
- [ ] 2. Upgrade to latest version of PP
- [ ] 3. Observe that you can see the new link "Tillatelseskonfigurasjon"

### Relevant issues (if applicable)

💔Thank you!
