### PR TITLE
Added "Description" to document templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Every change is marked with Pull Request ID.
 
 - Added a new portfolio webpart, 'Prosjekttidslinje' for showcasing projects on a timeline #435
 - Added list 'Tidslinjeinnhold' to portfolio level #437
-
+- Added 'Description' to document templates
 ## Fixed
 
 - Avoiding overwrite of portfolio views, columns, column configuration and insights graphs on update #440

--- a/SharePointFramework/ProjectExtensions/src/components/DocumentTemplateDialog/SelectScreen/columns.tsx
+++ b/SharePointFramework/ProjectExtensions/src/components/DocumentTemplateDialog/SelectScreen/columns.tsx
@@ -36,6 +36,13 @@ export default ({ setFolder }: { setFolder: (folder: TemplateItem) => void }) =>
       }
     },
     {
+      key: getId('description'),
+      fieldName: 'description',
+      name: ProjectExtensionsStrings.DescriptionLabel,
+      minWidth: 200,
+      isResizable:true
+    },
+    {
       key: getId('phase'),
       fieldName: 'phase',
       name: ProjectExtensionsStrings.PhaseLabel,

--- a/SharePointFramework/ProjectExtensions/src/loc/myStrings.d.ts
+++ b/SharePointFramework/ProjectExtensions/src/loc/myStrings.d.ts
@@ -29,6 +29,7 @@ declare interface IProjectExtensionsStrings {
   CopyListItemsText: string
   CopyFilesText: string
   CopyProgressLabel: string
+  DescriptionLabel: string
   EditPropertiesLinkText: string
   ErrorDialogTitle: string
   ExtensionsTitle: string

--- a/SharePointFramework/ProjectExtensions/src/loc/nb-no.js
+++ b/SharePointFramework/ProjectExtensions/src/loc/nb-no.js
@@ -78,6 +78,7 @@ define([], function () {
     SetupAbortedText: 'Installasjon avbrutt av bruker',
     UnknownErrorText: 'Ukjent feil',
     TemplateListContentConfigText: 'Den valgte prosjektmalen inneholder konfigurasjon for standardinnhold.',
+    DescriptionLabel: "Beskrivelse",
     FolderDropdownLabel: 'Velg mappe',
     DocumentLibraryDropdownLabel: 'Velg dokumentbibliotek',
     DocumentTemplateDialogScreenEditCopyRootLevelText: 'Øverste nivå'

--- a/SharePointFramework/ProjectExtensions/src/models/TemplateItem.ts
+++ b/SharePointFramework/ProjectExtensions/src/models/TemplateItem.ts
@@ -39,6 +39,11 @@ export class TemplateItem {
   public title: string
 
   /**
+   * The template description
+   */
+  public description: string
+
+  /**
    * The project phase
    */
   public phase: string
@@ -72,6 +77,7 @@ export class TemplateItem {
     this.id = _item.File?.UniqueId || _item.Folder.UniqueId
     this.name = _item.File?.Name || _item.Folder?.Name
     this.title = _item.File?.Title || this.nameWithoutExtension || _item.Folder?.Name
+    this.description = _item.FieldValuesAsText.GtDescription
     this.phase = _item.FieldValuesAsText.GtProjectPhase
     this.newName = this.name
     this.newTitle = this.title

--- a/Templates/Portfolio/Objects/Lists/Malbibliotek.xml
+++ b/Templates/Portfolio/Objects/Lists/Malbibliotek.xml
@@ -11,6 +11,7 @@
                 <FieldRef Name="DocIcon" />
                 <FieldRef Name="LinkFilename" />
                 <FieldRef Name="Title" />
+                <FieldRef Name="GtDescription" />
                 <FieldRef Name="GtProjectPhase" />
                 <FieldRef Name="Modified" />
                 <FieldRef Name="Editor" />
@@ -22,6 +23,7 @@
     </pnp:Views>
     <pnp:FieldRefs>
         <pnp:FieldRef ID="325543a5-815d-485d-a9a5-e0773ad762e9" Name="GtProjectPhase" />
+        <pnp:FieldRef ID="c3beecea-c0e5-4d18-9b45-3c7d7949bee4" Name="GtDescription" />
     </pnp:FieldRefs>
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="Objects/Lists/Security/DefaultSecurity.xml" />
 </pnp:ListInstance>


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [x] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [x] Check the commit's or even all commits' message 
- [x] Check if your code additions will fail linting checks
- [x] Remember: Add PR description to [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the ID that matches this PR

### Description

Adds "Description" field to document template selector and document template list.
Made the Description label resizeable in case of long descriptions

### How to test

1. Add description to the document template configuration list
2. Go to project document library
3. View document description

### Relevant issues (if applicable)
Closes #379

💔Thank you!
