### PR TITLE
Dynamic welcome page based on phase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Every change is marked with issue ID.
 
+## 1.X.X - TBA
+
+### Added
+
+- Added functionality for dynamic welcomepages based on project phases #643
+
 ## 1.4.0 - 08.02.2022
 
 ### Added

--- a/SharePointFramework/ProjectWebParts/config/config.json
+++ b/SharePointFramework/ProjectWebParts/config/config.json
@@ -1,53 +1,54 @@
 {
-    "$schema": "https://developer.microsoft.com/json-schemas/spfx-build/config.2.0.schema.json",
-    "version": "2.0",
-    "bundles": {
-        "project-status-web-part": {
-            "components": [
-                {
-                    "entrypoint": "./lib/webparts/projectStatus/index.js",
-                    "manifest": "./src/webparts/projectStatus/manifest.json"
-                }
-            ]
-        },
-        "project-phases-web-part": {
-            "components": [
-                {
-                    "entrypoint": "./lib/webparts/projectPhases/index.js",
-                    "manifest": "./src/webparts/projectPhases/manifest.json"
-                }
-            ]
-        },
-        "project-information-web-part": {
-            "components": [
-                {
-                    "entrypoint": "./lib/webparts/projectInformation/index.js",
-                    "manifest": "./src/webparts/projectInformation/manifest.json"
-                }
-            ]
-        },
-        "risk-matrix-web-part": {
-            "components": [
-                {
-                    "entrypoint": "./lib/webparts/riskMatrix/index.js",
-                    "manifest": "./src/webparts/riskMatrix/manifest.json"
-                }
-            ]
-        },
-        "project-timeline-web-part": {
-            "components": [
-                {
-                    "entrypoint": "./lib/webparts/projectTimeline/index.js",
-                    "manifest": "./src/webparts/projectTimeline/manifest.json"
-                }
-            ]
+  "$schema": "https://developer.microsoft.com/json-schemas/spfx-build/config.2.0.schema.json",
+  "version": "2.0",
+  "bundles": {
+    "project-status-web-part": {
+      "components": [
+        {
+          "entrypoint": "./lib/webparts/projectStatus/index.js",
+          "manifest": "./src/webparts/projectStatus/manifest.json"
         }
+      ]
     },
-    "externals": {},
-    "localizedResources": {
-        "ProjectWebPartsStrings": "lib/loc/{locale}.js",
-        "PortfolioWebPartsStrings": "node_modules/pp365-portfoliowebparts/lib/loc/{locale}.js",
-        "PzlSPFxComponentsStrings": "lib/loc/{locale}.js",
-        "ControlStrings": "lib/loc/{locale}.js"
+    "project-phases-web-part": {
+      "components": [
+        {
+          "entrypoint": "./lib/webparts/projectPhases/index.js",
+          "manifest": "./src/webparts/projectPhases/manifest.json"
+        }
+      ]
+    },
+    "project-information-web-part": {
+      "components": [
+        {
+          "entrypoint": "./lib/webparts/projectInformation/index.js",
+          "manifest": "./src/webparts/projectInformation/manifest.json"
+        }
+      ]
+    },
+    "risk-matrix-web-part": {
+      "components": [
+        {
+          "entrypoint": "./lib/webparts/riskMatrix/index.js",
+          "manifest": "./src/webparts/riskMatrix/manifest.json"
+        }
+      ]
+    },
+    "project-timeline-web-part": {
+      "components": [
+        {
+          "entrypoint": "./lib/webparts/projectTimeline/index.js",
+          "manifest": "./src/webparts/projectTimeline/manifest.json"
+        }
+      ]
     }
+  },
+  "externals": {},
+  "localizedResources": {
+    "ProjectWebPartsStrings": "lib/loc/{locale}.js",
+    "PortfolioWebPartsStrings": "node_modules/pp365-portfoliowebparts/lib/loc/{locale}.js",
+    "PzlSPFxComponentsStrings": "lib/loc/{locale}.js",
+    "ControlStrings": "lib/loc/{locale}.js",
+    "PropertyControlStrings": "node_modules/@pnp/spfx-property-controls/lib/loc/{locale}.js"
+  }
 }

--- a/SharePointFramework/ProjectWebParts/package-lock.json
+++ b/SharePointFramework/ProjectWebParts/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pp365-projectwebparts",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5825,6 +5825,550 @@
         }
       }
     },
+    "@pnp/spfx-property-controls": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@pnp/spfx-property-controls/-/spfx-property-controls-3.4.0.tgz",
+      "integrity": "sha512-W9R7uRRx9gvjdQNGlJyPrgVHUwiPLSPVhMEHZ2EadCHb9VyRHKqH1aIJGU7ZQw9H7WETxjOtkruexKzW22yDlQ==",
+      "requires": {
+        "@microsoft/sp-core-library": "1.13.1",
+        "@microsoft/sp-lodash-subset": "1.13.1",
+        "@microsoft/sp-office-ui-fabric-core": "1.13.1",
+        "@microsoft/sp-property-pane": "1.13.1",
+        "@microsoft/sp-webpart-base": "1.13.1",
+        "@pnp/common": "1.3.11",
+        "@pnp/logging": "1.3.11",
+        "@pnp/odata": "1.3.11",
+        "@pnp/sp": "1.3.11",
+        "@pnp/sp-clientsvc": "1.3.11",
+        "@pnp/sp-taxonomy": "1.3.11",
+        "@pnp/telemetry-js": "2.0.0",
+        "@uifabric/icons": "7.5.17",
+        "lodash.omit": "4.5.0",
+        "markdown-to-jsx": "^6.11.4",
+        "office-ui-fabric-react": "7.174.1",
+        "react": "16.13.1",
+        "react-ace": "5.8.0",
+        "react-dom": "16.13.1"
+      },
+      "dependencies": {
+        "@microsoft/office-ui-fabric-react-bundle": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/@microsoft/office-ui-fabric-react-bundle/-/office-ui-fabric-react-bundle-1.13.1.tgz",
+          "integrity": "sha512-Tt99MShwPSqULImwsXT0umaG7mPTEwqbKq4ZvVJPjkydkpDZBTeDV6C+oGpqSa+wrbOi3Sk94Vyb71tY92W0VA==",
+          "requires": {
+            "@microsoft/sp-core-library": "1.13.1",
+            "@uifabric/icons": "7.6.0",
+            "office-ui-fabric-react": "7.176.2",
+            "react": "16.13.1",
+            "react-dom": "16.13.1",
+            "tslib": "~1.10.0"
+          },
+          "dependencies": {
+            "@uifabric/icons": {
+              "version": "7.6.0",
+              "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.6.0.tgz",
+              "integrity": "sha512-Xx+CVMYOafJDijllYYkgE22lvKpKaodrB9XUgVSI77QveGcOV+x9z5FVa5CzwERb6Zjoafyj7q7SmH/EOi+AZw==",
+              "requires": {
+                "@uifabric/set-version": "^7.0.24",
+                "@uifabric/styling": "^7.19.1",
+                "tslib": "^1.10.0"
+              }
+            },
+            "office-ui-fabric-react": {
+              "version": "7.176.2",
+              "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.176.2.tgz",
+              "integrity": "sha512-ACOgx0ccx93NtRLWJBunJLwVdgIbsnzR/lbn6J+XYTINUrSR4DBZCuNoAzZVi8t1RYd6MnouLyyyEUWneNC9QQ==",
+              "requires": {
+                "@fluentui/date-time-utilities": "^7.9.1",
+                "@fluentui/react-focus": "^7.18.0",
+                "@fluentui/react-window-provider": "^1.0.2",
+                "@microsoft/load-themed-styles": "^1.10.26",
+                "@uifabric/foundation": "^7.10.0",
+                "@uifabric/icons": "^7.6.0",
+                "@uifabric/merge-styles": "^7.19.2",
+                "@uifabric/react-hooks": "^7.14.0",
+                "@uifabric/set-version": "^7.0.24",
+                "@uifabric/styling": "^7.19.1",
+                "@uifabric/utilities": "^7.33.5",
+                "prop-types": "^15.7.2",
+                "tslib": "^1.10.0"
+              }
+            }
+          }
+        },
+        "@microsoft/sp-component-base": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-component-base/-/sp-component-base-1.13.1.tgz",
+          "integrity": "sha512-8jcxFs7GRPO4xyqs0U9bhxG0iS+5a2yCF0XanauzK5yweIVCjGUGatM581ynCP0hD+HshtdEYV0Y2zMZ9OGZxQ==",
+          "requires": {
+            "@microsoft/office-ui-fabric-react-bundle": "1.13.1",
+            "@microsoft/sp-core-library": "1.13.1",
+            "@microsoft/sp-diagnostics": "1.13.1",
+            "@microsoft/sp-dynamic-data": "1.13.1",
+            "@microsoft/sp-http": "1.13.1",
+            "@microsoft/sp-lodash-subset": "1.13.1",
+            "@microsoft/sp-module-interfaces": "1.13.1",
+            "@microsoft/sp-page-context": "1.13.1",
+            "tslib": "~1.10.0"
+          }
+        },
+        "@microsoft/sp-core-library": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.13.1.tgz",
+          "integrity": "sha512-qTBMa3whxhMXn79YS2S+jq+a+iAId9v+WvZOvcgre4dI/7LL7zPhbsHQTfWhzzuB4f2tPxkldHO8eOv63Ud68Q==",
+          "requires": {
+            "@microsoft/sp-lodash-subset": "1.13.1",
+            "@microsoft/sp-module-interfaces": "1.13.1",
+            "@microsoft/sp-odata-types": "1.13.1",
+            "tslib": "~1.10.0"
+          }
+        },
+        "@microsoft/sp-diagnostics": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-diagnostics/-/sp-diagnostics-1.13.1.tgz",
+          "integrity": "sha512-KhzJo8kGL1M92WSDPhLlWyEnyAnkiRNMyQBb4eB9EYB8yZMhM2iBPpflIzatuJSOyNmq3jfmBS4G/ASg1tzyiQ==",
+          "requires": {
+            "@microsoft/sp-core-library": "1.13.1",
+            "@microsoft/sp-lodash-subset": "1.13.1"
+          }
+        },
+        "@microsoft/sp-dynamic-data": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.13.1.tgz",
+          "integrity": "sha512-x3Fk6dC5JgUOKhiFQ5JphMf9k+IhpLEWWk1bsmsLak3pCWeY9Xp3kR3SlrdPGaFtoa3wbFlEsYZ8Log+ut0b1w==",
+          "requires": {
+            "@microsoft/sp-core-library": "1.13.1",
+            "@microsoft/sp-diagnostics": "1.13.1",
+            "@microsoft/sp-lodash-subset": "1.13.1",
+            "@microsoft/sp-module-interfaces": "1.13.1",
+            "tslib": "~1.10.0"
+          }
+        },
+        "@microsoft/sp-http": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-http/-/sp-http-1.13.1.tgz",
+          "integrity": "sha512-MhlFCOhFUUt7HpG3oa9LSu7O1dqmyJfU2Zmk+uPrUnudy5JIL2K83g5rv2TK8YeGXDXxKEmqZsOsWP4ZHbo9YQ==",
+          "requires": {
+            "@microsoft/microsoft-graph-client": "~1.1.0",
+            "@microsoft/sp-core-library": "1.13.1",
+            "@microsoft/sp-diagnostics": "1.13.1",
+            "@types/adal-angular": "1.0.1",
+            "adal-angular": "1.0.16",
+            "msal": "1.4.13",
+            "msalLegacy": "npm:msal@1.4.12",
+            "tslib": "~1.10.0"
+          }
+        },
+        "@microsoft/sp-loader": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-loader/-/sp-loader-1.13.1.tgz",
+          "integrity": "sha512-Srry9SqR2JQA4l8+I1LTdO0lIkrekxWOxo9/2RgCbQtMyG6sSSCvw3VxUqRZ6VEFQbJzmmGFCWZRLGOho0GMlw==",
+          "requires": {
+            "@microsoft/office-ui-fabric-react-bundle": "1.13.1",
+            "@microsoft/sp-core-library": "1.13.1",
+            "@microsoft/sp-diagnostics": "1.13.1",
+            "@microsoft/sp-dynamic-data": "1.13.1",
+            "@microsoft/sp-http": "1.13.1",
+            "@microsoft/sp-lodash-subset": "1.13.1",
+            "@microsoft/sp-module-interfaces": "1.13.1",
+            "@microsoft/sp-odata-types": "1.13.1",
+            "@microsoft/sp-page-context": "1.13.1",
+            "@microsoft/sp-polyfills": "1.13.1",
+            "@rushstack/loader-raw-script": "1.3.175",
+            "@types/requirejs": "2.1.29",
+            "office-ui-fabric-react": "7.176.2",
+            "raw-loader": "~0.5.1",
+            "react": "16.13.1",
+            "react-dom": "16.13.1",
+            "requirejs": "2.3.6",
+            "tslib": "~1.10.0"
+          },
+          "dependencies": {
+            "@uifabric/icons": {
+              "version": "7.6.2",
+              "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.6.2.tgz",
+              "integrity": "sha512-q7jEIwB5Tt2Egw9fqdgNPlBqBQ6hNNMQ3qs5y4S4YETRluB+AQTdKbrbYMsXo3Pm0FsJnRfiDojMzxusGX+MWA==",
+              "requires": {
+                "@uifabric/set-version": "^7.0.24",
+                "@uifabric/styling": "^7.20.0",
+                "tslib": "^1.10.0"
+              }
+            },
+            "office-ui-fabric-react": {
+              "version": "7.176.2",
+              "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.176.2.tgz",
+              "integrity": "sha512-ACOgx0ccx93NtRLWJBunJLwVdgIbsnzR/lbn6J+XYTINUrSR4DBZCuNoAzZVi8t1RYd6MnouLyyyEUWneNC9QQ==",
+              "requires": {
+                "@fluentui/date-time-utilities": "^7.9.1",
+                "@fluentui/react-focus": "^7.18.0",
+                "@fluentui/react-window-provider": "^1.0.2",
+                "@microsoft/load-themed-styles": "^1.10.26",
+                "@uifabric/foundation": "^7.10.0",
+                "@uifabric/icons": "^7.6.0",
+                "@uifabric/merge-styles": "^7.19.2",
+                "@uifabric/react-hooks": "^7.14.0",
+                "@uifabric/set-version": "^7.0.24",
+                "@uifabric/styling": "^7.19.1",
+                "@uifabric/utilities": "^7.33.5",
+                "prop-types": "^15.7.2",
+                "tslib": "^1.10.0"
+              }
+            }
+          }
+        },
+        "@microsoft/sp-lodash-subset": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.13.1.tgz",
+          "integrity": "sha512-SXRG4KO0k/VVqWwkFFpC0177GxOOZ8jvsJHkg+i42+FyHGs5Uu4itffLarraGnPMokZLxHpkig9xRc8ZDytN7A==",
+          "requires": {
+            "@types/lodash": "4.14.117",
+            "tslib": "~1.10.0"
+          }
+        },
+        "@microsoft/sp-module-interfaces": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.13.1.tgz",
+          "integrity": "sha512-qrzmQW+T/2+s9/Lu1I0G1chF5DPN4xcR7znn3N3IjuM67o6E4cdvKel+m66mrqqzSGfo4qmCb6lGYTTYZsS3vw=="
+        },
+        "@microsoft/sp-odata-types": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-odata-types/-/sp-odata-types-1.13.1.tgz",
+          "integrity": "sha512-+dHWQY4E44OT/2E8c+lsSAxQJiRiRgk4jLLpNeOj/NzlydS8D85iUyOGlKfbmRu/6ujrc31/L77juKKzPQh7kw==",
+          "requires": {
+            "tslib": "~1.10.0"
+          }
+        },
+        "@microsoft/sp-office-ui-fabric-core": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-office-ui-fabric-core/-/sp-office-ui-fabric-core-1.13.1.tgz",
+          "integrity": "sha512-vsOv5QLaII35Nznw/pOyFIFBtxXkzA1bSif4MaRJpnENSAR49+050ot/MWYRMBKoGiXq/5cZD8zOAiNMwASoxQ==",
+          "requires": {
+            "office-ui-fabric-core": "9.6.1-fluent2",
+            "tslib": "~1.10.0"
+          }
+        },
+        "@microsoft/sp-page-context": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.13.1.tgz",
+          "integrity": "sha512-BO8I0TWCaubYpMKZ3/eTeGC/tx1nRirk2ulkQ/ggk2PhuKJo6NGcXKo/JHe48Mje4Yh4d1r5FkjUGHoqKK3ruA==",
+          "requires": {
+            "@microsoft/sp-core-library": "1.13.1",
+            "@microsoft/sp-diagnostics": "1.13.1",
+            "@microsoft/sp-dynamic-data": "1.13.1",
+            "@microsoft/sp-lodash-subset": "1.13.1",
+            "@microsoft/sp-odata-types": "1.13.1",
+            "tslib": "~1.10.0"
+          }
+        },
+        "@microsoft/sp-polyfills": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-polyfills/-/sp-polyfills-1.13.1.tgz",
+          "integrity": "sha512-sSN0su+v3tAzNTFt2QYJ/vzAIAZXZX6ox/1IFGFzNH0U30jdtfGG3vs5d45NkFkVLjDw9DL8Sc8uSi1lpEPNpA==",
+          "requires": {
+            "es6-promise": "4.2.4",
+            "es6-symbol": "3.1.3",
+            "tslib": "~1.10.0",
+            "whatwg-fetch": "2.0.3",
+            "whatwg-url": "4.7.1"
+          }
+        },
+        "@microsoft/sp-property-pane": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-property-pane/-/sp-property-pane-1.13.1.tgz",
+          "integrity": "sha512-eRqnrZGGv0nhDw4JdIi6wxCInFP2zlEZXMDFNaCTFJwM/ritRqGrHyVTxviENg7PXC5TTkVvIM9Hk/cNISRftg==",
+          "requires": {
+            "@microsoft/office-ui-fabric-react-bundle": "1.13.1",
+            "@microsoft/sp-component-base": "1.13.1",
+            "@microsoft/sp-core-library": "1.13.1",
+            "@microsoft/sp-diagnostics": "1.13.1",
+            "@microsoft/sp-dynamic-data": "1.13.1",
+            "@microsoft/sp-lodash-subset": "1.13.1",
+            "office-ui-fabric-react": "7.176.2",
+            "react": "16.13.1",
+            "react-dom": "16.13.1",
+            "tslib": "~1.10.0"
+          },
+          "dependencies": {
+            "@uifabric/icons": {
+              "version": "7.6.2",
+              "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.6.2.tgz",
+              "integrity": "sha512-q7jEIwB5Tt2Egw9fqdgNPlBqBQ6hNNMQ3qs5y4S4YETRluB+AQTdKbrbYMsXo3Pm0FsJnRfiDojMzxusGX+MWA==",
+              "requires": {
+                "@uifabric/set-version": "^7.0.24",
+                "@uifabric/styling": "^7.20.0",
+                "tslib": "^1.10.0"
+              }
+            },
+            "office-ui-fabric-react": {
+              "version": "7.176.2",
+              "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.176.2.tgz",
+              "integrity": "sha512-ACOgx0ccx93NtRLWJBunJLwVdgIbsnzR/lbn6J+XYTINUrSR4DBZCuNoAzZVi8t1RYd6MnouLyyyEUWneNC9QQ==",
+              "requires": {
+                "@fluentui/date-time-utilities": "^7.9.1",
+                "@fluentui/react-focus": "^7.18.0",
+                "@fluentui/react-window-provider": "^1.0.2",
+                "@microsoft/load-themed-styles": "^1.10.26",
+                "@uifabric/foundation": "^7.10.0",
+                "@uifabric/icons": "^7.6.0",
+                "@uifabric/merge-styles": "^7.19.2",
+                "@uifabric/react-hooks": "^7.14.0",
+                "@uifabric/set-version": "^7.0.24",
+                "@uifabric/styling": "^7.19.1",
+                "@uifabric/utilities": "^7.33.5",
+                "prop-types": "^15.7.2",
+                "tslib": "^1.10.0"
+              }
+            }
+          }
+        },
+        "@microsoft/sp-webpart-base": {
+          "version": "1.13.1",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-webpart-base/-/sp-webpart-base-1.13.1.tgz",
+          "integrity": "sha512-qBBtUaLGzP2rBuCrbwZQuEZqQtMmhF4MZQWGNvlDpJNOQEXJ6hj2vAnKxJjlTXdttWbfUdMWsyOx1Nb0bxOACg==",
+          "requires": {
+            "@microsoft/sp-component-base": "1.13.1",
+            "@microsoft/sp-core-library": "1.13.1",
+            "@microsoft/sp-diagnostics": "1.13.1",
+            "@microsoft/sp-dynamic-data": "1.13.1",
+            "@microsoft/sp-http": "1.13.1",
+            "@microsoft/sp-loader": "1.13.1",
+            "@microsoft/sp-lodash-subset": "1.13.1",
+            "@microsoft/sp-module-interfaces": "1.13.1",
+            "@microsoft/sp-page-context": "1.13.1",
+            "@microsoft/sp-property-pane": "1.13.1",
+            "@microsoft/teams-js": "1.10.0",
+            "@types/office-js": "1.0.36",
+            "office-ui-fabric-react": "7.176.2",
+            "react": "16.13.1",
+            "react-dom": "16.13.1",
+            "tslib": "~1.10.0"
+          },
+          "dependencies": {
+            "@uifabric/icons": {
+              "version": "7.6.2",
+              "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.6.2.tgz",
+              "integrity": "sha512-q7jEIwB5Tt2Egw9fqdgNPlBqBQ6hNNMQ3qs5y4S4YETRluB+AQTdKbrbYMsXo3Pm0FsJnRfiDojMzxusGX+MWA==",
+              "requires": {
+                "@uifabric/set-version": "^7.0.24",
+                "@uifabric/styling": "^7.20.0",
+                "tslib": "^1.10.0"
+              }
+            },
+            "office-ui-fabric-react": {
+              "version": "7.176.2",
+              "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.176.2.tgz",
+              "integrity": "sha512-ACOgx0ccx93NtRLWJBunJLwVdgIbsnzR/lbn6J+XYTINUrSR4DBZCuNoAzZVi8t1RYd6MnouLyyyEUWneNC9QQ==",
+              "requires": {
+                "@fluentui/date-time-utilities": "^7.9.1",
+                "@fluentui/react-focus": "^7.18.0",
+                "@fluentui/react-window-provider": "^1.0.2",
+                "@microsoft/load-themed-styles": "^1.10.26",
+                "@uifabric/foundation": "^7.10.0",
+                "@uifabric/icons": "^7.6.0",
+                "@uifabric/merge-styles": "^7.19.2",
+                "@uifabric/react-hooks": "^7.14.0",
+                "@uifabric/set-version": "^7.0.24",
+                "@uifabric/styling": "^7.19.1",
+                "@uifabric/utilities": "^7.33.5",
+                "prop-types": "^15.7.2",
+                "tslib": "^1.10.0"
+              }
+            }
+          }
+        },
+        "@microsoft/teams-js": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/@microsoft/teams-js/-/teams-js-1.10.0.tgz",
+          "integrity": "sha512-g8+ox5nWe9IjDFRHnCXk7mkQRGjHFcAMSn7JpUtJfuWu2tDUmXAp/4LUSgewvBbbmy68YtS+KTFPHRyUoTzk6w=="
+        },
+        "@pnp/common": {
+          "version": "1.3.11",
+          "resolved": "https://registry.npmjs.org/@pnp/common/-/common-1.3.11.tgz",
+          "integrity": "sha512-RhYKcfMP+h0pAzORZRHSPPLOBB58djN/pfnorpWPjsx6ZxMqbiDqTzAtTF4m8z/mdNnxJr0Q3kwt4ImU3FjwnA==",
+          "requires": {
+            "adal-angular": "1.0.17",
+            "tslib": "1.10.0"
+          },
+          "dependencies": {
+            "adal-angular": {
+              "version": "1.0.17",
+              "resolved": "https://registry.npmjs.org/adal-angular/-/adal-angular-1.0.17.tgz",
+              "integrity": "sha1-bpNuDkH5HTsqiOf/ypwvb29WLMQ="
+            }
+          }
+        },
+        "@pnp/logging": {
+          "version": "1.3.11",
+          "resolved": "https://registry.npmjs.org/@pnp/logging/-/logging-1.3.11.tgz",
+          "integrity": "sha512-hADlIXwvF/wjee7425nFJ6NhqaWpWTJ5yg02bpwBUsiSuFqEUf+LwuAcyHQre2lMs6KyNa65FWoRQok9BlZuxA==",
+          "requires": {
+            "tslib": "1.10.0"
+          }
+        },
+        "@pnp/odata": {
+          "version": "1.3.11",
+          "resolved": "https://registry.npmjs.org/@pnp/odata/-/odata-1.3.11.tgz",
+          "integrity": "sha512-yMaRiuVZRei2pkryCOqsw3ZXD2Lw30IJv136WQmQPQPOxG4cvsS9+woXkfMqbWV2KQ1evFUqVXbitIz6eDVfNA==",
+          "requires": {
+            "tslib": "1.10.0"
+          }
+        },
+        "@pnp/sp": {
+          "version": "1.3.11",
+          "resolved": "https://registry.npmjs.org/@pnp/sp/-/sp-1.3.11.tgz",
+          "integrity": "sha512-NjdeGe81aukiSPelSPjgAFRC1+SrNPTXvTdEqTH+Q1ZvgNtk8bdZp6K6xf9emfeM2qZDOu9GpKZpg0W/emq++g==",
+          "requires": {
+            "tslib": "1.10.0"
+          }
+        },
+        "@pnp/sp-clientsvc": {
+          "version": "1.3.11",
+          "resolved": "https://registry.npmjs.org/@pnp/sp-clientsvc/-/sp-clientsvc-1.3.11.tgz",
+          "integrity": "sha512-eIUnmDWjizcWJzhWxAbfsxEyHF1dabkGlihnDnlcYGhtvh8BwuM67A57qc5fbxzCS59c0YU57szB1EucoNmV4A==",
+          "requires": {
+            "tslib": "1.10.0"
+          }
+        },
+        "@pnp/sp-taxonomy": {
+          "version": "1.3.11",
+          "resolved": "https://registry.npmjs.org/@pnp/sp-taxonomy/-/sp-taxonomy-1.3.11.tgz",
+          "integrity": "sha512-shzCSjmOlr6mojCXJkfD8Xf9lJnhphq4Fj6mdUQGwpak+VIU+Fogf6AI0j6AReCKtKsKyqfud9X7C8tH07C3DA==",
+          "requires": {
+            "tslib": "1.10.0"
+          }
+        },
+        "@pnp/telemetry-js": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@pnp/telemetry-js/-/telemetry-js-2.0.0.tgz",
+          "integrity": "sha512-qFNm3mTerTnxgTR6c/4iMMt8EUKrQn5z0XG/IQtpNlp6m7KXRDFR87mQKeBVtSv2LhxGO0VNFndKJIibBw52zQ==",
+          "requires": {
+            "whatwg-fetch": "2.0.4"
+          },
+          "dependencies": {
+            "whatwg-fetch": {
+              "version": "2.0.4",
+              "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
+              "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng=="
+            }
+          }
+        },
+        "@rushstack/loader-raw-script": {
+          "version": "1.3.175",
+          "resolved": "https://registry.npmjs.org/@rushstack/loader-raw-script/-/loader-raw-script-1.3.175.tgz",
+          "integrity": "sha512-Rf+DewV7fMB5OX3yvhPNT5QRQgvI+2MWGbBmI0aYC5Aiax+RT5d+TN7CXket5CLFvT9/un3wN41vMtlnUbszKQ==",
+          "requires": {
+            "loader-utils": "~1.1.0"
+          }
+        },
+        "@uifabric/icons": {
+          "version": "7.5.17",
+          "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.5.17.tgz",
+          "integrity": "sha512-2S1kse0gtseTuV2r59iWukLxxoOJ6GgP2Yhxt9oxzaP9QubpYdxCUepvJmfPQQvvy4GELdykDUWQ6/hbzliJyw==",
+          "requires": {
+            "@uifabric/set-version": "^7.0.23",
+            "@uifabric/styling": "^7.16.18",
+            "tslib": "^1.10.0"
+          }
+        },
+        "@uifabric/utilities": {
+          "version": "7.33.5",
+          "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.33.5.tgz",
+          "integrity": "sha512-I+Oi0deD/xltSluFY8l2EVd/J4mvOaMljxKO2knSD9/KoGDlo/o5GN4gbnVo8nIt76HWHLAk3KtlJKJm6BhbIQ==",
+          "requires": {
+            "@fluentui/dom-utilities": "^1.1.2",
+            "@uifabric/merge-styles": "^7.19.2",
+            "@uifabric/set-version": "^7.0.24",
+            "prop-types": "^15.7.2",
+            "tslib": "^1.10.0"
+          }
+        },
+        "es6-promise": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+          "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+        },
+        "msal": {
+          "version": "1.4.13",
+          "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.13.tgz",
+          "integrity": "sha512-uFEa4KGlpGqNMwa7/1OQc6WQUF8iwHbaiHMVn0Cl66Ec7o30ZTtX9s9OWrf0wAxp8Mwg0JEE886z/PHpsiZUxQ==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
+        "office-ui-fabric-react": {
+          "version": "7.174.1",
+          "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.174.1.tgz",
+          "integrity": "sha512-zRUpUqZtVncvb+Tt+5SVNEcI3MfpwTLU+v2u7ZdF9ukPbD+UBKJSkIbydyO0P2S5jVizgdqioSOarfUA70ICvw==",
+          "requires": {
+            "@fluentui/date-time-utilities": "^7.9.1",
+            "@fluentui/react-focus": "^7.17.6",
+            "@fluentui/react-window-provider": "^1.0.2",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "@uifabric/foundation": "^7.9.26",
+            "@uifabric/icons": "^7.5.23",
+            "@uifabric/merge-styles": "^7.19.2",
+            "@uifabric/react-hooks": "^7.14.0",
+            "@uifabric/set-version": "^7.0.24",
+            "@uifabric/styling": "^7.19.0",
+            "@uifabric/utilities": "^7.33.5",
+            "prop-types": "^15.7.2",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "@uifabric/icons": {
+              "version": "7.6.2",
+              "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.6.2.tgz",
+              "integrity": "sha512-q7jEIwB5Tt2Egw9fqdgNPlBqBQ6hNNMQ3qs5y4S4YETRluB+AQTdKbrbYMsXo3Pm0FsJnRfiDojMzxusGX+MWA==",
+              "requires": {
+                "@uifabric/set-version": "^7.0.24",
+                "@uifabric/styling": "^7.20.0",
+                "tslib": "^1.10.0"
+              }
+            }
+          }
+        },
+        "react": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
+          "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "react-dom": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
+          "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "scheduler": "^0.19.1"
+          }
+        },
+        "requirejs": {
+          "version": "2.3.6",
+          "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.6.tgz",
+          "integrity": "sha512-ipEzlWQe6RK3jkzikgCupiTbTvm4S0/CAU5GlgptkN5SO6F3u0UD0K18wy6ErDqiCyP4J4YYe1HuAShvsxePLg=="
+        },
+        "scheduler": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "whatwg-fetch": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+          "integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
+        }
+      }
+    },
     "@pnp/telemetry-js": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@pnp/telemetry-js/-/telemetry-js-1.0.0.tgz",
@@ -9113,6 +9657,11 @@
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
       "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
       "dev": true
+    },
+    "brace": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/brace/-/brace-0.11.1.tgz",
+      "integrity": "sha1-SJb8ydVE7vRfS7dmDbMg07N5/lg="
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -18367,6 +18916,11 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "lodash.omit": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz",
+      "integrity": "sha1-brGa5aHuHdnfC5aeZs4Lf6MLXmA="
+    },
     "lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
@@ -18552,6 +19106,15 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/markdown-escapes/-/markdown-escapes-1.0.4.tgz",
       "integrity": "sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg=="
+    },
+    "markdown-to-jsx": {
+      "version": "6.11.4",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.11.4.tgz",
+      "integrity": "sha512-3lRCD5Sh+tfA52iGgfs/XZiw33f7fFX9Bn55aNnVNUd2GzLDkOWyKYYD8Yju2B1Vn+feiEdgJs8T6Tg0xNokPw==",
+      "requires": {
+        "prop-types": "^15.6.2",
+        "unquote": "^1.1.0"
+      }
     },
     "matchdep": {
       "version": "2.0.0",
@@ -18917,6 +19480,14 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/msal/-/msal-1.1.3.tgz",
       "integrity": "sha512-cdShb+N1H3OyR1y46ij6OO7QzeqC6BxrbrNcouS4JBrr1+DnZ55TumxQKEzWmTXHvsbsuz5PCyXZl812Un8L9g==",
+      "requires": {
+        "tslib": "^1.9.3"
+      }
+    },
+    "msalLegacy": {
+      "version": "npm:msal@1.4.12",
+      "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.12.tgz",
+      "integrity": "sha512-gjupwQ6nvNL6mZkl5NIXyUmZhTiEMRu5giNdgHMh8l5EPOnV2Xj6nukY1NIxFacSTkEYUSDB47Pej9GxDYf+1w==",
       "requires": {
         "tslib": "^1.9.3"
       }
@@ -22932,6 +23503,17 @@
         "scheduler": "^0.13.5"
       }
     },
+    "react-ace": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/react-ace/-/react-ace-5.8.0.tgz",
+      "integrity": "sha1-hy2e6LZkMA7Vq57axiNLvpCDaDY=",
+      "requires": {
+        "brace": "^0.11.0",
+        "lodash.get": "^4.4.2",
+        "lodash.isequal": "^4.1.1",
+        "prop-types": "^15.5.8"
+      }
+    },
     "react-calendar-timeline": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/react-calendar-timeline/-/react-calendar-timeline-0.26.0.tgz",
@@ -26047,8 +26629,7 @@
     "unquote": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
-      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ=",
-      "dev": true
+      "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
     },
     "unset-value": {
       "version": "1.0.0",

--- a/SharePointFramework/ProjectWebParts/package-lock.json
+++ b/SharePointFramework/ProjectWebParts/package-lock.json
@@ -22339,6 +22339,15 @@
             "object-assign": "^4.1.1"
           }
         },
+        "spfx-jsom": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/spfx-jsom/-/spfx-jsom-0.6.0.tgz",
+          "integrity": "sha1-LxRWebVSyhHn9HSTrdkCPrwgT1s=",
+          "requires": {
+            "@microsoft/sp-loader": "^1.4.0",
+            "jsom-ctx": "^1.0.8"
+          }
+        },
         "whatwg-fetch": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
@@ -24613,12 +24622,19 @@
       }
     },
     "spfx-jsom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/spfx-jsom/-/spfx-jsom-0.6.0.tgz",
-      "integrity": "sha1-LxRWebVSyhHn9HSTrdkCPrwgT1s=",
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/spfx-jsom/-/spfx-jsom-0.6.6.tgz",
+      "integrity": "sha512-in6HWs4i0f0ocCULoRHYAUko65eywCuJ+MCPPzXlZuQ8ZlIXKqg1/8kTyVEuW0kTXJLMkLG1KsG7GoA4pXTHTA==",
       "requires": {
-        "@microsoft/sp-loader": "^1.4.0",
-        "jsom-ctx": "^1.0.8"
+        "@microsoft/sp-loader": "^1.9.1",
+        "jsom-ctx": "^1.2.1"
+      },
+      "dependencies": {
+        "jsom-ctx": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/jsom-ctx/-/jsom-ctx-1.2.1.tgz",
+          "integrity": "sha512-JQm3JE7iClm6x2DHsT23x8yB6pF5vZvMbQwFBwhyvY421Tt+b1q+Quy0EuMuTyo4IPMNQFwOUaKvKG/q4Z0qLA=="
+        }
       }
     },
     "split": {

--- a/SharePointFramework/ProjectWebParts/package.json
+++ b/SharePointFramework/ProjectWebParts/package.json
@@ -32,6 +32,7 @@
     "@pnp/sp-clientsvc": "1.3.8",
     "@pnp/sp-taxonomy": "1.3.8",
     "@pnp/spfx-controls-react": "1.11.0",
+    "@pnp/spfx-property-controls": "^3.4.0",
     "@reduxjs/toolkit": "1.5.0",
     "@uifabric/utilities": "6.45.1",
     "dom-to-image": "2.6.0",

--- a/SharePointFramework/ProjectWebParts/package.json
+++ b/SharePointFramework/ProjectWebParts/package.json
@@ -50,7 +50,7 @@
     "react-scroll": "1.7.11",
     "sp-entityportal-service": "1.3.3",
     "sp-hubsite-service": "0.5.1",
-    "spfx-jsom": "0.6.0",
+    "spfx-jsom": "^0.6.6",
     "underscore": "1.9.1"
   },
   "resolutions": {

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/ChangePhaseDialog/ChangePhaseDialog.module.scss
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/ChangePhaseDialog/ChangePhaseDialog.module.scss
@@ -1,4 +1,17 @@
 .root {
   width: 550px;
   max-width: 550px;
+
+  .useDynamicHomepageContent {
+    display: flex;
+    margin-top: 10px;
+    font-weight: 300;
+
+    .descriptionIcon {
+      vertical-align: middle;
+      padding-top: 15px;
+      padding-right: 10px;
+      padding-left: 10px;
+    }
+  }
 }

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/ChangePhaseDialog/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/ChangePhaseDialog/index.tsx
@@ -46,7 +46,7 @@ export const ChangePhaseDialog = () => {
         title={strings.ChangePhaseText}
         subText={
           state.view === View.Confirm &&
-          format(strings.ConfirmChangePhase, context.state.confirmPhase.name)
+          format(strings.ConfirmChangePhase, context.state.confirmPhase.name) + "Endring til denne fasen vil også medføre endring av forside til prosjektet."
         }
         dialogContentProps={{ type: DialogType.largeHeader }}
         modalProps={{ isDarkOverlay: true, isBlocking: false }}

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/ChangePhaseDialog/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/ChangePhaseDialog/index.tsx
@@ -1,4 +1,5 @@
 import SPDataAdapter from 'data'
+import { Icon } from 'office-ui-fabric-react'
 import Dialog, { DialogType } from 'office-ui-fabric-react/lib/Dialog'
 import { format } from 'office-ui-fabric-react/lib/Utilities'
 import { IProjectPhaseChecklistItem } from 'pp365-shared/lib/models'
@@ -46,11 +47,17 @@ export const ChangePhaseDialog = () => {
         title={strings.ChangePhaseText}
         subText={
           state.view === View.Confirm &&
-          format(strings.ConfirmChangePhase, context.state.confirmPhase.name) + "Endring til denne fasen vil også medføre endring av forside til prosjektet."
+          format(strings.ConfirmChangePhase, context.state.confirmPhase.name)
         }
         dialogContentProps={{ type: DialogType.largeHeader }}
         modalProps={{ isDarkOverlay: true, isBlocking: false }}
         onDismiss={() => context.dispatch(DISMISS_CHANGE_PHASE_DIALOG())}>
+        {state.view === View.Confirm && context.props.useDynamicHomepage &&
+          <div className={styles.useDynamicHomepageContent}>
+            <Icon iconName={'Info'} className={styles.descriptionIcon} />
+            {strings.UseDynamicHomepageChangePhaseDescription}
+          </div>
+        }
         <Body />
         <Footer />
       </Dialog>

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/changePhase.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/changePhase.ts
@@ -1,22 +1,25 @@
 import SPDataAdapter from 'data'
 import { ProjectPhaseModel } from 'pp365-shared/lib/models'
+import { changeWelcomePage } from './changeWelcomePage'
 import { modifyCurrentPhaseView } from './modifyCurrentPhaseView'
+import { IProjectPhasesProps } from './types'
 
 /**
  * Change phase
  *
  * @param {ProjectPhaseModel} phase Phase
- * @param {string} phaseTextField Phase text field
  * @param {string} currentPhaseViewName Current phase view name
+ * @param {IProjectPhasesProps} props IProjectPhasesProps props
  */
 export const changePhase = async (
   phase: ProjectPhaseModel,
   phaseTextField: string,
-  currentPhaseViewName: string
+  props: IProjectPhasesProps,
 ) => {
   try {
     await SPDataAdapter.project.updatePhase(phase, phaseTextField)
-    await modifyCurrentPhaseView(phase.name, currentPhaseViewName)
+    if (props.useDynamicHomepage) await changeWelcomePage(phase.name, props.webPartContext.pageContext.web.absoluteUrl);
+    await modifyCurrentPhaseView(phase.name, props.currentPhaseViewName)
     sessionStorage.clear()
   } catch (error) {
     throw error

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/changeWelcomePage.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/changeWelcomePage.ts
@@ -12,13 +12,10 @@ export const changeWelcomePage = async (
 ) => {
   try {
     console.log("changeWelcomePage", phaseName)
-
     let spfxJsomContext = await initSpfxJsom(absoluteUrl)
     spfxJsomContext.jsomContext.web['get_rootFolder']()['set_welcomePage'](`SitePages/${phaseName}.aspx`);
     spfxJsomContext.jsomContext.web.update()
     await ExecuteJsomQuery(spfxJsomContext.jsomContext)
-
-    sessionStorage.clear()
   } catch (error) {
     throw error
   }

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/changeWelcomePage.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/changeWelcomePage.ts
@@ -1,0 +1,25 @@
+import initSpfxJsom, { ExecuteJsomQuery } from 'spfx-jsom'
+
+/**
+ * Change phase
+ *
+ * @param {string} phaseName
+ * @param {string} absoluteUrl absoluteurl
+ */
+export const changeWelcomePage = async (
+  phaseName: string,
+  absoluteUrl: string
+) => {
+  try {
+    console.log("changeWelcomePage", phaseName)
+
+    let spfxJsomContext = await initSpfxJsom(absoluteUrl)
+    spfxJsomContext.jsomContext.web['get_rootFolder']()['set_welcomePage'](`SitePages/${phaseName}.aspx`);
+    spfxJsomContext.jsomContext.web.update()
+    await ExecuteJsomQuery(spfxJsomContext.jsomContext)
+
+    sessionStorage.clear()
+  } catch (error) {
+    throw error
+  }
+}

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/fetchData.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/fetchData.ts
@@ -1,14 +1,16 @@
 import { Logger, LogLevel } from '@pnp/logging'
+import { sp } from "@pnp/sp";
 import SPDataAdapter from 'data'
 import * as strings from 'ProjectWebPartsStrings'
-import { IProjectPhasesData } from '.'
+import { IProjectPhasesData, IProjectPhasesProps } from '.'
 
 /***
  * Fetch phase terms
  *
- * @param {string} phaseField Phase field
+ * @param {IProjectPhasesProps} props IProjectPhasesProps props
  */
-export async function fetchData(phaseField: string): Promise<IProjectPhasesData> {
+export async function fetchData(props: IProjectPhasesProps): Promise<IProjectPhasesData> {
+  const { phaseField, useDynamicHomepage } = props;
   try {
     const [phaseFieldCtx, checklistData] = await Promise.all([
       SPDataAdapter.getTermFieldContext(phaseField),
@@ -18,6 +20,25 @@ export async function fetchData(phaseField: string): Promise<IProjectPhasesData>
       SPDataAdapter.project.getPhases(phaseFieldCtx.termSetId, checklistData),
       SPDataAdapter.project.getCurrentPhaseName(phaseFieldCtx.fieldName)
     ])
+
+    if (!useDynamicHomepage) {
+      let sitepages = await sp.web.lists.getByTitle('Områdesider').items.get()
+      console.log("1", sitepages)
+
+      sitepages = sitepages.filter(sitepage => {
+        return phases.some(phase => phase.name === sitepage.Title)
+      })
+
+      sitepages = sitepages.map((item) => ({
+        id: item.Id,
+        title: item.Title
+      }))
+
+      console.log(sitepages)
+    }
+
+    console.log(phases)
+
     Logger.log({
       message: '(ProjectPhases) _fetchData: Successfully fetch phases',
       level: LogLevel.Info

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/fetchData.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/fetchData.ts
@@ -1,5 +1,4 @@
 import { Logger, LogLevel } from '@pnp/logging'
-import { sp } from "@pnp/sp";
 import SPDataAdapter from 'data'
 import * as strings from 'ProjectWebPartsStrings'
 import { IProjectPhasesData, IProjectPhasesProps } from '.'
@@ -10,7 +9,7 @@ import { IProjectPhasesData, IProjectPhasesProps } from '.'
  * @param {IProjectPhasesProps} props IProjectPhasesProps props
  */
 export async function fetchData(props: IProjectPhasesProps): Promise<IProjectPhasesData> {
-  const { phaseField, useDynamicHomepage } = props;
+  const { phaseField } = props;
   try {
     const [phaseFieldCtx, checklistData] = await Promise.all([
       SPDataAdapter.getTermFieldContext(phaseField),
@@ -20,24 +19,6 @@ export async function fetchData(props: IProjectPhasesProps): Promise<IProjectPha
       SPDataAdapter.project.getPhases(phaseFieldCtx.termSetId, checklistData),
       SPDataAdapter.project.getCurrentPhaseName(phaseFieldCtx.fieldName)
     ])
-
-    if (!useDynamicHomepage) {
-      let sitepages = await sp.web.lists.getByTitle('Områdesider').items.get()
-      console.log("1", sitepages)
-
-      sitepages = sitepages.filter(sitepage => {
-        return phases.some(phase => phase.name === sitepage.Title)
-      })
-
-      sitepages = sitepages.map((item) => ({
-        id: item.Id,
-        title: item.Title
-      }))
-
-      console.log(sitepages)
-    }
-
-    console.log(phases)
 
     Logger.log({
       message: '(ProjectPhases) _fetchData: Successfully fetch phases',

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/index.tsx
@@ -4,7 +4,6 @@ import { Shimmer } from 'office-ui-fabric-react/lib/Shimmer'
 import * as strings from 'ProjectWebPartsStrings'
 import React, { useEffect, useReducer, useRef } from 'react'
 import { changePhase } from './changePhase'
-import { changeWelcomePage } from './changeWelcomePage'
 import { ChangePhaseDialog } from './ChangePhaseDialog'
 import { ProjectPhasesContext } from './context'
 import { fetchData } from './fetchData'
@@ -32,8 +31,6 @@ export const ProjectPhases = (props: IProjectPhasesProps) => {
 
   if (state.hidden) return null
 
-  console.log(state, props)
-
   if (state.error) {
     return (
       <UserMessage
@@ -49,8 +46,7 @@ export const ProjectPhases = (props: IProjectPhasesProps) => {
    */
   const onChangePhase = async () => {
     dispatch(INIT_CHANGE_PHASE())
-    await changePhase(state.confirmPhase, state.data.phaseTextField, props.currentPhaseViewName)
-    if (props.useDynamicHomepage) await changeWelcomePage(state.confirmPhase.name, props.webPartContext.pageContext.web.absoluteUrl);
+    await changePhase(state.confirmPhase, state.data.phaseTextField, props)
     dispatch(SET_PHASE({ phase: state.confirmPhase }))
     if (
       props.syncPropertiesAfterPhaseChange === undefined ||
@@ -61,8 +57,7 @@ export const ProjectPhases = (props: IProjectPhasesProps) => {
           {
             document.location.href = `${document.location.protocol}//${document.location.hostname}${document.location.pathname}#syncproperties=1`
             window.location.reload()
-
-          }          ,
+          },
         1000
       )
     }

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/index.tsx
@@ -4,6 +4,7 @@ import { Shimmer } from 'office-ui-fabric-react/lib/Shimmer'
 import * as strings from 'ProjectWebPartsStrings'
 import React, { useEffect, useReducer, useRef } from 'react'
 import { changePhase } from './changePhase'
+import { changeWelcomePage } from './changeWelcomePage'
 import { ChangePhaseDialog } from './ChangePhaseDialog'
 import { ProjectPhasesContext } from './context'
 import { fetchData } from './fetchData'
@@ -26,10 +27,12 @@ export const ProjectPhases = (props: IProjectPhasesProps) => {
   const [state, dispatch] = useReducer(reducer, initState())
 
   useEffect(() => {
-    fetchData(props.phaseField).then((data) => dispatch(INIT_DATA({ data })))
+    fetchData(props).then((data) => dispatch(INIT_DATA({ data })))
   }, [])
 
   if (state.hidden) return null
+
+  console.log(state, props)
 
   if (state.error) {
     return (
@@ -47,6 +50,7 @@ export const ProjectPhases = (props: IProjectPhasesProps) => {
   const onChangePhase = async () => {
     dispatch(INIT_CHANGE_PHASE())
     await changePhase(state.confirmPhase, state.data.phaseTextField, props.currentPhaseViewName)
+    if (props.useDynamicHomepage) await changeWelcomePage(state.confirmPhase.name, props.webPartContext.pageContext.web.absoluteUrl);
     dispatch(SET_PHASE({ phase: state.confirmPhase }))
     if (
       props.syncPropertiesAfterPhaseChange === undefined ||

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/types.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/types.ts
@@ -27,6 +27,11 @@ export interface IProjectPhasesProps extends IBaseWebPartComponentProps {
    * Sync properties after phase change
    */
   syncPropertiesAfterPhaseChange: boolean
+
+  /**
+   * If the site uses a dynamic homepage based off of the phase
+   */
+  useDynamicHomepage: boolean
 }
 
 export interface IProjectPhasesState extends IBaseWebPartComponentState<IProjectPhasesData> {

--- a/SharePointFramework/ProjectWebParts/src/loc/en-us.js
+++ b/SharePointFramework/ProjectWebParts/src/loc/en-us.js
@@ -140,6 +140,7 @@ define([], function () {
     ShowCmdTimelineListLabel: 'Vis kommandolinje for liste',
     ShowTimelineListLabel: 'Vis liste',
     UseDynamicHomepageFieldLabel: 'Bruk dynamisk hjemmeside',
+    UseDynamicHomepageCalloutText: 'Her kan du velge om fasevelgeren skal være dynamisk og bruke egne sider for hver fase. Det krever at det er opprettet sider for hver fase på forhånd. Navnene på sidene må være identiske med navnene på fasene.',
     AdvancedGroupName: 'Avansert'
   }
 })

--- a/SharePointFramework/ProjectWebParts/src/loc/en-us.js
+++ b/SharePointFramework/ProjectWebParts/src/loc/en-us.js
@@ -138,6 +138,8 @@ define([], function () {
     ShowTimelineLabel: 'Vis tidslinje',
     ShowInfoMessageLabel: 'Vis infomelding',
     ShowCmdTimelineListLabel: 'Vis kommandolinje for liste',
-    ShowTimelineListLabel: 'Vis liste'
+    ShowTimelineListLabel: 'Vis liste',
+    UseDynamicHomepageFieldLabel: 'Bruk dynamisk hjemmeside',
+    AdvancedGroupName: 'Avansert'
   }
 })

--- a/SharePointFramework/ProjectWebParts/src/loc/en-us.js
+++ b/SharePointFramework/ProjectWebParts/src/loc/en-us.js
@@ -141,6 +141,7 @@ define([], function () {
     ShowTimelineListLabel: 'Vis liste',
     UseDynamicHomepageFieldLabel: 'Bruk dynamisk hjemmeside',
     UseDynamicHomepageCalloutText: 'Her kan du velge om fasevelgeren skal være dynamisk og bruke egne sider for hver fase. Det krever at det er opprettet sider for hver fase på forhånd. Navnene på sidene må være identiske med navnene på fasene.',
-    AdvancedGroupName: 'Avansert'
+    AdvancedGroupName: 'Avansert',
+    UseDynamicHomepageChangePhaseDescription: 'Endring til denne fasen vil også medføre endring av forside til prosjektet, dersom side er opprettet for fasen du endrer til.'
   }
 })

--- a/SharePointFramework/ProjectWebParts/src/loc/mystrings.d.ts
+++ b/SharePointFramework/ProjectWebParts/src/loc/mystrings.d.ts
@@ -138,6 +138,8 @@ declare interface IProjectWebPartsStrings {
   ShowInfoMessageLabel: string;
   ShowCmdTimelineListLabel: string;
   ShowTimelineListLabel: string;
+  UseDynamicHomepageFieldLabel: string;
+  AdvancedGroupName: string;
 }
 
 declare module 'ProjectWebPartsStrings' {

--- a/SharePointFramework/ProjectWebParts/src/loc/mystrings.d.ts
+++ b/SharePointFramework/ProjectWebParts/src/loc/mystrings.d.ts
@@ -141,6 +141,7 @@ declare interface IProjectWebPartsStrings {
   UseDynamicHomepageFieldLabel: string;
   UseDynamicHomepageCalloutText: string;
   AdvancedGroupName: string;
+  UseDynamicHomepageChangePhaseDescription: string;
 }
 
 declare module 'ProjectWebPartsStrings' {

--- a/SharePointFramework/ProjectWebParts/src/loc/mystrings.d.ts
+++ b/SharePointFramework/ProjectWebParts/src/loc/mystrings.d.ts
@@ -139,6 +139,7 @@ declare interface IProjectWebPartsStrings {
   ShowCmdTimelineListLabel: string;
   ShowTimelineListLabel: string;
   UseDynamicHomepageFieldLabel: string;
+  UseDynamicHomepageCalloutText: string;
   AdvancedGroupName: string;
 }
 

--- a/SharePointFramework/ProjectWebParts/src/loc/nb-no.js
+++ b/SharePointFramework/ProjectWebParts/src/loc/nb-no.js
@@ -141,6 +141,7 @@ define([], function () {
     ShowCmdTimelineListLabel: 'Vis kommandolinje for liste',
     ShowTimelineListLabel: 'Vis liste',
     UseDynamicHomepageFieldLabel: 'Bruk dynamisk hjemmeside',
+    UseDynamicHomepageCalloutText: 'Her kan du velge om fasevelgeren skal være dynamisk og bruke egne sider for hver fase. Det krever at det er opprettet sider for hver fase på forhånd. Navnene på sidene må være identiske med navnene på fasene.',
     AdvancedGroupName: 'Avansert'
   }
 })

--- a/SharePointFramework/ProjectWebParts/src/loc/nb-no.js
+++ b/SharePointFramework/ProjectWebParts/src/loc/nb-no.js
@@ -139,6 +139,8 @@ define([], function () {
     ShowTimelineLabel: 'Vis tidslinje',
     ShowInfoMessageLabel: 'Vis infomelding',
     ShowCmdTimelineListLabel: 'Vis kommandolinje for liste',
-    ShowTimelineListLabel: 'Vis liste'
+    ShowTimelineListLabel: 'Vis liste',
+    UseDynamicHomepageFieldLabel: 'Bruk dynamisk hjemmeside',
+    AdvancedGroupName: 'Avansert'
   }
 })

--- a/SharePointFramework/ProjectWebParts/src/loc/nb-no.js
+++ b/SharePointFramework/ProjectWebParts/src/loc/nb-no.js
@@ -142,6 +142,7 @@ define([], function () {
     ShowTimelineListLabel: 'Vis liste',
     UseDynamicHomepageFieldLabel: 'Bruk dynamisk hjemmeside',
     UseDynamicHomepageCalloutText: 'Her kan du velge om fasevelgeren skal være dynamisk og bruke egne sider for hver fase. Det krever at det er opprettet sider for hver fase på forhånd. Navnene på sidene må være identiske med navnene på fasene.',
-    AdvancedGroupName: 'Avansert'
+    AdvancedGroupName: 'Avansert',
+    UseDynamicHomepageChangePhaseDescription: 'Endring til denne fasen vil også medføre endring av forside til prosjektet, dersom side er opprettet for fasen du endrer til.'
   }
 })

--- a/SharePointFramework/ProjectWebParts/src/webparts/projectPhases/index.ts
+++ b/SharePointFramework/ProjectWebParts/src/webparts/projectPhases/index.ts
@@ -25,7 +25,7 @@ export default class ProjectPhasesWebPart extends BaseProjectWebPart<IProjectPha
   }
 
   public render(): void {
-    this.renderComponent(ProjectPhases, {})
+    this.renderComponent(ProjectPhases, { webPartContext: this.context })
   }
 
   public getPropertyPaneConfiguration(): IPropertyPaneConfiguration {
@@ -64,6 +64,14 @@ export default class ProjectPhasesWebPart extends BaseProjectWebPart<IProjectPha
               groupFields: [
                 PropertyPaneTextField('currentPhaseViewName', {
                   label: strings.CurrentPhaseViewNameFieldLabel
+                })
+              ]
+            },
+            {
+              groupName: strings.AdvancedGroupName,
+              groupFields: [
+                PropertyPaneToggle('useDynamicHomepage', {
+                  label: strings.UseDynamicHomepageFieldLabel
                 })
               ]
             }

--- a/SharePointFramework/ProjectWebParts/src/webparts/projectPhases/index.ts
+++ b/SharePointFramework/ProjectWebParts/src/webparts/projectPhases/index.ts
@@ -5,12 +5,15 @@ import {
   PropertyPaneTextField,
   PropertyPaneToggle
 } from '@microsoft/sp-property-pane'
+import { CalloutTriggers } from '@pnp/spfx-property-controls/lib/PropertyFieldHeader';
+import { PropertyFieldToggleWithCallout } from '@pnp/spfx-property-controls/lib/PropertyFieldToggleWithCallout';
 import '@pnp/polyfill-ie11'
 import { sp } from '@pnp/sp'
 import { IProjectPhasesProps, ProjectPhases } from 'components/ProjectPhases'
 import 'office-ui-fabric-react/dist/css/fabric.min.css'
 import * as strings from 'ProjectWebPartsStrings'
 import { BaseProjectWebPart } from 'webparts/@baseProjectWebPart'
+import React from 'react';
 
 export default class ProjectPhasesWebPart extends BaseProjectWebPart<IProjectPhasesProps> {
   private _fields: { Title: string; InternalName: string }[] = []
@@ -70,8 +73,15 @@ export default class ProjectPhasesWebPart extends BaseProjectWebPart<IProjectPha
             {
               groupName: strings.AdvancedGroupName,
               groupFields: [
-                PropertyPaneToggle('useDynamicHomepage', {
-                  label: strings.UseDynamicHomepageFieldLabel
+                PropertyFieldToggleWithCallout('useDynamicHomepage', {
+                  calloutTrigger: CalloutTriggers.Click,
+                  key: 'useDynamicHomepageFieldId',
+                  label: strings.UseDynamicHomepageFieldLabel,
+                  onText: 'På',
+                  offText: 'Av',
+                  calloutWidth: 430,
+                  calloutContent: React.createElement('p', {}, strings.UseDynamicHomepageCalloutText),
+                  checked: this.properties.useDynamicHomepage
                 })
               ]
             }

--- a/SharePointFramework/ProjectWebParts/src/webparts/projectPhases/manifest.json
+++ b/SharePointFramework/ProjectWebParts/src/webparts/projectPhases/manifest.json
@@ -28,7 +28,8 @@
         "syncPropertiesAfterPhaseChange": true,
         "showSubText": true,
         "subTextTruncateLength": 50,
-        "currentPhaseViewName": "Gjeldende fase"
+        "currentPhaseViewName": "Gjeldende fase",
+        "useDynamicHomepage": false
       }
     }
   ]


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [X] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [X] Check the commit's or even all commits' message 
- [X] Check if your code additions will fail linting checks
- [X] Remember: Add issue description to [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the **ID of the Issue** associated with this PR
- [X] Documentation: Have a look at the [PP365 User manual](https://puzzlepart.github.io/prosjektportalen-manual/) and consider the need for updates to be made. Updates can be done directly into the 'Kladd' branch or by providing information to test team for implementation.

### Description

When changing the phase in a project, if enabled, also change project's WelcomePage. As long as a SitePage exists with the same name as the phase that is being selected for change.

Added information if dynamic WelcomePage is enabled. This is to give the user an indication that a SitePage exists with the phase the user has selected and that the WelcomePage will change when pressing "Yes" in the change phase dialog.

### How to test

- [ ] 1. Create new project with sitepages for each phase
- [ ] 2. Enable dynamic welcomepage/homepage
- [ ] 3. Change phases
- [ ] 4. After phase change the welcomepage will be set to the one representing the selected phase


### Update of documentation
- [X] Check if user manual requires update
  - [X] No


### Relevant issues (if applicable)

#643 
