### PR TITLE
Removed Detailslist and Risk Matrix from outdated project reports

### DIFF
--- a/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/Sections/BaseSection/types.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/Sections/BaseSection/types.ts
@@ -37,6 +37,11 @@ export interface IBaseSectionProps {
    * URL for the web
    */
   webUrl: string
+
+  /**
+   * Should list data be displayed?
+   */
+  showLists: boolean;
 }
 
 export interface IBaseSectionState {

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/Sections/ListSection/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/Sections/ListSection/index.tsx
@@ -42,7 +42,7 @@ export class ListSection extends BaseSection<
           <div className='ms-Grid-col ms-sm12'>
             <StatusElement {...this.props.headerProps} />
           </div>
-          {this._renderList()}
+          {this.props.showLists && this._renderList()}
         </div>
       </BaseSection>
     )

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/Sections/RiskSection/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/Sections/RiskSection/index.tsx
@@ -40,7 +40,7 @@ export class RiskSection extends BaseSection<IRiskSectionProps, IRiskSectionStat
           <div className='ms-Grid-col ms-sm12'>
             <StatusElement {...this.props.headerProps} />
           </div>
-          {this._renderContent()}
+          {this.props.showLists && this._renderContent()}
         </div>
       </BaseSection>
     )

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/index.tsx
@@ -69,11 +69,14 @@ export class ProjectStatus extends React.Component<IProjectStatusProps, IProject
           (report) => report.id === parseInt(selectedReportUrlParam, 10)
         )
       }
+      const newestReportId = data.reports.length > 0 ? Math.max.apply(Math, data.reports.map(report => { return report.id; })) : 0;
+
       this.setState({
         data,
         selectedReport,
         sourceUrl: decodeURIComponent(sourceUrlParam || ''),
-        loading: false
+        loading: false,
+        newestReportId
       })
     } catch (error) {
       this.setState({ error, loading: false })
@@ -212,13 +215,13 @@ export class ProjectStatus extends React.Component<IProjectStatusProps, IProject
         disabled: true
       })
     }
-
     return (
       <CommandBar
         items={removeMenuBorder<IContextualMenuItem>(items)}
         farItems={removeMenuBorder<IContextualMenuItem>(farItems)}
       />
     )
+    
   }
 
   /**
@@ -246,7 +249,8 @@ export class ProjectStatus extends React.Component<IProjectStatusProps, IProject
       data: this.state.data,
       hubSiteUrl: this.props.hubSite.url,
       siteId: this.props.siteId,
-      webUrl: this.props.webUrl
+      webUrl: this.props.webUrl,
+      showLists: this.state.data.reports ? this.state.selectedReport.id === this.state.newestReportId : true
     }
     return baseProps
   }

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/types.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/types.ts
@@ -29,6 +29,12 @@ export interface IProjectStatusState extends IBaseWebPartComponentState<IProject
    * Is the report being published?
    */
   isPublishing: boolean
+
+  /**
+   * ID of the most recent report
+   */
+
+  newestReportId?: number;
 }
 
 export interface IProjectStatusHashState {


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [x] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [x] Check the commit's or even all commits' message 
- [x] Check if your code additions will fail linting checks
- [ ] Remember: Add PR description to [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the ID that matches this PR

### Description

This PR removes the list views and Risk matrix from outdated reports. If browsing older reports, the list elements are current, creating a mismatch. 

### How to test

- [ ] 1. Go to project reports
- [ ] 2. Check already published reports to ensure lists are removed
- [ ] 3. Create new project report and ensure lists are visible.

### Relevant issues (if applicable)

#374 

💔Thank you!
