### PR TITLE
Added opacity and alert message to ReadOnly projects (Frontpage)

### DIFF
--- a/SharePointFramework/PortfolioWebParts/src/components/ProjectList/ProjectCard/index.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/ProjectList/ProjectCard/index.tsx
@@ -5,12 +5,16 @@ import { ProjectCardContent } from './ProjectCardContent'
 import { ProjectCardFooter } from './ProjectCardFooter'
 import { ProjectCardHeader } from './ProjectCardHeader'
 import { IProjectCardProps } from './types'
+import * as strings from 'PortfolioWebPartsStrings'
 
 export const ProjectCard: FunctionComponent<IProjectCardProps> = (props: IProjectCardProps) => {
   return (
     <DocumentCard
       className={styles.projectCard}
-      onClickHref={props.project.readOnly ? '#' : props.project.url}>
+      onClickHref={props.project.readOnly ? '#' : props.project.url}
+      onClick={() => props.project.readOnly && alert(strings.NoAccessMessage)}
+      style={props.project.readOnly && { opacity: "20%", cursor: "not-allowed" }}
+      >
       <ProjectCardHeader {...props} />
       <ProjectCardContent {...props} />
       <ProjectCardFooter {...props} />

--- a/SharePointFramework/PortfolioWebParts/src/loc/mystrings.d.ts
+++ b/SharePointFramework/PortfolioWebParts/src/loc/mystrings.d.ts
@@ -159,6 +159,7 @@ declare interface IPortfolioWebPartsStrings {
   DisplayAllProjects: string
   MyProjectsLabel: string
   AllProjectsLabel: string
+  NoAccessMessage: string
 }
 
 declare module 'PortfolioWebPartsStrings' {

--- a/SharePointFramework/PortfolioWebParts/src/loc/nb-no.js
+++ b/SharePointFramework/PortfolioWebParts/src/loc/nb-no.js
@@ -156,6 +156,7 @@ define([], function () {
     ReadOnlyGroupName: "Porteføljeinnsyn",
     DisplayAllProjects: "Vis alle prosjekter",
     MyProjectsLabel: "Mine prosjekter",
-    AllProjectsLabel: "Alle prosjekter"
+    AllProjectsLabel: "Alle prosjekter",
+    NoAccessMessage: "Du har ikke tilgang til dette prosjektet"
   }
 })


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [X] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [X] Check the commit's or even all commits' message 
- [X] Check if your code additions will fail linting checks
- [X] Remember: Add PR description to [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the ID that matches this PR

### Description

Added opacity and alert message to projectcards in listview on frontpage.

### How to test

- [ ] 1. Go to frontpage to see that project has opacity.
- [ ] 2. Click on the project that user dont have access to see alert message. 


### Relevant issues (if applicable)

#505 
