### PR TITLE
Rewrite Get-PnPHubSiteChild to pure rest

### DIFF
--- a/Install/Scripts/PP365Functions.ps1
+++ b/Install/Scripts/PP365Functions.ps1
@@ -1,0 +1,20 @@
+﻿function Get-PP365HubSiteChild {
+    [CmdletBinding()]
+    param(
+        $Identity    
+    )
+
+    if( -not (Get-PnPWeb | select Url) -like ("*admin.sharepoint.com*") ){
+        Write-Host "Not connected to an admin site, cannot get hubsite children"
+        throw
+    }
+
+    if($Identity.GetType().Name -eq "HubSiteProperties"){
+        $filterId = $Identity.SiteId.ToString()
+    } else {
+        $filterId = $Identity
+    }
+
+    $items = Invoke-PnPSPRestMethod -Method Get ("/_api/web/lists/getbytitle('DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECOLLECTIONS')/items?`$filter=HubSiteId eq '{0}'" -f $filterId)
+    return $items.value.SiteUrl
+}

--- a/Install/Scripts/PP365Functions.ps1
+++ b/Install/Scripts/PP365Functions.ps1
@@ -15,6 +15,7 @@
         $filterId = $Identity
     }
 
-    $items = Invoke-PnPSPRestMethod -Method Get ("/_api/web/lists/getbytitle('DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECOLLECTIONS')/items?`$filter=HubSiteId eq '{0}'" -f $filterId)
+  
+    $items = Invoke-PnPSPRestMethod -Method Get ("/_api/web/lists/getbytitle('DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECOLLECTIONS')/items?`$filter=HubSiteId eq '{0}' and SiteId ne '{0}' and TimeDeleted eq null&$select=SiteUrl" -f $filterId)
     return $items.value.SiteUrl
 }

--- a/Install/Scripts/UpgradeAllSitesToLatest.ps1
+++ b/Install/Scripts/UpgradeAllSitesToLatest.ps1
@@ -3,6 +3,9 @@ Param(
     [string]$PortfolioUrl
 )
 
+$ScriptDir = (Split-Path -Path $MyInvocation.MyCommand.Definition -Parent)
+. $ScriptDir\PP365Functions.ps1
+
 function EnsureProjectTimelinePage($Url) {
     Connect-PnPOnline -Url $Url -UseWebLogin
         
@@ -40,7 +43,8 @@ $AdminSiteUrl = (@($Uri.Scheme, "://", $Uri.Authority) -join "").Replace(".share
 Connect-PnPOnline -Url $AdminSiteUrl -UseWebLogin
 
 $PPHubSite = Get-PnPHubSite -Identity $PortfolioUrl
-$ProjectsInHub = Get-PnPHubSiteChild -Identity $PPHubSite
+
+$ProjectsInHub = Get-PP365HubSiteChild -Identity $PPHubSite
 
 # Get current logged in user
 $ctx = Get-PnPContext


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [x] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [x] Check the commit's or even all commits' message 
- [x] Check if your code additions will fail linting checks
- [x] Remember: Add issue description to [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the **ID of the Issue** associated with this PR
- [x] Documentation: Have a look at the [PP365 User manual](https://puzzlepart.github.io/prosjektportalen-manual/) and consider the need for updates to be made. Updates can be done directly into the 'Kladd' branch or by providing information to test team for implementation.

### Description

PnP Powershell bundle has issues with Get-PnPHubSiteChild for larger tenants. The command fails due to listview threshold being exceeded. 

This happens due to Get-PnPHubSiteChild calling [Tenant.GetHubSiteChildUrls](https://github.com/pnp/PnP-Sites-Core/blob/master/Core/OfficeDevPnP.Core/Extensions/TenantExtensions.cs#L87) which requests list items from the ... aptly named list `DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECOLLECTIONS` which exists at the tenant admin site.  

As a curiosity this list is part of the extended family of DO_NOT_DELETE_SPLIST lists provisioned to the tenant admin site

DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_CONTENTTYPES
DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_POLICYINSIGHTS_STORAGE
DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECOLLECTIONS
DO_NOT_DELETE_SPLIST_TENANTADMIN_ALL_SITES_AGGREGATED_SITECOLLECTIONS
DO_NOT_DELETE_SPLIST_TENANTADMIN_USERSTORAGE

### How to test

Run `UpgradeAllSitesToLatest.ps1` against a tenant which currently cannot be upgraded