### PR TITLE
Add 'Vis alle egenskaper' button with customizable panel (ProjectInformation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Every change is marked with issue ID.
 ### Added
 
 - Added functionality for dynamic welcomepages based on project phases #643
+- Added 'Vis alle egenskaper' button with customizable panel to ProjectInformation webpart #650
 
 ## 1.4.0 - 08.02.2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Every change is marked with issue ID.
 ### Added
 
 - Added functionality for dynamic welcomepages based on project phases #643
-- Added 'Vis alle egenskaper' button with customizable panel to ProjectInformation webpart #650
+- Added 'Vis alle egenskaper' button with panel to ProjectInformation webpart #650
 
 ## 1.4.0 - 08.02.2022
 

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/ProjectInformation.module.scss
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/ProjectInformation.module.scss
@@ -15,3 +15,14 @@
   max-width: 450px;
   width: 450px;
 }
+
+.btn {
+  width: 320px;
+  margin: 5px 0 0;
+
+  [class*='ms-Button-label'] {
+    float: left;
+    margin-left: 20px;
+  }
+}
+

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/index.tsx
@@ -123,7 +123,7 @@ export class ProjectInformation extends BaseWebPartComponent<
         <ProgressDialog {...this.state.progress} />
         {this.state.confirmActionProps && <ConfirmDialog {...this.state.confirmActionProps} />}
         <Panel
-          type={PanelType.medium}
+          type={this.props.setMediumPanelWidth ? PanelType.medium : PanelType.smallFixedFar}
           headerText={strings.ProjectPropertiesListName}
           isOpen={this.state.showProjectPropertiesPanel}
           onDismiss={() => this.setState({ showProjectPropertiesPanel: false })}
@@ -132,6 +132,7 @@ export class ProjectInformation extends BaseWebPartComponent<
           closeButtonAriaLabel={strings.CloseText}
         >
           <ProjectProperties
+            title={this.props.title}
             properties={this.state.allProperties}
             displayMode={this.props.displayMode}
             isSiteAdmin={this.props.isSiteAdmin}

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/index.tsx
@@ -123,7 +123,7 @@ export class ProjectInformation extends BaseWebPartComponent<
         <ProgressDialog {...this.state.progress} />
         {this.state.confirmActionProps && <ConfirmDialog {...this.state.confirmActionProps} />}
         <Panel
-          type={this.props.setMediumPanelWidth ? PanelType.medium : PanelType.smallFixedFar}
+          type={PanelType.medium}
           headerText={strings.ProjectPropertiesListName}
           isOpen={this.state.showProjectPropertiesPanel}
           onDismiss={() => this.setState({ showProjectPropertiesPanel: false })}

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/index.tsx
@@ -4,6 +4,8 @@ import { LogLevel } from '@pnp/logging'
 import { MessageBarType } from 'office-ui-fabric-react/lib/MessageBar'
 import { IProgressIndicatorProps } from 'office-ui-fabric-react/lib/ProgressIndicator'
 import { format } from 'office-ui-fabric-react/lib/Utilities'
+import { Panel, PanelType } from 'office-ui-fabric-react/lib/Panel'
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button'
 import { PortalDataService } from 'pp365-shared/lib/services'
 import { parseUrlHash, sleep } from 'pp365-shared/lib/util'
 import * as strings from 'ProjectWebPartsStrings'
@@ -112,8 +114,32 @@ export class ProjectInformation extends BaseWebPartComponent<
             this._onSyncProperties.bind(this)
           }
         />
+        <DefaultButton
+          text={strings.ViewAllPropertiesText}
+          iconProps={{ iconName: 'EntryView' }}
+          className={styles.btn}
+          onClick={() => this.setState({ showProjectPropertiesPanel: true })}
+        />
         <ProgressDialog {...this.state.progress} />
         {this.state.confirmActionProps && <ConfirmDialog {...this.state.confirmActionProps} />}
+        <Panel
+          type={PanelType.medium}
+          headerText={strings.ProjectPropertiesListName}
+          isOpen={this.state.showProjectPropertiesPanel}
+          onDismiss={() => this.setState({ showProjectPropertiesPanel: false })}
+          onLightDismissClick={() => this.setState({ showProjectPropertiesPanel: false })}
+          isLightDismiss
+          closeButtonAriaLabel={strings.CloseText}
+        >
+          <ProjectProperties
+            properties={this.state.allProperties}
+            displayMode={this.props.displayMode}
+            isSiteAdmin={this.props.isSiteAdmin}
+            onFieldExternalChanged={this.props.onFieldExternalChanged}
+            showFieldExternal={this.props.showFieldExternal}
+            propertiesList={!stringIsNullOrEmpty(this.state.data.propertiesListId)}
+          />
+        </Panel>
       </Fragment>
     )
   }
@@ -187,7 +213,7 @@ export class ProjectInformation extends BaseWebPartComponent<
         this.props.webUrl,
         strings.ProjectPropertiesListName,
         this.state.data.templateParameters.ProjectContentTypeId ||
-          '0x0100805E9E4FEAAB4F0EABAB2600D30DB70C',
+        '0x0100805E9E4FEAAB4F0EABAB2600D30DB70C',
         { Title: this.props.webTitle }
       )
       if (!created) {
@@ -216,8 +242,9 @@ export class ProjectInformation extends BaseWebPartComponent<
    * Transform properties from entity item and configuration
    *
    * @param {IProjectInformationData} data Data
+   * @param {boolean} useVisibleFilter Set to false if all properties should be returned
    */
-  private _transformProperties({ columns, fields, fieldValuesText }: IProjectInformationData) {
+  private _transformProperties({ columns, fields, fieldValuesText }: IProjectInformationData, useVisibleFilter: boolean = true) {
     const fieldNames: string[] = Object.keys(fieldValuesText).filter((fieldName) => {
       const [field] = fields.filter((fld) => fld.InternalName === fieldName)
       if (!field) return false
@@ -227,9 +254,15 @@ export class ProjectInformation extends BaseWebPartComponent<
       ) {
         return true
       }
+
       const [column] = columns.filter((c) => c.internalName === fieldName)
-      return column ? column.isVisible(this.props.page) : false
+      return column
+        ? useVisibleFilter
+          ? column.isVisible(this.props.page)
+          : true
+        : false
     })
+
     const properties = fieldNames.map((fn) => {
       const [field] = fields.filter((fld) => fld.InternalName === fn)
       return new ProjectPropertyModel(field, fieldValuesText[fn])
@@ -256,8 +289,10 @@ export class ProjectInformation extends BaseWebPartComponent<
         columns,
         ...propertiesData
       }
+
       const properties = this._transformProperties(data)
-      return { data, properties }
+      const allProperties = this._transformProperties(data, false)
+      return { data, properties, allProperties }
     } catch (error) {
       this.logError('Failed to retrieve data.', '_fetchData', error)
       throw error

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/types.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/types.ts
@@ -35,6 +35,11 @@ export interface IProjectInformationProps extends IBaseWebPartComponentProps {
   skipSyncToHub?: boolean
 
   /**
+   * Set medium panel width (true/false), false = small
+   */
+  setMediumPanelWidth?: boolean
+
+  /**
    * Custom actions/button to add
    */
   customActions?: ActionType[]

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/types.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/types.ts
@@ -35,11 +35,6 @@ export interface IProjectInformationProps extends IBaseWebPartComponentProps {
   skipSyncToHub?: boolean
 
   /**
-   * Set medium panel width (true/false), false = small
-   */
-  setMediumPanelWidth?: boolean
-
-  /**
    * Custom actions/button to add
    */
   customActions?: ActionType[]

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/types.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/types.ts
@@ -48,6 +48,11 @@ export interface IProjectInformationState
   properties?: ProjectPropertyModel[]
 
   /**
+   * All Properties
+   */
+  allProperties?: ProjectPropertyModel[]
+
+  /**
    * Progress
    */
   progress?: IProgressDialogProps
@@ -61,6 +66,11 @@ export interface IProjectInformationState
    * Confirm action props
    */
   confirmActionProps?: any
+
+  /**
+   * Show project properties panel
+   */
+  showProjectPropertiesPanel?: boolean
 }
 
 export interface IProjectInformationUrlHash {

--- a/SharePointFramework/ProjectWebParts/src/loc/en-us.js
+++ b/SharePointFramework/ProjectWebParts/src/loc/en-us.js
@@ -21,6 +21,7 @@ define([], function () {
     CurrentPhaseViewNameFieldLabel: 'Current phase display name',
     DocumentsListName: 'Documents',
     EditPropertiesText: 'Edit properties',
+    ViewAllPropertiesText: 'View all properties',
     EditReportButtonText: 'Edit status',
     PublishReportButtonText: 'Publish',
     GetSnapshotButtonText: 'Open as snapshot',

--- a/SharePointFramework/ProjectWebParts/src/loc/en-us.js
+++ b/SharePointFramework/ProjectWebParts/src/loc/en-us.js
@@ -143,9 +143,6 @@ define([], function () {
     UseDynamicHomepageFieldLabel: 'Bruk dynamisk hjemmeside',
     UseDynamicHomepageCalloutText: 'Her kan du velge om fasevelgeren skal være dynamisk og bruke egne sider for hver fase. Det krever at det er opprettet sider for hver fase på forhånd. Navnene på sidene må være identiske med navnene på fasene.',
     AdvancedGroupName: 'Avansert',
-    UseDynamicHomepageChangePhaseDescription: 'Endring til denne fasen vil også medføre endring av forside til prosjektet, dersom side er opprettet for fasen du endrer til.',
-    SetMediumPanelWidthLabel: 'Middels eller smalt panel?',
-    PanelWidthOnText: 'Middels',
-    PanelWidthOffText: 'Smalt',
+    UseDynamicHomepageChangePhaseDescription: 'Endring til denne fasen vil også medføre endring av forside til prosjektet, dersom side er opprettet for fasen du endrer til.'
   }
 })

--- a/SharePointFramework/ProjectWebParts/src/loc/en-us.js
+++ b/SharePointFramework/ProjectWebParts/src/loc/en-us.js
@@ -143,6 +143,9 @@ define([], function () {
     UseDynamicHomepageFieldLabel: 'Bruk dynamisk hjemmeside',
     UseDynamicHomepageCalloutText: 'Her kan du velge om fasevelgeren skal være dynamisk og bruke egne sider for hver fase. Det krever at det er opprettet sider for hver fase på forhånd. Navnene på sidene må være identiske med navnene på fasene.',
     AdvancedGroupName: 'Avansert',
-    UseDynamicHomepageChangePhaseDescription: 'Endring til denne fasen vil også medføre endring av forside til prosjektet, dersom side er opprettet for fasen du endrer til.'
+    UseDynamicHomepageChangePhaseDescription: 'Endring til denne fasen vil også medføre endring av forside til prosjektet, dersom side er opprettet for fasen du endrer til.',
+    SetMediumPanelWidthLabel: 'Middels eller smalt panel?',
+    PanelWidthOnText: 'Middels',
+    PanelWidthOffText: 'Smalt',
   }
 })

--- a/SharePointFramework/ProjectWebParts/src/loc/mystrings.d.ts
+++ b/SharePointFramework/ProjectWebParts/src/loc/mystrings.d.ts
@@ -26,6 +26,7 @@ declare interface IProjectWebPartsStrings {
   CurrentPhaseViewNameFieldLabel: string;
   DocumentsListName: string;
   EditPropertiesText: string;
+  ViewAllPropertiesText: string;
   EditReportButtonText: string;
   PublishReportButtonText: string;
   PublishedStatusReport: string;

--- a/SharePointFramework/ProjectWebParts/src/loc/mystrings.d.ts
+++ b/SharePointFramework/ProjectWebParts/src/loc/mystrings.d.ts
@@ -143,9 +143,6 @@ declare interface IProjectWebPartsStrings {
   UseDynamicHomepageCalloutText: string;
   AdvancedGroupName: string;
   UseDynamicHomepageChangePhaseDescription: string;
-  SetMediumPanelWidthLabel: string;
-  PanelWidthOnText: string;
-  PanelWidthOffText: string;
 }
 
 declare module 'ProjectWebPartsStrings' {

--- a/SharePointFramework/ProjectWebParts/src/loc/mystrings.d.ts
+++ b/SharePointFramework/ProjectWebParts/src/loc/mystrings.d.ts
@@ -143,6 +143,9 @@ declare interface IProjectWebPartsStrings {
   UseDynamicHomepageCalloutText: string;
   AdvancedGroupName: string;
   UseDynamicHomepageChangePhaseDescription: string;
+  SetMediumPanelWidthLabel: string;
+  PanelWidthOnText: string;
+  PanelWidthOffText: string;
 }
 
 declare module 'ProjectWebPartsStrings' {

--- a/SharePointFramework/ProjectWebParts/src/loc/nb-no.js
+++ b/SharePointFramework/ProjectWebParts/src/loc/nb-no.js
@@ -21,6 +21,7 @@ define([], function () {
     CurrentPhaseViewNameFieldLabel: 'Visningsnavn for gjeldende fase',
     DocumentsListName: 'Dokumenter',
     EditPropertiesText: 'Rediger egenskaper',
+    ViewAllPropertiesText: 'Vis alle egenskaper',
     EditReportButtonText: 'Rediger status',
     PublishReportButtonText: 'Publiser',
     GetSnapshotButtonText: 'Åpne som øyeblikksbilde',

--- a/SharePointFramework/ProjectWebParts/src/loc/nb-no.js
+++ b/SharePointFramework/ProjectWebParts/src/loc/nb-no.js
@@ -144,9 +144,6 @@ define([], function () {
     UseDynamicHomepageFieldLabel: 'Bruk dynamisk hjemmeside',
     UseDynamicHomepageCalloutText: 'Her kan du velge om fasevelgeren skal være dynamisk og bruke egne sider for hver fase. Det krever at det er opprettet sider for hver fase på forhånd. Navnene på sidene må være identiske med navnene på fasene.',
     AdvancedGroupName: 'Avansert',
-    UseDynamicHomepageChangePhaseDescription: 'Endring til denne fasen vil også medføre endring av forside til prosjektet, dersom side er opprettet for fasen du endrer til.',
-    SetMediumPanelWidthLabel: 'Middels eller smalt panel?',
-    PanelWidthOnText: 'Middels',
-    PanelWidthOffText: 'Smalt',
+    UseDynamicHomepageChangePhaseDescription: 'Endring til denne fasen vil også medføre endring av forside til prosjektet, dersom side er opprettet for fasen du endrer til.'
   }
 })

--- a/SharePointFramework/ProjectWebParts/src/loc/nb-no.js
+++ b/SharePointFramework/ProjectWebParts/src/loc/nb-no.js
@@ -144,6 +144,9 @@ define([], function () {
     UseDynamicHomepageFieldLabel: 'Bruk dynamisk hjemmeside',
     UseDynamicHomepageCalloutText: 'Her kan du velge om fasevelgeren skal være dynamisk og bruke egne sider for hver fase. Det krever at det er opprettet sider for hver fase på forhånd. Navnene på sidene må være identiske med navnene på fasene.',
     AdvancedGroupName: 'Avansert',
-    UseDynamicHomepageChangePhaseDescription: 'Endring til denne fasen vil også medføre endring av forside til prosjektet, dersom side er opprettet for fasen du endrer til.'
+    UseDynamicHomepageChangePhaseDescription: 'Endring til denne fasen vil også medføre endring av forside til prosjektet, dersom side er opprettet for fasen du endrer til.',
+    SetMediumPanelWidthLabel: 'Middels eller smalt panel?',
+    PanelWidthOnText: 'Middels',
+    PanelWidthOffText: 'Smalt',
   }
 })

--- a/SharePointFramework/ProjectWebParts/src/webparts/projectInformation/index.ts
+++ b/SharePointFramework/ProjectWebParts/src/webparts/projectInformation/index.ts
@@ -30,6 +30,11 @@ export default class ProjectInformationWebPart extends BaseProjectWebPart<IProje
               groupFields: [
                 PropertyPaneToggle('skipSyncToHub', {
                   label: strings.SkipSyncToHubLabel
+                }),
+                PropertyPaneToggle('setMediumPanelWidth', {
+                  label: strings.SetMediumPanelWidthLabel,
+                  onText: strings.PanelWidthOnText,
+                  offText: strings.PanelWidthOffText,
                 })
               ]
             }

--- a/SharePointFramework/ProjectWebParts/src/webparts/projectInformation/index.ts
+++ b/SharePointFramework/ProjectWebParts/src/webparts/projectInformation/index.ts
@@ -30,11 +30,6 @@ export default class ProjectInformationWebPart extends BaseProjectWebPart<IProje
               groupFields: [
                 PropertyPaneToggle('skipSyncToHub', {
                   label: strings.SkipSyncToHubLabel
-                }),
-                PropertyPaneToggle('setMediumPanelWidth', {
-                  label: strings.SetMediumPanelWidthLabel,
-                  onText: strings.PanelWidthOnText,
-                  offText: strings.PanelWidthOffText,
                 })
               ]
             }


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [X] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [X] Check the commit's or even all commits' message 
- [X] Check if your code additions will fail linting checks
- [X] Remember: Add issue description to [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the **ID of the Issue** associated with this PR
- [X] Documentation: Have a look at the [PP365 User manual](https://puzzlepart.github.io/prosjektportalen-manual/) and consider the need for updates to be made. Updates can be done directly into the 'Kladd' branch or by providing information to test team for implementation.

### Description

Added a 'Vis alle egenskaper' button to the ProjectInformation webpart, pressing this will display a panel on the right side of the screen. The panel displays all properties with values. (see image below)

This button is visible to all users who can access the project, configuration functionality for external users is also available in the panel. The panel's width is also customizable through the webpart properties.

![image](https://user-images.githubusercontent.com/28678468/156194874-6823d38e-190c-4a07-b6e5-85e85c5234ef.png)
![image](https://user-images.githubusercontent.com/28678468/156195020-f2e14cb4-3726-4328-8e4d-3544e93f4c30.png)

### How to test

- [x] 1. Press 'Vis alle egenskaper' button
- [x] 2. Test different widths through the webpart properties.


### Relevant issues (if applicable)

#650 
