### PR TITLE
Fix for syncing number and currency flds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Every change is marked with issue ID.
 
-## 1.3.1 - 03.11.2021
+## 1.3.2 - 07.01.2022
+
+### Changed
+
+- Added support for syncing number and currency fields in project properties
+
+## 1.3.1 - 20.12.2021
 
 ### Added
 

--- a/SharePointFramework/ProjectWebParts/src/data/SPDataAdapter/index.ts
+++ b/SharePointFramework/ProjectWebParts/src/data/SPDataAdapter/index.ts
@@ -87,8 +87,8 @@ class SPDataAdapter extends SPDataAdapterBase<ISPDataAdapterConfiguration> {
       const [fields, siteUsers] = await Promise.all([
         templateParameters.ProjectContentTypeId
           ? this.entityService
-              .usingParams({ contentTypeId: templateParameters.ProjectContentTypeId })
-              .getEntityFields()
+            .usingParams({ contentTypeId: templateParameters.ProjectContentTypeId })
+            .getEntityFields()
           : this.entityService.getEntityFields(),
         this.sp.web.siteUsers.select('Id', 'Email', 'LoginName').get<
           {
@@ -139,12 +139,17 @@ class SPDataAdapter extends SPDataAdapterBase<ISPDataAdapterConfiguration> {
               properties[fld.InternalName] = fldValue ? new Date(fldValue) : null
             }
             break
-          case 'Number': 
+          case 'Number':
           case 'Currency':
             {
               properties[fld.InternalName] = fldValue ? parseFloat(fldValue) : null
             }
           case 'URL':
+            {
+              properties[fld.InternalName] = fldValue || null
+            }
+            break
+          case 'Boolean':
             {
               properties[fld.InternalName] = fldValue || null
             }

--- a/SharePointFramework/ProjectWebParts/src/data/SPDataAdapter/index.ts
+++ b/SharePointFramework/ProjectWebParts/src/data/SPDataAdapter/index.ts
@@ -139,7 +139,11 @@ class SPDataAdapter extends SPDataAdapterBase<ISPDataAdapterConfiguration> {
               properties[fld.InternalName] = fldValue ? new Date(fldValue) : null
             }
             break
+          case 'Number': 
           case 'Currency':
+            {
+              properties[fld.InternalName] = fldValue ? parseFloat(fldValue) : null
+            }
           case 'URL':
             {
               properties[fld.InternalName] = fldValue || null


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [X] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [X] Check the commit's or even all commits' message 
- [X] Check if your code additions will fail linting checks
- [X] Remember: Add issue description to [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the **ID of the Issue** associated with this PR
- [X] Documentation: Have a look at the [PP365 User manual](https://puzzlepart.github.io/prosjektportalen-manual/) and consider the need for updates to be made. Updates can be done directly into the 'Kladd' branch or by providing information to test team for implementation.

### Description

Added support for number and currency fields in project properties, to allow sync of them

### How to test

Please describe how someone else (a regular user without coding skills) can test this PR. In the form of a numbered list and checkboxes for Jan when the testing period occurs.

Example:

- [ ] 1. Create number and currency fields and add them to the Project content type of the hub
- [ ] 2. Create project 
- [ ] 3. Edit project properties and add values to the number and currency fields
- [ ] 4. Observe that sync of project props is working


### Relevant issues (if applicable)

💔Thank you!
