### PR TITLE
Checklist status field missing options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Every change is marked with Pull Request ID.
 
-## 1.2.7 - N/A
+## 1.2.8 - 17.06.2021
+
+## Fixed
+- Fixed issue with checklist status field missing options #485
+
+## 1.2.7 - 20.05.2021
 
 ## Added
 

--- a/Templates/_JsonTemplate.json
+++ b/Templates/_JsonTemplate.json
@@ -690,7 +690,7 @@
                 "EnableVersioning": true
             },
             "Fields": [
-                "<Field ID=\"{249527a3-c7f9-4ea5-9c33-f942c06c9215}\" Type=\"Choice\" Name=\"GtChecklistStatus\" StaticName=\"GtChecklistStatus\" DisplayName=\"Status\" Description=\"Hva er statusen for sjekkpunktet? (Anbefalt status = 'Åpen'. Dette påvirker om man blir etterspurt sjekkpunktet ifm faseendring)\" />"
+                "<Field ID=\"{fa564e0f-0c70-4ab9-b863-0177e6ddd247}\" Type=\"Text\" Name=\"Title\" StaticName=\"Title\" DisplayName=\"Tittel\" Description=\"Oppgi et navn/tittel på sjekkpunktet som registreres\" />"
             ],
             "Views": [
                 {

--- a/Templates/_JsonTemplate.json
+++ b/Templates/_JsonTemplate.json
@@ -689,9 +689,6 @@
             "AdditionalSettings": {
                 "EnableVersioning": true
             },
-            "Fields": [
-                "<Field ID=\"{fa564e0f-0c70-4ab9-b863-0177e6ddd247}\" Type=\"Text\" Name=\"Title\" StaticName=\"Title\" DisplayName=\"Tittel\" Description=\"Oppgi et navn/tittel på sjekkpunktet som registreres\" />"
-            ],
             "Views": [
                 {
                     "Title": "{{View_AllItems_DisplayName}}",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pp365",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Removing definition of field GtChecklistStatus on list Fasesjekkliste, as this definition overrides the sitefield and causes this field to be missing its options

### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [x] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [x] Check the commit's or even all commits' message 
- [x] Check if your code additions will fail linting checks
- [ ] Remember: Add PR description to [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the ID that matches this PR

### Description


- 
### How to test
- Add _JsonTemplate.json to a tenant currently using pp365 1.2.7
- create a new project
- observe that the phasechecklist has the "status" field and that this field has the correct options

### Relevant issues (if applicable)

Closes #484
