### PR TITLE
Fixed Default view error in Portfolio overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Every change is marked with Pull Request ID.
 
 - Avoiding overwrite of portfolio views, columns, column configuration and insights graphs on update #440
 - Overwriting configuration page to support new configuration links on update #425
+- Fixed portfolio overview crashing when default view was selected #428
 
 ## Changed
 

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/index.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/index.tsx
@@ -446,7 +446,7 @@ export class PortfolioOverview extends Component<IPortfolioOverviewProps, IPortf
         throw new PortfolioOverviewErrorMessage(strings.ViewNotFoundMessage, MessageBarType.error)
       }
     } else if (defaultViewId) {
-      currentView = _.find(views, (v) => v.id.toString() === defaultViewId)
+      currentView = _.find(views, (v) => v.id.toString() === defaultViewId.toString())
       if (!currentView) {
         throw new PortfolioOverviewErrorMessage(strings.ViewNotFoundMessage, MessageBarType.error)
       }


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [x] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [x] Check the commit's or even all commits' message 
- [x] Check if your code additions will fail linting checks
- [x] Remember: Add PR description to [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the ID that matches this PR

### Description

Fixes default view crash on Portfolio overview. Although the variable was initialized as type string, the typeof was number, so adding .toString() fixed the comparison.

### How to test

1. Go to SitePages/Porteføljeoversikt.aspx
2. Edit page
3. Set a value for "Standardvisning" in property pane
4. Refresh SitePages/Porteføljeoversikt.aspx

### Relevant issues (if applicable)

Closes #428 

💔Thank you!
