### PR TITLE
Added another setup validation.

### DIFF
--- a/SharePointFramework/ProjectExtensions/src/loc/myStrings.d.ts
+++ b/SharePointFramework/ProjectExtensions/src/loc/myStrings.d.ts
@@ -80,6 +80,8 @@ declare interface IProjectExtensionsStrings {
   SetupAbortedText: string
   UnknownErrorText: string
   TemplateListContentConfigText: string
+  ProjectAlreadySetupMessage: string
+  ProjectAlreadySetupStack: string
 }
 
 declare module 'ProjectExtensionsStrings' {

--- a/SharePointFramework/ProjectExtensions/src/loc/nb-no.js
+++ b/SharePointFramework/ProjectExtensions/src/loc/nb-no.js
@@ -81,6 +81,8 @@ define([], function () {
     DescriptionLabel: "Beskrivelse",
     FolderDropdownLabel: 'Velg mappe',
     DocumentLibraryDropdownLabel: 'Velg dokumentbibliotek',
-    DocumentTemplateDialogScreenEditCopyRootLevelText: 'Øverste nivå'
+    DocumentTemplateDialogScreenEditCopyRootLevelText: 'Øverste nivå',
+    ProjectAlreadySetupMessage: "Det ser ut til at prosjektet allerede er satt opp. Denne dialogen vil nå slettes.", 
+    ProjectAlreadySetupStack: "Prosjektet er allerede satt opp"
   }
 })

--- a/SharePointFramework/ProjectExtensions/src/projectSetup/types.ts
+++ b/SharePointFramework/ProjectExtensions/src/projectSetup/types.ts
@@ -80,5 +80,10 @@ export enum ProjectSetupValidation {
   /**
    * The site is ready for setup/configuration
    */
-  Ready
+  Ready,
+
+  /**
+   * The site is already finished setup
+   */
+  AlreadySetup
 }


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [X] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [X] Check the commit's or even all commits' message 
- [ ] Check if your code additions will fail linting checks
- [ ] Remember: Add PR description to [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the ID that matches this PR

### Description

As the issue #528 describes, the project wizard is reactivated when attached to another hubsite. This is a draft which adds another check to the validation. The thought is to check the project for earlier setups. I guess we could write some data to a list when the setup is complete to get a more robust solution. In this draft I'm just checking if "Prosjektegenskaper" exists, which have some flaws. Any ideas? 

### Relevant issues (if applicable)
#528 

💔Thank you!
