### PR TITLE
Dynamic welcomepage and ProjectPhases webpart improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Every change is marked with issue ID.
 - Added 'Vis alle egenskaper' button with panel to ProjectInformation webpart #650
 - Added support for {site} token in Planner-tasks #646
 
+### Changed
+
+- If there are no items in the list "Fasesjekkeliste". "Gå til fasesjekklisten" button won't show and the empty dialog when changing phase is skipped #660
+
 ### Fixed
 
 - Fixed bug where ProjectTimeline would not load properly #661

--- a/SharePointFramework/ProjectExtensions/src/projectSetup/tasks/PlannerConfiguration/index.ts
+++ b/SharePointFramework/ProjectExtensions/src/projectSetup/tasks/PlannerConfiguration/index.ts
@@ -35,7 +35,7 @@ export class PlannerConfiguration extends BaseTask {
    * @param pageContext - Page context
    */
   private replaceUrlTokens(str: string, pageContext: PageContext) {
-    const siteAbsoluteUrl = pageContext.site.absoluteUrl.split('%').join('%25').split('.').join('%2E').split(':').join('%3A');
+    const siteAbsoluteUrl = pageContext.site.absoluteUrl.split('%').join('%25').split('.').join('%2E').split(':').join('%3A')
     return str.replace('{site}', siteAbsoluteUrl)
   }
 

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/ChangePhaseDialog/ChangePhaseDialog.module.scss
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/ChangePhaseDialog/ChangePhaseDialog.module.scss
@@ -3,7 +3,7 @@
   max-width: 550px;
   font-weight: 300;
 
-  .useDynamicHomepageContent {
+  .dynamicHomepageContent {
     font-weight: 300;
   }
 }

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/ChangePhaseDialog/ChangePhaseDialog.module.scss
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/ChangePhaseDialog/ChangePhaseDialog.module.scss
@@ -1,17 +1,9 @@
 .root {
   width: 550px;
   max-width: 550px;
+  font-weight: 300;
 
   .useDynamicHomepageContent {
-    display: flex;
-    margin-top: 10px;
     font-weight: 300;
-
-    .descriptionIcon {
-      vertical-align: middle;
-      padding-top: 15px;
-      padding-right: 10px;
-      padding-left: 10px;
-    }
   }
 }

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/ChangePhaseDialog/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/ChangePhaseDialog/index.tsx
@@ -6,6 +6,7 @@ import { IProjectPhaseChecklistItem } from 'pp365-shared/lib/models'
 import * as strings from 'ProjectWebPartsStrings'
 import React, { useContext, useEffect, useReducer } from 'react'
 import * as ReactMarkdown from 'react-markdown/with-html'
+import _ from 'underscore'
 import { ProjectPhasesContext } from '../context'
 import { DISMISS_CHANGE_PHASE_DIALOG } from '../reducer'
 import { Body } from './Body'
@@ -19,8 +20,9 @@ export const ChangePhaseDialog = () => {
   const context = useContext(ProjectPhasesContext)
   if (!context.state.confirmPhase) return null
   const [state, dispatch] = useReducer(reducer, {})
-  const phaseSitePage = context.state.data.phaseSitePages && context.state.data.phaseSitePages
-    .filter((phaseSitePage) => phaseSitePage.title === context.state.confirmPhase.name)[0];
+  const phaseSitePages = context.state.data.phaseSitePages
+  const confirmPhaseName = context.state.confirmPhase.name
+  const phaseSitePage = phaseSitePages && _.find(phaseSitePages, (p) => p.title === confirmPhaseName)
 
   useEffect(() => dispatch(INIT({ context })), [])
 
@@ -50,17 +52,17 @@ export const ChangePhaseDialog = () => {
         title={strings.ChangePhaseText}
         subText={
           state.view === View.Confirm &&
-          format(strings.ConfirmChangePhase, context.state.confirmPhase.name)
+          format(strings.ConfirmChangePhase, confirmPhaseName)
         }
         dialogContentProps={{ type: DialogType.largeHeader }}
         modalProps={{ isDarkOverlay: true, isBlocking: false }}
         onDismiss={() => context.dispatch(DISMISS_CHANGE_PHASE_DIALOG())}>
         {state.view === View.Confirm && context.props.useDynamicHomepage &&
-          <div className={styles.useDynamicHomepageContent} >
+          <div className={styles.dynamicHomepageContent} >
             <MessageBar messageBarType={phaseSitePage ? MessageBarType.info : MessageBarType.warning}>
               <ReactMarkdown escapeHtml={false} source={phaseSitePage
                 ? format(strings.PhaseSitePageFoundDescription, phaseSitePage && phaseSitePage.fileLeafRef)
-                : format(strings.PhaseSitePageNotFoundDescription, context.state.confirmPhase.name)} />
+                : format(strings.PhaseSitePageNotFoundDescription, confirmPhaseName)} />
             </MessageBar>
           </div>
         }

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/ChangePhaseDialog/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/ChangePhaseDialog/index.tsx
@@ -15,11 +15,12 @@ import { Footer } from './Footer'
 import reducer, { CHECKLIST_ITEM_UPDATED, INIT } from './reducer'
 import { View } from './Views'
 
-export const ChangePhaseDialog = ({ data }) => {
+export const ChangePhaseDialog = () => {
   const context = useContext(ProjectPhasesContext)
   if (!context.state.confirmPhase) return null
   const [state, dispatch] = useReducer(reducer, {})
-  const phaseSitePage = data.phaseSitePages.filter((phaseSitePage) => phaseSitePage.title === context.state.confirmPhase.name)[0];
+  const phaseSitePage = context.state.data.phaseSitePages && context.state.data.phaseSitePages
+    .filter((phaseSitePage) => phaseSitePage.title === context.state.confirmPhase.name)[0];
 
   useEffect(() => dispatch(INIT({ context })), [])
 

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/ChangePhaseDialog/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/ChangePhaseDialog/index.tsx
@@ -1,10 +1,11 @@
 import SPDataAdapter from 'data'
-import { Icon } from 'office-ui-fabric-react'
+import { MessageBar, MessageBarType } from 'office-ui-fabric-react'
 import Dialog, { DialogType } from 'office-ui-fabric-react/lib/Dialog'
 import { format } from 'office-ui-fabric-react/lib/Utilities'
 import { IProjectPhaseChecklistItem } from 'pp365-shared/lib/models'
 import * as strings from 'ProjectWebPartsStrings'
 import React, { useContext, useEffect, useReducer } from 'react'
+import * as ReactMarkdown from 'react-markdown/with-html'
 import { ProjectPhasesContext } from '../context'
 import { DISMISS_CHANGE_PHASE_DIALOG } from '../reducer'
 import { Body } from './Body'
@@ -14,10 +15,11 @@ import { Footer } from './Footer'
 import reducer, { CHECKLIST_ITEM_UPDATED, INIT } from './reducer'
 import { View } from './Views'
 
-export const ChangePhaseDialog = (phaseSitePages?: any) => {
+export const ChangePhaseDialog = ({ data }) => {
   const context = useContext(ProjectPhasesContext)
   if (!context.state.confirmPhase) return null
   const [state, dispatch] = useReducer(reducer, {})
+  const phaseSitePage = data.phaseSitePages.filter((phaseSitePage) => phaseSitePage.title === context.state.confirmPhase.name)[0];
 
   useEffect(() => dispatch(INIT({ context })), [])
 
@@ -39,8 +41,6 @@ export const ChangePhaseDialog = (phaseSitePages?: any) => {
     dispatch(CHECKLIST_ITEM_UPDATED({ properties }))
   }
 
-  console.log(phaseSitePages)
-
   return (
     <ChangePhaseDialogContext.Provider value={{ state, dispatch, nextChecklistItem }}>
       <Dialog
@@ -55,9 +55,12 @@ export const ChangePhaseDialog = (phaseSitePages?: any) => {
         modalProps={{ isDarkOverlay: true, isBlocking: false }}
         onDismiss={() => context.dispatch(DISMISS_CHANGE_PHASE_DIALOG())}>
         {state.view === View.Confirm && context.props.useDynamicHomepage &&
-          <div className={styles.useDynamicHomepageContent}>
-            <Icon iconName={'Info'} className={styles.descriptionIcon} />
-            {strings.UseDynamicHomepageChangePhaseDescription}phaseSitePages
+          <div className={styles.useDynamicHomepageContent} >
+            <MessageBar messageBarType={phaseSitePage ? MessageBarType.info : MessageBarType.warning}>
+              <ReactMarkdown escapeHtml={false} source={phaseSitePage
+                ? format(strings.PhaseSitePageFoundDescription, phaseSitePage && phaseSitePage.fileLeafRef)
+                : format(strings.PhaseSitePageNotFoundDescription, context.state.confirmPhase.name)} />
+            </MessageBar>
           </div>
         }
         <Body />

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/ChangePhaseDialog/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/ChangePhaseDialog/index.tsx
@@ -14,7 +14,7 @@ import { Footer } from './Footer'
 import reducer, { CHECKLIST_ITEM_UPDATED, INIT } from './reducer'
 import { View } from './Views'
 
-export const ChangePhaseDialog = () => {
+export const ChangePhaseDialog = (phaseSitePages?: any) => {
   const context = useContext(ProjectPhasesContext)
   if (!context.state.confirmPhase) return null
   const [state, dispatch] = useReducer(reducer, {})
@@ -39,6 +39,8 @@ export const ChangePhaseDialog = () => {
     dispatch(CHECKLIST_ITEM_UPDATED({ properties }))
   }
 
+  console.log(phaseSitePages)
+
   return (
     <ChangePhaseDialogContext.Provider value={{ state, dispatch, nextChecklistItem }}>
       <Dialog
@@ -55,7 +57,7 @@ export const ChangePhaseDialog = () => {
         {state.view === View.Confirm && context.props.useDynamicHomepage &&
           <div className={styles.useDynamicHomepageContent}>
             <Icon iconName={'Info'} className={styles.descriptionIcon} />
-            {strings.UseDynamicHomepageChangePhaseDescription}
+            {strings.UseDynamicHomepageChangePhaseDescription}phaseSitePages
           </div>
         }
         <Body />

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/ChangePhaseDialog/reducer.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/ChangePhaseDialog/reducer.ts
@@ -19,10 +19,15 @@ export default createReducer<IChangePhaseDialogState>(
     [INIT.type]: (state, { payload }: ReturnType<typeof INIT>) => {
       if (payload.context.state.phase) {
         const checklistItems = payload.context.state.phase.checklistData?.items || []
+        const items = Object.keys(payload.context.state.phase.checklistData.items)
         const openCheclistItems = checklistItems.filter(
           (item) => item.GtChecklistStatus === strings.StatusOpen
         )
-        state.view = isEmpty(openCheclistItems) ? View.Summary : View.Initial
+        state.view = isEmpty(openCheclistItems)
+          ? isEmpty(items)
+            ? View.Confirm
+            : View.Summary
+          : View.Initial
         state.checklistItems = checklistItems
         state.currentIdx = getNextIndex(checklistItems)
       } else {

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/ChangePhaseDialog/reducer.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/ChangePhaseDialog/reducer.ts
@@ -17,19 +17,20 @@ export default createReducer<IChangePhaseDialogState>(
   {},
   {
     [INIT.type]: (state, { payload }: ReturnType<typeof INIT>) => {
+      
       if (payload.context.state.phase) {
-        const checklistItems = payload.context.state.phase.checklistData?.items || []
         const items = Object.keys(payload.context.state.phase.checklistData.items)
-        const openCheclistItems = checklistItems.filter(
-          (item) => item.GtChecklistStatus === strings.StatusOpen
-        )
-        state.view = isEmpty(openCheclistItems)
-          ? isEmpty(items)
-            ? View.Confirm
-            : View.Summary
-          : View.Initial
-        state.checklistItems = checklistItems
-        state.currentIdx = getNextIndex(checklistItems)
+        if (!isEmpty(items)) {
+          const checklistItems = payload.context.state.phase.checklistData?.items || []
+          const openCheclistItems = checklistItems.filter(
+            (item) => item.GtChecklistStatus === strings.StatusOpen
+          )
+          state.view = isEmpty(openCheclistItems) ? View.Summary : View.Initial
+          state.checklistItems = checklistItems
+          state.currentIdx = getNextIndex(checklistItems)
+        } else {
+          state.view = View.Confirm
+        }
       } else {
         state.view = View.Confirm
       }

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/ProjectPhase/ProjectPhaseCallout/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/ProjectPhase/ProjectPhaseCallout/index.tsx
@@ -12,7 +12,7 @@ export const ProjectPhaseCallout = ({ phase, target }: IProjectPhaseCalloutProps
   if (!target) return null
   const context = useContext(ProjectPhasesContext)
   const stats = Object.keys(phase.checklistData.stats)
-
+  const items = Object.keys(phase.checklistData.items)
   return (
     <Callout
       gapSpace={5}
@@ -40,13 +40,13 @@ export const ProjectPhaseCallout = ({ phase, target }: IProjectPhaseCalloutProps
               })}
             </div>
             <div className={styles.actions}>
-              <ActionButton
+              {!isEmpty(items) && <ActionButton
                 href={phase.getFilteredPhaseChecklistViewUrl(
                   `${context.props.webUrl}/${strings.PhaseChecklistViewUrl}`
                 )}
                 text={strings.PhaseChecklistLinkText}
                 iconProps={{ iconName: 'CheckList' }}
-              />
+              />}
               <ActionButton
                 onClick={() => context.dispatch(CHANGE_PHASE())}
                 text={strings.ChangePhaseText}

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/changePhase.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/changePhase.ts
@@ -10,17 +10,17 @@ import { IPhaseSitePageModel, IProjectPhasesProps } from './types'
  * @param {ProjectPhaseModel} phase Phase
  * @param {string} phaseTextField Phase TextField
  * @param {IProjectPhasesProps} props IProjectPhasesProps props
- * @param {IPhaseSitePageModel} phaseSitePages Phase SitePages
+ * @param {IPhaseSitePageModel[]} phaseSitePages Phase SitePages
  */
 export const changePhase = async (
   phase: ProjectPhaseModel,
   phaseTextField: string,
   props: IProjectPhasesProps,
-  phaseSitePages?: IPhaseSitePageModel,
+  phaseSitePages?: IPhaseSitePageModel[],
 ) => {
   try {
     await SPDataAdapter.project.updatePhase(phase, phaseTextField)
-    if (props.useDynamicHomepage) await changeWelcomePage(phase.name, props.webPartContext.pageContext.web.absoluteUrl)
+    if (props.useDynamicHomepage) await changeWelcomePage(phase.name, props.webPartContext.pageContext.web.absoluteUrl, phaseSitePages)
     await modifyCurrentPhaseView(phase.name, props.currentPhaseViewName)
     sessionStorage.clear()
   } catch (error) {

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/changePhase.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/changePhase.ts
@@ -2,19 +2,21 @@ import SPDataAdapter from 'data'
 import { ProjectPhaseModel } from 'pp365-shared/lib/models'
 import { changeWelcomePage } from './changeWelcomePage'
 import { modifyCurrentPhaseView } from './modifyCurrentPhaseView'
-import { IProjectPhasesProps } from './types'
+import { IPhaseSitePageModel, IProjectPhasesProps } from './types'
 
 /**
  * Change phase
  *
  * @param {ProjectPhaseModel} phase Phase
- * @param {string} currentPhaseViewName Current phase view name
+ * @param {string} phaseTextField Phase TextField
  * @param {IProjectPhasesProps} props IProjectPhasesProps props
+ * @param {IPhaseSitePageModel} phaseSitePages Phase SitePages
  */
 export const changePhase = async (
   phase: ProjectPhaseModel,
   phaseTextField: string,
   props: IProjectPhasesProps,
+  phaseSitePages?: IPhaseSitePageModel,
 ) => {
   try {
     await SPDataAdapter.project.updatePhase(phase, phaseTextField)

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/changeWelcomePage.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/changeWelcomePage.ts
@@ -15,10 +15,13 @@ export const changeWelcomePage = async (
 ) => {
   try {
     const phaseSitePage = phaseSitePages.filter((phaseSitePage) => phaseSitePage.title === phaseName)[0]
-    const spfxJsomContext = await initSpfxJsom(absoluteUrl)
-    spfxJsomContext.jsomContext.web['get_rootFolder']()['set_welcomePage'](`SitePages/${phaseSitePage.fileLeafRef}`)
-    spfxJsomContext.jsomContext.web.update()
-    await ExecuteJsomQuery(spfxJsomContext.jsomContext)
+    if (phaseSitePage && phaseSitePage.fileLeafRef) {
+      const spfxJsomContext = await initSpfxJsom(absoluteUrl)
+      spfxJsomContext.jsomContext.web['get_rootFolder']()['set_welcomePage'](`SitePages/${phaseSitePage.fileLeafRef}`)
+      spfxJsomContext.jsomContext.web.update()
+      await ExecuteJsomQuery(spfxJsomContext.jsomContext)
+    }
+
   } catch (error) {
     throw error
   }

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/changeWelcomePage.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/changeWelcomePage.ts
@@ -14,10 +14,7 @@ export const changeWelcomePage = async (
   phaseSitePages?: IPhaseSitePageModel[],
 ) => {
   try {
-    // filter phaseSitePages on phaseName
     const phaseSitePage = phaseSitePages.filter((phaseSitePage) => phaseSitePage.title === phaseName)[0]
-    console.log(phaseSitePage)
-
     const spfxJsomContext = await initSpfxJsom(absoluteUrl)
     spfxJsomContext.jsomContext.web['get_rootFolder']()['set_welcomePage'](`SitePages/${phaseSitePage.fileLeafRef}`)
     spfxJsomContext.jsomContext.web.update()

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/changeWelcomePage.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/changeWelcomePage.ts
@@ -1,14 +1,17 @@
 import initSpfxJsom, { ExecuteJsomQuery } from 'spfx-jsom'
+import { IPhaseSitePageModel } from './types'
 
 /**
  * Change phase
  *
  * @param {string} phaseName
  * @param {string} absoluteUrl absoluteurl
+ * @param {IPhaseSitePageModel} phaseSitePages Phase SitePages
  */
 export const changeWelcomePage = async (
   phaseName: string,
-  absoluteUrl: string
+  absoluteUrl: string,
+  phaseSitePages?: IPhaseSitePageModel,
 ) => {
   try {
     const spfxJsomContext = await initSpfxJsom(absoluteUrl)

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/changeWelcomePage.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/changeWelcomePage.ts
@@ -1,4 +1,5 @@
 import initSpfxJsom, { ExecuteJsomQuery } from 'spfx-jsom'
+import _ from 'underscore'
 import { IPhaseSitePageModel } from './types'
 
 /**
@@ -14,7 +15,7 @@ export const changeWelcomePage = async (
   phaseSitePages?: IPhaseSitePageModel[],
 ) => {
   try {
-    const phaseSitePage = phaseSitePages.filter((phaseSitePage) => phaseSitePage.title === phaseName)[0]
+    const phaseSitePage = phaseSitePages && _.find(phaseSitePages, (p) => p.title === phaseName)
     if (phaseSitePage && phaseSitePage.fileLeafRef) {
       const spfxJsomContext = await initSpfxJsom(absoluteUrl)
       spfxJsomContext.jsomContext.web['get_rootFolder']()['set_welcomePage'](`SitePages/${phaseSitePage.fileLeafRef}`)

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/changeWelcomePage.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/changeWelcomePage.ts
@@ -6,16 +6,20 @@ import { IPhaseSitePageModel } from './types'
  *
  * @param {string} phaseName
  * @param {string} absoluteUrl absoluteurl
- * @param {IPhaseSitePageModel} phaseSitePages Phase SitePages
+ * @param {IPhaseSitePageModel[]} phaseSitePages Phase SitePages
  */
 export const changeWelcomePage = async (
   phaseName: string,
   absoluteUrl: string,
-  phaseSitePages?: IPhaseSitePageModel,
+  phaseSitePages?: IPhaseSitePageModel[],
 ) => {
   try {
+    // filter phaseSitePages on phaseName
+    const phaseSitePage = phaseSitePages.filter((phaseSitePage) => phaseSitePage.title === phaseName)[0]
+    console.log(phaseSitePage)
+
     const spfxJsomContext = await initSpfxJsom(absoluteUrl)
-    spfxJsomContext.jsomContext.web['get_rootFolder']()['set_welcomePage'](`SitePages/${phaseName}.aspx`)
+    spfxJsomContext.jsomContext.web['get_rootFolder']()['set_welcomePage'](`SitePages/${phaseSitePage.fileLeafRef}`)
     spfxJsomContext.jsomContext.web.update()
     await ExecuteJsomQuery(spfxJsomContext.jsomContext)
   } catch (error) {

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/fetchData.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/fetchData.ts
@@ -11,7 +11,7 @@ import { getPhaseSitePages } from './getPhaseSitePages'
  */
 export async function fetchData(props: IProjectPhasesProps): Promise<IProjectPhasesData> {
   const { phaseField } = props
-  let phaseSitePages;
+  let phaseSitePages
 
   try {
     const [phaseFieldCtx, checklistData] = await Promise.all([
@@ -24,7 +24,7 @@ export async function fetchData(props: IProjectPhasesProps): Promise<IProjectPha
     ])
 
     if (props.useDynamicHomepage) {
-      phaseSitePages = await getPhaseSitePages(phases);
+      phaseSitePages = await getPhaseSitePages(phases)
     }
 
     Logger.log({

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/fetchData.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/fetchData.ts
@@ -25,7 +25,6 @@ export async function fetchData(props: IProjectPhasesProps): Promise<IProjectPha
 
     if (props.useDynamicHomepage) {
       phaseSitePages = await getPhaseSitePages(phases);
-      console.log("fetchData", phaseSitePages)
     }
 
     Logger.log({
@@ -33,11 +32,6 @@ export async function fetchData(props: IProjectPhasesProps): Promise<IProjectPha
       level: LogLevel.Info
     })
     const [currentPhase] = phases.filter((p) => p.name === currentPhaseName)
-
-    console.log(props)
-
-    console.log(phaseSitePages)
-
 
     return {
       currentPhase,

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/fetchData.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/fetchData.ts
@@ -2,6 +2,7 @@ import { Logger, LogLevel } from '@pnp/logging'
 import SPDataAdapter from 'data'
 import * as strings from 'ProjectWebPartsStrings'
 import { IProjectPhasesData, IProjectPhasesProps } from '.'
+import { getPhaseSitePages } from './getPhaseSitePages'
 
 /***
  * Fetch phase terms
@@ -10,6 +11,8 @@ import { IProjectPhasesData, IProjectPhasesProps } from '.'
  */
 export async function fetchData(props: IProjectPhasesProps): Promise<IProjectPhasesData> {
   const { phaseField } = props
+  let phaseSitePages;
+
   try {
     const [phaseFieldCtx, checklistData] = await Promise.all([
       SPDataAdapter.getTermFieldContext(phaseField),
@@ -20,15 +23,27 @@ export async function fetchData(props: IProjectPhasesProps): Promise<IProjectPha
       SPDataAdapter.project.getCurrentPhaseName(phaseFieldCtx.fieldName)
     ])
 
+    if (props.useDynamicHomepage) {
+      phaseSitePages = await getPhaseSitePages(phases);
+      console.log("fetchData", phaseSitePages)
+    }
+
     Logger.log({
       message: '(ProjectPhases) _fetchData: Successfully fetch phases',
       level: LogLevel.Info
     })
     const [currentPhase] = phases.filter((p) => p.name === currentPhaseName)
+
+    console.log(props)
+
+    console.log(phaseSitePages)
+
+
     return {
       currentPhase,
       phases,
-      phaseTextField: phaseFieldCtx.phaseTextField
+      phaseTextField: phaseFieldCtx.phaseTextField,
+      phaseSitePages
     }
   } catch (error) {
     throw new Error()

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/getPhaseSitePages.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/getPhaseSitePages.ts
@@ -1,6 +1,6 @@
 import { ProjectPhaseModel } from 'pp365-shared/lib/models'
-import { sp } from "@pnp/sp";
-import { IPhaseSitePageModel } from './types';
+import { sp } from '@pnp/sp'
+import { IPhaseSitePageModel } from './types'
 
 /**
  * Change phase
@@ -11,15 +11,15 @@ export const getPhaseSitePages = async (
   phases: ProjectPhaseModel[]
 ) => {
   try {
-    let sitepages = await sp.web.lists.getByTitle('Områdesider').items.select("Id, Title, FileRef, EncodedAbsUrl, FileLeafRef").get()
-    sitepages = sitepages.filter(sitepage => {
-      return phases.some(phase => phase.name === sitepage.Title)
+    let sitePages = await sp.web.lists.getByTitle('Områdesider').items.select('Id, Title, FileRef, EncodedAbsUrl, FileLeafRef').get()
+    sitePages = sitePages.filter((p) => {
+      return phases.some(phase => phase.name === p.Title)
     })
 
-    const phaseSitePages: IPhaseSitePageModel[] = sitepages.map((item) => ({
-      id: item.Id,
-      title: item.Title,
-      fileLeafRef: item.FileLeafRef
+    const phaseSitePages: IPhaseSitePageModel[] = sitePages.map((p) => ({
+      id: p.Id,
+      title: p.Title,
+      fileLeafRef: p.FileLeafRef
     }))
 
     return phaseSitePages

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/getPhaseSitePages.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/getPhaseSitePages.ts
@@ -12,8 +12,6 @@ export const getPhaseSitePages = async (
 ) => {
   try {
     let sitepages = await sp.web.lists.getByTitle('Områdesider').items.select("Id, Title, FileRef, EncodedAbsUrl, FileLeafRef").get()
-    console.log("sitepages", sitepages)
-
     sitepages = sitepages.filter(sitepage => {
       return phases.some(phase => phase.name === sitepage.Title)
     })
@@ -23,8 +21,6 @@ export const getPhaseSitePages = async (
       title: item.Title,
       fileLeafRef: item.FileLeafRef
     }))
-
-    console.log("getPhaseSitePages", phaseSitePages)
 
     return phaseSitePages
     

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/getPhaseSitePages.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/getPhaseSitePages.ts
@@ -1,0 +1,34 @@
+import { ProjectPhaseModel } from 'pp365-shared/lib/models'
+import { sp } from "@pnp/sp";
+import { IPhaseSitePageModel } from './types';
+
+/**
+ * Change phase
+ *
+ * @param {ProjectPhaseModel} phases
+ */
+export const getPhaseSitePages = async (
+  phases: ProjectPhaseModel[]
+) => {
+  try {
+    let sitepages = await sp.web.lists.getByTitle('Områdesider').items.select("Id, Title, FileRef, EncodedAbsUrl, FileLeafRef").get()
+    console.log("sitepages", sitepages)
+
+    sitepages = sitepages.filter(sitepage => {
+      return phases.some(phase => phase.name === sitepage.Title)
+    })
+
+    const phaseSitePages: IPhaseSitePageModel[] = sitepages.map((item) => ({
+      id: item.Id,
+      title: item.Title,
+      fileLeafRef: item.FileLeafRef
+    }))
+
+    console.log("getPhaseSitePages", phaseSitePages)
+
+    return phaseSitePages
+    
+  } catch (error) {
+    throw error
+  }
+}

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/index.tsx
@@ -83,7 +83,7 @@ export const ProjectPhases = (props: IProjectPhasesProps) => {
                 ))}
             </ul>
             <ProjectPhaseCallout {...(state.callout || {})} />
-            <ChangePhaseDialog phaseSitePages={state.data.phaseSitePages} />
+            <ChangePhaseDialog data={state.data} />
           </Shimmer>
         </ProjectPhasesContext.Provider>
       </div>

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/index.tsx
@@ -83,7 +83,7 @@ export const ProjectPhases = (props: IProjectPhasesProps) => {
                 ))}
             </ul>
             <ProjectPhaseCallout {...(state.callout || {})} />
-            <ChangePhaseDialog />
+            <ChangePhaseDialog phaseSitePages={state.data.phaseSitePages} />
           </Shimmer>
         </ProjectPhasesContext.Provider>
       </div>

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/index.tsx
@@ -46,7 +46,7 @@ export const ProjectPhases = (props: IProjectPhasesProps) => {
    */
   const onChangePhase = async () => {
     dispatch(INIT_CHANGE_PHASE())
-    await changePhase(state.confirmPhase, state.data.phaseTextField, props)
+    await changePhase(state.confirmPhase, state.data.phaseTextField, props, state.data.phaseSitePages)
     dispatch(SET_PHASE({ phase: state.confirmPhase }))
     if (
       props.syncPropertiesAfterPhaseChange === undefined ||

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/index.tsx
@@ -83,7 +83,7 @@ export const ProjectPhases = (props: IProjectPhasesProps) => {
                 ))}
             </ul>
             <ProjectPhaseCallout {...(state.callout || {})} />
-            <ChangePhaseDialog data={state.data} />
+            <ChangePhaseDialog />
           </Shimmer>
         </ProjectPhasesContext.Provider>
       </div>

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/types.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/types.ts
@@ -80,4 +80,26 @@ export interface IProjectPhasesData {
    * Phase text field name
    */
   phaseTextField?: string
+
+  /**
+   * Phase SitePages
+   */
+  phaseSitePages?: IPhaseSitePageModel
+}
+
+export interface IPhaseSitePageModel {
+  /**
+   * Id of SitePage
+   */
+  id?: number;
+
+  /**
+   * Title of SitePage
+   */
+  title?: string
+
+  /**
+   * FileLeafRef of SitePage
+   */
+  fileLeafRef?: string
 }

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/types.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/types.ts
@@ -82,24 +82,24 @@ export interface IProjectPhasesData {
   phaseTextField?: string
 
   /**
-   * Phase SitePages
+   * Phase site pages
    */
   phaseSitePages?: IPhaseSitePageModel[]
 }
 
 export interface IPhaseSitePageModel {
   /**
-   * Id of SitePage
+   * Id of phase site page
    */
   id?: number;
 
   /**
-   * Title of SitePage
+   * Title of phase site page
    */
   title?: string
 
   /**
-   * FileLeafRef of SitePage
+   * FileLeafRef of phase site page
    */
   fileLeafRef?: string
 }

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/types.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/types.ts
@@ -84,7 +84,7 @@ export interface IProjectPhasesData {
   /**
    * Phase SitePages
    */
-  phaseSitePages?: IPhaseSitePageModel
+  phaseSitePages?: IPhaseSitePageModel[]
 }
 
 export interface IPhaseSitePageModel {

--- a/SharePointFramework/ProjectWebParts/src/loc/en-us.js
+++ b/SharePointFramework/ProjectWebParts/src/loc/en-us.js
@@ -143,6 +143,7 @@ define([], function () {
     UseDynamicHomepageFieldLabel: 'Bruk dynamisk hjemmeside',
     UseDynamicHomepageCalloutText: 'Her kan du velge om fasevelgeren skal være dynamisk og bruke egne sider for hver fase. Det krever at det er opprettet sider for hver fase på forhånd. Navnene på sidene må være identiske med navnene på fasene.',
     AdvancedGroupName: 'Avansert',
-    UseDynamicHomepageChangePhaseDescription: 'Endring til denne fasen vil også medføre endring av forside til prosjektet, dersom side er opprettet for fasen du endrer til.'
+    PhaseSitePageFoundDescription: 'Endring til denne fasen vil også medføre endring av forside til prosjektet.<br /><br />Side for fase funnet: \'{0}\'. Denne siden vil bli brukt som forside for prosjektet. Trykk \'Ja\' for å fortsette.',
+    PhaseSitePageNotFoundDescription: 'Dynamisk forside er aktivert.<br /><br />Side for \'{0}\' ble ikke funnet, vennligst opprett. Ved trykk på \'Ja\' vil ikke forside endres.',
   }
 })

--- a/SharePointFramework/ProjectWebParts/src/loc/mystrings.d.ts
+++ b/SharePointFramework/ProjectWebParts/src/loc/mystrings.d.ts
@@ -142,7 +142,8 @@ declare interface IProjectWebPartsStrings {
   UseDynamicHomepageFieldLabel: string;
   UseDynamicHomepageCalloutText: string;
   AdvancedGroupName: string;
-  UseDynamicHomepageChangePhaseDescription: string;
+  PhaseSitePageFoundDescription: string;
+  PhaseSitePageNotFoundDescription: string;
 }
 
 declare module 'ProjectWebPartsStrings' {

--- a/SharePointFramework/ProjectWebParts/src/loc/nb-no.js
+++ b/SharePointFramework/ProjectWebParts/src/loc/nb-no.js
@@ -144,6 +144,7 @@ define([], function () {
     UseDynamicHomepageFieldLabel: 'Bruk dynamisk hjemmeside',
     UseDynamicHomepageCalloutText: 'Her kan du velge om fasevelgeren skal være dynamisk og bruke egne sider for hver fase. Det krever at det er opprettet sider for hver fase på forhånd. Navnene på sidene må være identiske med navnene på fasene.',
     AdvancedGroupName: 'Avansert',
-    UseDynamicHomepageChangePhaseDescription: 'Endring til denne fasen vil også medføre endring av forside til prosjektet, dersom side er opprettet for fasen du endrer til.'
+    PhaseSitePageFoundDescription: 'Endring til denne fasen vil også medføre endring av forside til prosjektet.<br /><br />Side for fase funnet: \'{0}\'. Denne siden vil bli brukt som forside for prosjektet. Trykk \'Ja\' for å fortsette.',
+    PhaseSitePageNotFoundDescription: 'Dynamisk forside er aktivert.<br /><br />Side for \'{0}\' ble ikke funnet, vennligst opprett. Ved trykk på \'Ja\' vil ikke forside endres.',
   }
 })


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [X] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [X] Check the commit's or even all commits' message 
- [X] Check if your code additions will fail linting checks
- [X] Remember: Add issue description to [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the **ID of the Issue** associated with this PR
- [X] Documentation: Have a look at the [PP365 User manual](https://puzzlepart.github.io/prosjektportalen-manual/) and consider the need for updates to be made. Updates can be done directly into the 'Kladd' branch or by providing information to test team for implementation.

### Description

#### Dynamic welcomepage improvements

Description from #647 for context below.

> When changing the phase in a project, if enabled, also change project's WelcomePage. As long as a SitePage exists with the same name as the phase that is being selected for change.
> 
> Added information if dynamic WelcomePage is enabled. This is to give the user an indication that a SitePage exists with the phase the user has selected and that the WelcomePage will change when pressing "Yes" in the change phase dialog.

🐛 Bug where changing phase with Dynamic WelcomePage enabled where a SitePages name (FileLeafRef) didn't 100% match the phasename has been fixed. Setting of WelcomePage filters SitePages based on the currently selected phase == Sitepage title and finds the name of that SitePage, uses this when WelcomePage is set.

Additional information in ChangePhase dialog has been added, see image below (first: old, second: new)
![image](https://user-images.githubusercontent.com/28678468/158573030-a0b34949-6f65-4a34-b96f-df95a26613bb.png)![image](https://user-images.githubusercontent.com/28678468/158573084-c93ea20c-1ad3-435d-bf1a-826767c86e0b.png)

As shown in the second image, the dialog now informs the use if there is a SitePage for the phase and what the SitePage's name is.

If there is not a SitePage for the phase this will be shown (see image below).
![image](https://user-images.githubusercontent.com/28678468/158573308-1541dcd4-dffa-4160-82be-2f7925cd4963.png)

#### ProjectPhases webpart improvements

Removed "Gå til fasesjekkliste" action if the phase checklist is empty. (see image below)
![image](https://user-images.githubusercontent.com/28678468/158573750-e0733eae-1a57-4eaf-b39e-708692f48092.png)

Additionally skips the empty Summary view if there are no phase checklist items. If no items are found it skips to the Confirm view of the ChangePhase dialog.

### How to test

- [ ] 1. Create new project with sitepages for each phase or use the test prosjekt below
- [ ] 2. Enable dynamic welcomepage/homepage
- [ ] 3. Change phases
- [ ] 4. After phase change the welcomepage will be set to the one representing the selected phase
- [ ] 5. Test changing the name of a SitePage but with correct title to see that welcomephase is still being set
 
Test project with sitepages for each phase: https://puzzlepart.sharepoint.com/sites/Nordre-follo

- [ ] 6. Test normal phase changing dialog with or without phase checklist items
- [ ] 7. Check that "Gå til fasesjekkliste" is not shown and that it skips the Summary dialog view if no phase checklist items


### Relevant issues (if applicable)

#643 #660
