### PR TITLE
Null catch when converting older projects to parent project

### DIFF
--- a/SharePointFramework/ProjectWebParts/src/loc/en-us.js
+++ b/SharePointFramework/ProjectWebParts/src/loc/en-us.js
@@ -145,6 +145,7 @@ define([], function () {
     AdvancedGroupName: 'Avansert',
     PhaseSitePageFoundDescription: 'Endring til denne fasen vil også medføre endring av forside til prosjektet.<br /><br />Side for fase funnet: \'{0}\'. Denne siden vil bli brukt som forside for prosjektet. Trykk \'Ja\' for å fortsette.',
     PhaseSitePageNotFoundDescription: 'Dynamisk forside er aktivert.<br /><br />Side for \'{0}\' ble ikke funnet, vennligst opprett. Ved trykk på \'Ja\' vil ikke forside endres.',
-        AdminPageLinkLabel: 'Path to Admin page'
+    AdminPageLinkLabel: 'Path to Admin page',
+    DefaultAdminPageLink: "Admin.aspx"
     }
 })

--- a/SharePointFramework/ProjectWebParts/src/loc/mystrings.d.ts
+++ b/SharePointFramework/ProjectWebParts/src/loc/mystrings.d.ts
@@ -148,6 +148,7 @@ declare interface IProjectWebPartsStrings {
   CreateParentProjectLabel: string;
   ChildProjectAdminLabel: string;
   AdminPageLinkLabel: string;
+  DefaultAdminPageLink: string;
 }
 
 declare module 'ProjectWebPartsStrings' {

--- a/SharePointFramework/ProjectWebParts/src/loc/nb-no.js
+++ b/SharePointFramework/ProjectWebParts/src/loc/nb-no.js
@@ -151,6 +151,7 @@ define([], function() {
         ChildProjectAdminLabel: 'Administrer underområder',
         PhaseSitePageFoundDescription: 'Endring til denne fasen vil også medføre endring av forside til prosjektet.<br /><br />Side for fase funnet: \'{0}\'. Denne siden vil bli brukt som forside for prosjektet. Trykk \'Ja\' for å fortsette.',
         PhaseSitePageNotFoundDescription: 'Dynamisk forside er aktivert.<br /><br />Side for \'{0}\' ble ikke funnet, vennligst opprett. Ved trykk på \'Ja\' vil ikke forside endres.',
+        DefaultAdminPageLink: "Admin.aspx"
 
     }
 })

--- a/SharePointFramework/ProjectWebParts/src/webparts/projectInformation/index.ts
+++ b/SharePointFramework/ProjectWebParts/src/webparts/projectInformation/index.ts
@@ -17,7 +17,7 @@ export default class ProjectInformationWebPart extends BaseProjectWebPart<
   public render(): void {
     this.renderComponent<IProjectInformationProps>(ProjectInformation, {
       onFieldExternalChanged: this._onFieldExternalChanged.bind(this),
-      adminPageLink: this.properties.adminPageLink,
+      adminPageLink: this.properties.adminPageLink ?? strings.DefaultAdminPageLink,
       webPartContext: this.context
     })
   }


### PR DESCRIPTION
Had an issue where Administrer Underområder property was not set on older projects in Web part properties, making the button redirect to /undefined. 

Added a null catch directing to /Admin.aspx, which is the default value.

💔Thank you!
