### PR TITLE
Change refinablestring to match search mappings

### DIFF
--- a/Templates/Portfolio/Objects/Lists/Prosjektkolonner.xml
+++ b/Templates/Portfolio/Objects/Lists/Prosjektkolonner.xml
@@ -422,9 +422,9 @@
             <pnp:DataValue FieldName="GtSortOrder">310</pnp:DataValue>
             <pnp:DataValue FieldName="Title">Prosjektstøtte</pnp:DataValue>
             <pnp:DataValue FieldName="GtInternalName">GtProjectSupport</pnp:DataValue>
-            <pnp:DataValue FieldName="GtManagedProperty">RefinableString61</pnp:DataValue>
+            <pnp:DataValue FieldName="GtManagedProperty">RefinableString60</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">User</pnp:DataValue>
-            <pnp:DataValue FieldName="GtColMinWidth">150</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">175</pnp:DataValue>
             <pnp:DataValue FieldName="GtShowFieldProjectStatus">True</pnp:DataValue>
             <pnp:DataValue FieldName="GtShowFieldFrontpage">True</pnp:DataValue>
             <pnp:DataValue FieldName="GtShowFieldPortfolio">True</pnp:DataValue>


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [X] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [X] Check the commit's or even all commits' message 
- [X] Check if your code additions will fail linting checks
- [X] Remember: Add PR description to [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the ID that matches this PR

### Description

Prosjektstøtte is not displayed in porteføljeoversikt.
Mapped to refinablestring60, while it is 61 in prosjektkolonner.
Also added some width to the field.

### How to test

See #526 


### Relevant issues (if applicable)

fixes #555 

💔Thank you!
