### PR TITLE
Fix for filter checkbox not persisting when changing views in Portfolio overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Every change is marked with issue ID.
 - Changed behavior when deleting a status report #597
 - Changed behavior when deleting timeline item #569
 
+### Fixed
+
+- Fixed persistant filter checkbox on view change #545
+
 ## 1.3.1 - 20.12.2021
 
 ### Added

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/index.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/index.tsx
@@ -188,9 +188,27 @@ export class PortfolioOverview extends Component<IPortfolioOverviewProps, IPortf
       let items: IFilterItemProps[] = uniqueValues
         .filter((value: string) => !stringIsNullOrEmpty(value))
         .map((value: string) => ({ name: value, value }))
-      items = items.sort((a, b) => (a.value > b.value ? 1 : -1))
+      items = items.sort((a, b) => (a.value > b.value ? 1 : -1))    
       return { column, items }
     })
+
+    const activeFilters = this.state.activeFilters
+    if (!_.isEmpty(activeFilters)) {
+    const filteredFields = Object.keys(activeFilters)
+    filteredFields.forEach((key) => {  
+      filters.forEach(filter => {
+        if (filter.column.fieldName === key) {
+          activeFilters[key].forEach((value) => {
+            filter.items.forEach((item) => {
+              if (value === item.name) {
+                 item.selected = true
+               }
+            })
+          })          
+        }})
+      })
+    }
+
     return filters
   }
 


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [x] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [x] Check the commit's or even all commits' message 
- [x] Check if your code additions will fail linting checks
- [x] Remember: Add issue description to [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the **ID of the Issue** associated with this PR
- [x] Documentation: Have a look at the [PP365 User manual](https://puzzlepart.github.io/prosjektportalen-manual/) and consider the need for updates to be made. Updates can be done directly into the 'Kladd' branch or by providing information to test team for implementation.

### Description

Portfolio Overview lost the selected filter in the filterpane, while maintaining the filter in the search query. This PR ensures the persistence of checkboxes.

### How to test

- [x] 1. Navigate to Porfolio Overview
- [x] 2. Activate filter
- [x] 3. Change view
- [x] 4. Ensure the checkbox persists

### Relevant issues (if applicable)

Closes #545 

💔Thank you!
