### PR TITLE
Changed behavior of PortfolioAggregation to fix grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Every change is marked with Pull Request ID.
 
 - Changed Portfolio status view columns from "comments" to "status" #451
 - Improved project properties sync and fetching  #444 #449
+- Overviews using PortfolioAggregation (Benefit overview, Experience log, Delivery overview, Risk overview) now initially sort on project and grouping now automatically sorts group from A-Z by project. Also removes groups when sorting to avoid the issue found in #459
 
 ## 1.2.6 - 03.03.2021
 

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/reducer.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/reducer.ts
@@ -71,11 +71,11 @@ export default (props: IPortfolioAggregationProps) =>
     [DATA_FETCHED.type]: (state, { payload }: ReturnType<typeof DATA_FETCHED>) => {
       if (payload.items) {
         state.items = props.postTransform ? props.postTransform(payload.items) : payload.items
-        if (state.sortBy) {
-          state.items = sortArray([...state.items], [state.sortBy.fieldName], {
-            reverse: state.sortBy.isSortedDescending
+        //if (state.sortBy) {
+          state.items = sortArray([...state.items], [state.sortBy?.fieldName ? state.sortBy.fieldName : 'SiteTitle'], {
+            reverse: state.sortBy?.isSortedDescending ? state.sortBy.isSortedDescending : false
           })
-        }
+        //}
         state.loading = false
       }
       if (payload.dataSources) state.dataSources = payload.dataSources
@@ -122,11 +122,12 @@ export default (props: IPortfolioAggregationProps) =>
     },
 
     [SET_GROUP_BY.type]: (state, { payload }: ReturnType<typeof SET_GROUP_BY>) => {
-      const itemsSort = { props: [state.groupBy?.fieldName], opts: { reverse: false } }
+      const itemsSort = { props: [(state.groupBy?.fieldName) ? state.groupBy.fieldName : 'SiteTitle' ], opts: { reverse: false } }
       if (state.sortBy) {
         itemsSort.props.push(state.sortBy.fieldName)
         itemsSort.opts.reverse = !state.sortBy.isSortedDescending
       }
+      console.log(itemsSort);
       state.items = sortArray([...state.items], itemsSort.props, itemsSort.opts)
       if (state.groupBy?.fieldName === payload.column?.fieldName) {
         state.groupBy = null
@@ -167,20 +168,6 @@ export default (props: IPortfolioAggregationProps) =>
         return col
       })
     },
-
-    [SET_SORT.type]: (state, { payload }: ReturnType<typeof SET_SORT>) => {
-      const { column, sortDesencing } = payload
-      state.sortBy = column
-      state.items = sortArray([...state.items], [column.fieldName], { reverse: !sortDesencing })
-      state.columns = [...state.columns].map((col) => {
-        col.isSorted = col.key === column.key
-        if (col.isSorted) {
-          col.isSortedDescending = sortDesencing
-        }
-        return col
-      })
-    },
-
     [MOVE_COLUMN.type]: (state, { payload }: ReturnType<typeof MOVE_COLUMN>) => {
       const index = indexOf(
         state.columns.map((c) => c.fieldName),

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/reducer.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/reducer.ts
@@ -71,11 +71,9 @@ export default (props: IPortfolioAggregationProps) =>
     [DATA_FETCHED.type]: (state, { payload }: ReturnType<typeof DATA_FETCHED>) => {
       if (payload.items) {
         state.items = props.postTransform ? props.postTransform(payload.items) : payload.items
-        //if (state.sortBy) {
           state.items = sortArray([...state.items], [state.sortBy?.fieldName ? state.sortBy.fieldName : 'SiteTitle'], {
             reverse: state.sortBy?.isSortedDescending ? state.sortBy.isSortedDescending : false
           })
-        //}
         state.loading = false
       }
       if (payload.dataSources) state.dataSources = payload.dataSources
@@ -122,18 +120,7 @@ export default (props: IPortfolioAggregationProps) =>
     },
 
     [SET_GROUP_BY.type]: (state, { payload }: ReturnType<typeof SET_GROUP_BY>) => {
-      const itemsSort = { props: [(state.groupBy?.fieldName) ? state.groupBy.fieldName : 'SiteTitle' ], opts: { reverse: false } }
-      if (state.sortBy) {
-        itemsSort.props.push(state.sortBy.fieldName)
-        itemsSort.opts.reverse = !state.sortBy.isSortedDescending
-      }
-      console.log(itemsSort);
-      state.items = sortArray([...state.items], itemsSort.props, itemsSort.opts)
-      if (state.groupBy?.fieldName === payload.column?.fieldName) {
-        state.groupBy = null
-        state.groups = null
-        return
-      }
+      state.items = sortArray([...state.items], [payload.column.fieldName])
       state.groupBy = payload.column
       const groupNames: string[] = state.items.map((g) =>
         get<string>(g, state.groupBy.fieldName, strings.NotSet)
@@ -159,6 +146,10 @@ export default (props: IPortfolioAggregationProps) =>
     [SET_SORT.type]: (state, { payload }: ReturnType<typeof SET_SORT>) => {
       const { column, sortDesencing } = payload
       state.sortBy = column
+      if (state.groupBy) {
+        state.groupBy = null
+        state.groups = null
+      }
       state.items = sortArray([...state.items], [column.fieldName], { reverse: !sortDesencing })
       state.columns = [...state.columns].map((col) => {
         col.isSorted = col.key === column.key


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [x] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [x] Check the commit's or even all commits' message 
- [x] Check if your code additions will fail linting checks
- [x] Remember: Add PR description to [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the ID that matches this PR

### Description

Changes behavior of PortfolioAggregation. Due to grouping being based on which index an item has in an array, it could, and often led to issues as demonstrated in #459 

The PR adds: 
When data is fetched, it is immediately sorted by project title.
When grouping on project (others are already disabled), we ignore other sortings that have been triggered.
If grouping has been selected, and you attempt to sort any column, it will remove the groupings.

(An example for a potential change to improve this functionality, for example sorting any other column while still having grouped items by project, we could potentially have an object array where we group the items after fetching the data, e.g:)
```
[{
    Title: Project,
    Items: [{
          ItemObject
    }]
}]

```
This does include a bit more of refactoring and changes to the code, so per now, we don't do it.

### How to test

- [ ] 1. Go to the Benefit overview, Experience log, Delivery overview, Risk overview pages
- [ ] 2. Try sorting different columns
- [ ] 3. Try grouping on project
- [ ] 4. Try sorting on a column


### Relevant issues (if applicable)

Closes #459 

💔Thank you!
