### PR TITLE
Reapply old navigation elements

### DIFF
--- a/Install/Install.ps1
+++ b/Install/Install.ps1
@@ -103,6 +103,18 @@ function LoadBundle() {
     return (Get-Command Connect-PnPOnline).Version
 }
 
+function ApplyOldNavigation($existingNodes) {
+    $newNodes = Get-PnPNavigationNode -Location TopNavigationBar
+
+    $existingNodes | ForEach-Object {
+        $index = $existingNodes.IndexOf($_)
+        if($newNodes.Title -notcontains $existingNodes[$index].Title) {
+            Add-PnPNavigationNode -Location TopNavigationBar -Title $existingNodes[$index].Title -Url $existingNodes[$index].Url
+            Write-Host "[INFO] ADDED $(existingNodes[$index].Title) FROM OLD NAVIGATION"
+        }
+    }
+}
+
 if (-not [string]::IsNullOrEmpty($CI)) {
     Write-Host "[Running in CI mode. Installing module SharePointPnPPowerShellOnline.]" -ForegroundColor Yellow
     Install-Module -Name SharePointPnPPowerShellOnline -Force -Scope CurrentUser -ErrorAction Stop

--- a/Install/Install.ps1
+++ b/Install/Install.ps1
@@ -110,7 +110,6 @@ function ApplyOldNavigation($existingNodes) {
         $index = $existingNodes.IndexOf($_)
         if($newNodes.Title -notcontains $existingNodes[$index].Title) {
             Add-PnPNavigationNode -Location TopNavigationBar -Title $existingNodes[$index].Title -Url $existingNodes[$index].Url
-            Write-Host "[INFO] ADDED $(existingNodes[$index].Title) FROM OLD NAVIGATION"
         }
     }
 }

--- a/Install/Install.ps1
+++ b/Install/Install.ps1
@@ -345,8 +345,10 @@ if (-not $SkipTemplate.IsPresent) {
         Write-Host "[INFO] Applying PnP template [Portfolio] to [$Url]"
         $Instance = Read-PnPProvisioningTemplate "$BasePath\Portfolio.pnp"
         $Instance.SupportedUILanguages[0].LCID = $LanguageId
-        Apply-PnPProvisioningTemplate -InputInstance $Instance -Handlers SupportedUILanguages
+        $OldNavNodes = Get-PnPNavigationNode -Location TopNavigationBar
+        Apply-PnPProvisioningTemplate -InputInstance $Instance -Handlers SupportedUILanguages, Navigation
         Apply-PnPProvisioningTemplate "$BasePath\Portfolio.pnp" -ExcludeHandlers SupportedUILanguages -ErrorAction Stop
+        ApplyOldNavigation($OldNavNodes)
         Write-Host "[SUCCESS] Successfully applied PnP template [Portfolio] to [$Url]" -ForegroundColor Green
 
         if ($Upgrade.IsPresent) {


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [X] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [X] Check the commit's or even all commits' message 
- [X] Check if your code additions will fail linting checks
- [ ] Remember: Add issue description to [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the **ID of the Issue** associated with this PR
- [ ] Documentation: Have a look at the [PP365 User manual](https://puzzlepart.github.io/prosjektportalen-manual/) and consider the need for updates to be made. Updates can be done directly into the 'Kladd' branch or by providing information to test team for implementation.

### Description (DRAFT)

Draft for #567. Added a check that reapplies old custom navigation nodes that are not applied by the template. Could this be a solution if it takes care of deprecated pages + customer deleted navigation links?

### How to test

Run Install script with the changes applied to the script. 


### Relevant issues (if applicable)
#567 

💔Thank you!
