### PR TITLE
Setting default site design for hub on install

### DIFF
--- a/Install/Install.ps1
+++ b/Install/Install.ps1
@@ -230,6 +230,9 @@ if (-not $SkipSiteDesign.IsPresent) {
             Write-Host "[INFO] Granting group $SiteDesignSecurityGroupId View access to site design [$SiteDesignName]"
             Grant-PnPSiteDesignRights -Identity $SiteDesign.Id.Guid -Principals @("c:0t.c|tenant|$SiteDesignSecurityGroupId")
         }
+        Write-Host "[INFO] Setting default site design for hub [$Url] to [$SiteDesignName]"
+        Set-PnPHubSite -Identity $Url -SiteDesignId $SiteDesign.Id.Guid
+
         Disconnect-PnPOnline
         Write-Host "[SUCCESS] Successfully created/updated site design [$SiteDesignName]" -ForegroundColor Green
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pp365",
-  "version": "1.2.6",
+  "version": "1.2.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [x] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [x] Check the commit's or even all commits' message 
- [x] Check if your code additions will fail linting checks
- [x] Remember: Add PR description to [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the ID that matches this PR

### Description
resolving issue #491 where we have to set a default site design when installing

### How to test
Run installer against a dev/test tenant which is in targeted release, i.e. has the new site template experience where you cannot select site design upon group creation

- [ ] Run installer
- [ ] Create a new project

The 'prosjektområde' template shoud automatically be applied.


### Relevant issues (if applicable)
#491
