### PR TITLE
Show report published date with fallback to created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Every change is marked with issue ID.
 - Added 'Vis alle egenskaper' button with panel to ProjectInformation webpart #650
 - Added support for {site} token in Planner-tasks #646
 - Add possibility to lock'project template configurations #645
-- Changed header in projectstatus report to show date when published instead of when created. 
+- Changed header in projectstatus report to show date when published instead of when created. #654
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Every change is marked with issue ID.
 - Added 'Vis alle egenskaper' button with panel to ProjectInformation webpart #650
 - Added support for {site} token in Planner-tasks #646
 - Add possibility to lock'project template configurations #645
+- Changed header in projectstatus report to show date when published instead of when created. 
 
 ### Changed
 

--- a/SharePointFramework/@Shared/src/models/StatusReport.ts
+++ b/SharePointFramework/@Shared/src/models/StatusReport.ts
@@ -11,7 +11,6 @@ export class StatusReport {
   public created: Date
   public defaultEditFormUrl: string
   public modified: Date
-  public gtLastReportDate: Date
   public publishedDate: Date
 
   /**
@@ -24,7 +23,6 @@ export class StatusReport {
     this.id = _item.Id
     this.created = new Date(_item.Created)
     this.modified = new Date(_item.Modified)
-    this.gtLastReportDate = new Date(_item.GtLastReportDate)
     this.publishedDate = new Date(_item.GtLastReportDate)
   }
 

--- a/SharePointFramework/@Shared/src/models/StatusReport.ts
+++ b/SharePointFramework/@Shared/src/models/StatusReport.ts
@@ -11,6 +11,7 @@ export class StatusReport {
   public created: Date
   public defaultEditFormUrl: string
   public modified: Date
+  public gtLastReportDate: Date
   public publishedDate: Date
 
   /**
@@ -23,6 +24,7 @@ export class StatusReport {
     this.id = _item.Id
     this.created = new Date(_item.Created)
     this.modified = new Date(_item.Modified)
+    this.gtLastReportDate = new Date(_item.GtLastReportDate)
     this.publishedDate = new Date(_item.GtLastReportDate)
   }
 

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/index.tsx
@@ -115,7 +115,6 @@ export class ProjectStatus extends React.Component<IProjectStatusProps, IProject
         </div>
       )
     }
-
     return (
       <div className={styles.projectStatus}>
         {this._commandBar()}
@@ -129,7 +128,7 @@ export class ProjectStatus extends React.Component<IProjectStatusProps, IProject
             <div className={styles.title}>
               {this.props.title}{' '}
               {this.state.selectedReport
-                ? moment(this.state.selectedReport.created).format('DD.MM.yyyy')
+                ? moment(this.state.selectedReport.gtLastReportDate).format('DD.MM.yyyy')
                 : null}{' '}
             </div>
           </div>

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/index.tsx
@@ -128,7 +128,7 @@ export class ProjectStatus extends React.Component<IProjectStatusProps, IProject
             <div className={styles.title}>
               {this.props.title}{' '}
               {this.state.selectedReport
-                ? moment(this.state.selectedReport.gtLastReportDate).format('DD.MM.yyyy')
+                ? moment(this.state.selectedReport.publishedDate ?? this.state.selectedReport.created).format('DD.MM.yyyy')
                 : null}{' '}
             </div>
           </div>


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [x] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [x] Check the commit's or even all commits' message 
- [x] Check if your code additions will fail linting checks
- [x] Remember: Add issue description to [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the **ID of the Issue** associated with this PR
- [x] Documentation: Have a look at the [PP365 User manual](https://puzzlepart.github.io/prosjektportalen-manual/) and consider the need for updates to be made. Updates can be done directly into the 'Kladd' branch or by providing information to test team for implementation.

### Description

Changing the header on projectstatus report to show published date, instead of created date. 

### How to test

- [ ] 1. Create new report on day x
- [ ] 2. Publish the report on day x+1
- [ ] 3. See the date chaning when published. 


### Update of documentation
- [x] Check if user manual requires update
  - [x] No
  - [ ] Yes
    - [ ] Update user manual


### Relevant issues (if applicable)
#654 

💔Thank you!
