### PR TITLE
Field types not in sync with 'Prosjektinnholdskolonner' data

### DIFF
--- a/SharePointFramework/@Shared/package-lock.json
+++ b/SharePointFramework/@Shared/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "pp365-shared",
-  "version": "1.5.4-706.10",
+  "version": "1.5.4-706.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/SharePointFramework/@Shared/package.json
+++ b/SharePointFramework/@Shared/package.json
@@ -3,7 +3,7 @@
   "engines": {
     "node": "^12"
   },
-  "version": "1.5.4-706.10",
+  "version": "1.5.4-706.11",
   "description": "Shared utilities, helpers and models",
   "main": "lib/index.js",
   "scripts": {

--- a/SharePointFramework/@Shared/src/models/ProjectColumn.ts
+++ b/SharePointFramework/@Shared/src/models/ProjectColumn.ts
@@ -47,7 +47,7 @@ export class ProjectColumn implements IColumn {
       this.sortOrder = _item.GtSortOrder
       this.internalName = _item.GtInternalName
       this.dataType = _item.GtFieldDataType && _item.GtFieldDataType.toLowerCase()
-      this.isMultiline = this.dataType === 'note'
+      this.isMultiline = this.dataType === 'note' || this.dataType === 'tags'
       this.isRefinable = _item.GtIsRefinable
       this.isGroupable = _item.GtIsGroupable
       this.isResizable = true

--- a/SharePointFramework/PortfolioWebParts/package-lock.json
+++ b/SharePointFramework/PortfolioWebParts/package-lock.json
@@ -22924,9 +22924,9 @@
       }
     },
     "pp365-shared": {
-      "version": "1.5.4-706.10",
-      "resolved": "https://registry.npmjs.org/pp365-shared/-/pp365-shared-1.5.4-706.10.tgz",
-      "integrity": "sha512-9K3sYd5eUm2pgGBQ5gtcWa+mRBP7LR1cFYNp8ZTIBRSRT+p3brCoNMmyi3l9jFgH8BKVLEXy38yRHMgsWN03rQ==",
+      "version": "1.5.4-706.11",
+      "resolved": "https://registry.npmjs.org/pp365-shared/-/pp365-shared-1.5.4-706.11.tgz",
+      "integrity": "sha512-UpzKpAZOAdwxxpl7zsINGT3n9W0hIJhesaDQ1S+OSiUgIQPyFRaDjgOFcEu50uFHQYRfvPVn367iy60+P9AkwQ==",
       "requires": {
         "@microsoft/sp-core-library": "1.12.1",
         "@microsoft/sp-page-context": "1.12.1",

--- a/SharePointFramework/PortfolioWebParts/package.json
+++ b/SharePointFramework/PortfolioWebParts/package.json
@@ -39,7 +39,7 @@
     "object-assign": "4.1.1",
     "office-ui-fabric-react": "6.214.0",
     "pp365-projectwebparts": "latest",
-    "pp365-shared": "1.5.4-706.10",
+    "pp365-shared": "1.5.4-706.11",
     "pzl-react-reusable-components": "^0.0.14",
     "react": "16.8.5",
     "react-calendar-timeline": "0.27.0",

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/ColumnFormPanel/index.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/ColumnFormPanel/index.tsx
@@ -55,7 +55,14 @@ export const ColumnFormPanel = () => {
   const onSave = async () => {
     setColumn(initialColumn)
     if (state.editColumn)
-      dispatch(ADD_COLUMN({ column: { ...column, key: column.fieldName } }))
+      await Promise.resolve(props.dataAdapter.configure().then((adapter) => {
+        adapter
+          .updateProjectContentColumn(column)
+          .then(() => {
+            dispatch(ADD_COLUMN({ column: { ...column, key: column.fieldName } }))
+          })
+          .catch((error) => (state.error = error))
+      }))
     else {
       const renderAs =
         column.data?.renderAs.charAt(0).toUpperCase() +

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/ColumnFormPanel/index.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/ColumnFormPanel/index.tsx
@@ -74,7 +74,8 @@ export const ColumnFormPanel = () => {
         GtInternalName: column.internalName,
         GtManagedProperty: column.fieldName,
         GtFieldDataType: renderAs,
-        GtDataSourceCategory: props.title
+        GtDataSourceCategory: props.title,
+        GtColMinWidth: column.minWidth
       }
 
       await Promise.resolve(props.dataAdapter.configure().then((adapter) => {
@@ -181,6 +182,7 @@ export const ColumnFormPanel = () => {
       <div className={styles.field}>
         <TextField
           label={strings.MaxWidthLabel}
+          disabled={true}
           type='number'
           value={column.maxWidth.toString()}
           onChange={(_, value) =>

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/reducer.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/reducer.ts
@@ -131,7 +131,10 @@ export default (props: IPortfolioAggregationProps) =>
               return {
                 ...col,
                 id: payCol.id,
-                internalName: payCol.internalName
+                internalName: payCol.internalName,
+                data: {
+                  renderAs: payCol.dataType ? payCol.dataType.toLowerCase() : 'text'
+                }
               }
             else return col
           })

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/reducer.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/reducer.ts
@@ -97,7 +97,7 @@ export const initState = (props: IPortfolioAggregationProps): IPortfolioAggregat
  */
 export default (props: IPortfolioAggregationProps) =>
   createReducer(initState(props), {
-    [DATA_FETCHED.type]: (state, { payload }: ReturnType<typeof DATA_FETCHED>) => {
+    [DATA_FETCHED.type]: (state, { payload }: ReturnType<typeof DATA_FETCHED>) => {      
       if (payload.items) {
         state.items = props.postTransform ? props.postTransform(payload.items) : payload.items
         state.items = sortArray(
@@ -132,8 +132,9 @@ export default (props: IPortfolioAggregationProps) =>
                 ...col,
                 id: payCol.id,
                 internalName: payCol.internalName,
+                minWidth: payCol.minWidth,
                 data: {
-                  renderAs: payCol.dataType ? payCol.dataType.toLowerCase() : 'text'
+                  renderAs: payCol.dataType ? payCol.dataType !== 'note' ? payCol.dataType.toLowerCase() : 'text' : 'text'
                 }
               }
             else return col

--- a/SharePointFramework/PortfolioWebParts/src/data/index.ts
+++ b/SharePointFramework/PortfolioWebParts/src/data/index.ts
@@ -293,9 +293,8 @@ export class DataAdapter implements IDataAdapter {
       }),
       sp.search({
         ...DEFAULT_SEARCH_SETTINGS,
-        QueryTemplate: `${
-          queryArray ?? ''
-        } DepartmentId:{${siteId}} ContentTypeId:0x010022252E35737A413FB56A1BA53862F6D5* GtModerationStatusOWSCHCS:Publisert`,
+        QueryTemplate: `${queryArray ?? ''
+          } DepartmentId:{${siteId}} ContentTypeId:0x010022252E35737A413FB56A1BA53862F6D5* GtModerationStatusOWSCHCS:Publisert`,
         SelectProperties: [...configuration.columns.map((f) => f.fieldName), siteIdProperty],
         Refiners: configuration.refiners.map((ref) => ref.fieldName).join(',')
       })
@@ -808,6 +807,35 @@ export class DataAdapter implements IDataAdapter {
 
     } catch (error) {
       throw new Error(format(strings.DataSourceError, dataSourceCategory))
+    }
+  }
+
+  /**
+   * Update project content column
+   *
+   * @param properties Properties
+   */
+  public async updateProjectContentColumn(properties: TypedHash<any>): Promise<any> {
+    try {
+      const list = sp.web.lists.getByTitle(strings.ProjectContentColumnsListName)
+      const items = await list.items.get()
+      const item = items.find((i) => i.GtManagedProperty === properties.fieldName)
+
+      if (!item) {
+        throw new Error(format(strings.ProjectContentColumnItemNotFound, properties.fieldName))
+      }
+
+      const renderAs =
+        properties.data.renderAs.charAt(0).toUpperCase() +
+        properties.data.renderAs.slice(1)
+
+      const itemUpdateResult = await list.items.getById(item.Id).update({
+        GtFieldDataType: renderAs,
+        GtColMinWidth: properties.minWidth
+      })
+      return itemUpdateResult
+    } catch (error) {
+      throw new Error(error)
     }
   }
 

--- a/SharePointFramework/PortfolioWebParts/src/data/types.ts
+++ b/SharePointFramework/PortfolioWebParts/src/data/types.ts
@@ -98,6 +98,7 @@ export interface IDataAdapter {
     dataSourceCategory?: string
   ): Promise<any[]>
   fetchProjectContentColumns?(dataSourceCategory: string): Promise<any[]>
+  updateProjectContentColumn?(properties: TypedHash<any>): Promise<any>
   deleteProjectContentColumn?(property: TypedHash<any>): Promise<any>
   addItemToList?(listName: string, properties: TypedHash<any>): Promise<any[]>
   updateDataSourceItem?(properties: TypedHash<any>, dataSourceTitle: string, shouldReplace?: boolean): Promise<ItemUpdateResult>

--- a/SharePointFramework/PortfolioWebParts/src/interfaces/IProjectContentColumn.ts
+++ b/SharePointFramework/PortfolioWebParts/src/interfaces/IProjectContentColumn.ts
@@ -4,4 +4,5 @@ export interface IProjectContentColumn extends IColumn {
   id?: number
   internalName?: string
   sortOrder?: number
+  dataType?: string
 }

--- a/Templates/Portfolio/Objects/ContentTypes/Prosjektinnholdskolonne.xml
+++ b/Templates/Portfolio/Objects/ContentTypes/Prosjektinnholdskolonne.xml
@@ -7,5 +7,6 @@
         <pnp:FieldRef ID="14dfd5b2-cf1d-4735-9e1b-7fa0d3658430" Name="GtManagedProperty" Required="true" />
         <pnp:FieldRef ID="7463d38f-5f51-4b25-a920-04ea1ec24a26" Name="GtFieldDataType" Required="true" />
         <pnp:FieldRef ID="67a0a4b1-61d7-45c3-9157-7e302450a304" Name="GtDataSourceCategory" />
+        <pnp:FieldRef ID="a156e8b6-fc02-475c-a377-47c6795fed1d" Name="GtColMinWidth" />
     </pnp:FieldRefs>
 </pnp:ContentType>

--- a/Templates/Portfolio/Objects/Lists/Prosjektinnholdskolonner.xml
+++ b/Templates/Portfolio/Objects/Lists/Prosjektinnholdskolonner.xml
@@ -17,6 +17,7 @@
                 <FieldRef Name="GtManagedProperty" />
                 <FieldRef Name="GtFieldDataType" />
                 <FieldRef Name="GtDataSourceCategory" />
+                <FieldRef Name="GtColMinWidth" />
             </ViewFields>
             <RowLimit Paged="TRUE">100</RowLimit>
             <Aggregations Value="Off" />
@@ -31,6 +32,7 @@
             <pnp:DataValue FieldName="GtManagedProperty">Title</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Text</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory"></pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">120</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 2 -->
             <pnp:DataValue FieldName="GtSortOrder">100</pnp:DataValue>
@@ -39,6 +41,7 @@
             <pnp:DataValue FieldName="GtManagedProperty">GtDeliveryDescriptionOWSMTXT</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Note</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Leveranseoversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">320</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 3 -->
             <pnp:DataValue FieldName="GtSortOrder">110</pnp:DataValue>
@@ -47,6 +50,7 @@
             <pnp:DataValue FieldName="GtManagedProperty">GtDeliveryEndTimeOWSDATE</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Date</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Leveranseoversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">120</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 4 -->
             <pnp:DataValue FieldName="GtSortOrder">120</pnp:DataValue>
@@ -55,6 +59,7 @@
             <pnp:DataValue FieldName="GtManagedProperty">GtDeliveryStatusOWSCHCS</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Text</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Leveranseoversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">120</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 5 -->
             <pnp:DataValue FieldName="GtSortOrder">130</pnp:DataValue>
@@ -63,6 +68,7 @@
             <pnp:DataValue FieldName="GtManagedProperty">GtDeliveryStatusCommentOWSMTXT</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Note</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Leveranseoversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">320</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 6 -->
             <pnp:DataValue FieldName="GtSortOrder">200</pnp:DataValue>
@@ -71,6 +77,7 @@
             <pnp:DataValue FieldName="GtManagedProperty">GtRiskProbabilityOWSNMBR</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Number</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Risikooversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">100</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 7 -->
             <pnp:DataValue FieldName="GtSortOrder">210</pnp:DataValue>
@@ -79,6 +86,7 @@
             <pnp:DataValue FieldName="GtManagedProperty">GtRiskConsequenceOWSNMBR</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Number</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Risikooversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">100</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 8 -->
             <pnp:DataValue FieldName="GtSortOrder">220</pnp:DataValue>
@@ -87,14 +95,16 @@
             <pnp:DataValue FieldName="GtManagedProperty">GtRiskProbabilityPostActionOWSNMBR</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Number</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Risikooversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">100</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 9 -->
             <pnp:DataValue FieldName="GtSortOrder">230</pnp:DataValue>
             <pnp:DataValue FieldName="Title">K etter tiltak</pnp:DataValue>
             <pnp:DataValue FieldName="GtInternalName">GtRiskConsequencePostAction</pnp:DataValue>
             <pnp:DataValue FieldName="GtManagedProperty">GtRiskConsequencePostActionOWSNMBR</pnp:DataValue>
-            <pnp:DataValue FieldName="GtFieldDataType">Note</pnp:DataValue>
+            <pnp:DataValue FieldName="GtFieldDataType">Number</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Risikooversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">100</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 10 -->
             <pnp:DataValue FieldName="GtSortOrder">240</pnp:DataValue>
@@ -103,6 +113,7 @@
             <pnp:DataValue FieldName="GtManagedProperty">GtRiskActionOWSMTXT</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Note</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Risikooversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">300</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 11 -->
             <pnp:DataValue FieldName="GtSortOrder">300</pnp:DataValue>
@@ -111,6 +122,7 @@
             <pnp:DataValue FieldName="GtManagedProperty">GtProjectLogDescriptionOWSMTXT</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Note</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Erfaringslogg</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">320</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 12 -->
             <pnp:DataValue FieldName="GtSortOrder">310</pnp:DataValue>
@@ -119,6 +131,7 @@
             <pnp:DataValue FieldName="GtManagedProperty">GtProjectLogActorsOWSCHCM</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Tags</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Erfaringslogg</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">100</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 13 -->
             <pnp:DataValue FieldName="GtSortOrder">320</pnp:DataValue>
@@ -127,14 +140,16 @@
             <pnp:DataValue FieldName="GtManagedProperty">GtProjectLogResponsibleOWSCHCS</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Text</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Erfaringslogg</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">100</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 14 -->
             <pnp:DataValue FieldName="GtSortOrder">330</pnp:DataValue>
             <pnp:DataValue FieldName="Title">Konsekvens</pnp:DataValue>
             <pnp:DataValue FieldName="GtInternalName">GtProjectLogConsequence</pnp:DataValue>
             <pnp:DataValue FieldName="GtManagedProperty">GtProjectLogConsequenceOWSMTXT</pnp:DataValue>
-            <pnp:DataValue FieldName="GtFieldDataType">Number</pnp:DataValue>
+            <pnp:DataValue FieldName="GtFieldDataType">Note</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Erfaringslogg</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">320</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 15 -->
             <pnp:DataValue FieldName="GtSortOrder">340</pnp:DataValue>
@@ -143,6 +158,7 @@
             <pnp:DataValue FieldName="GtManagedProperty">GtProjectLogRecommendationOWSMTXT</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Note</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Erfaringslogg</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">320</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 16 -->
             <pnp:DataValue FieldName="GtSortOrder">400</pnp:DataValue>
@@ -151,6 +167,7 @@
             <pnp:DataValue FieldName="GtManagedProperty">GtGainsResponsible</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">User</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Gevinstoversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">100</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 17 -->
             <pnp:DataValue FieldName="GtSortOrder">410</pnp:DataValue>
@@ -159,6 +176,7 @@
             <pnp:DataValue FieldName="GtManagedProperty">GtGainsOwner</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">User</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Gevinstoversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">100</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 18 -->
             <pnp:DataValue FieldName="GtSortOrder">420</pnp:DataValue>
@@ -167,6 +185,7 @@
             <pnp:DataValue FieldName="GtManagedProperty">GtDesiredValueOWSNMBR</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Number</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Gevinstoversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">100</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 19 -->
             <pnp:DataValue FieldName="GtSortOrder">430</pnp:DataValue>
@@ -175,6 +194,7 @@
             <pnp:DataValue FieldName="GtManagedProperty">GtMeasurementUnitOWSCHCS</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Text</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Gevinstoversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">100</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 20 -->
             <pnp:DataValue FieldName="GtSortOrder">440</pnp:DataValue>
@@ -183,6 +203,7 @@
             <pnp:DataValue FieldName="GtManagedProperty">GtStartValueOWSNMBR</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Number</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Gevinstoversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">100</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 21 -->
             <pnp:DataValue FieldName="GtSortOrder">450</pnp:DataValue>
@@ -191,6 +212,7 @@
             <pnp:DataValue FieldName="GtManagedProperty">GtMeasurementValueOWSNMBR</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Number</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Gevinstoversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">100</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 22 -->
             <pnp:DataValue FieldName="GtSortOrder">460</pnp:DataValue>
@@ -199,6 +221,7 @@
             <pnp:DataValue FieldName="GtManagedProperty">GtMeasurementCommentOWSMTXT</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Note</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Gevinstoversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">200</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 23 -->
             <pnp:DataValue FieldName="GtSortOrder">470</pnp:DataValue>
@@ -207,6 +230,7 @@
             <pnp:DataValue FieldName="GtManagedProperty">GtMeasurementDateOWSDATE</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Date</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Gevinstoversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">120</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 24 -->
             <pnp:DataValue FieldName="GtSortOrder">480</pnp:DataValue>
@@ -215,6 +239,7 @@
             <pnp:DataValue FieldName="GtManagedProperty">GtGainsTurnoverOWSMTXT</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Note</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Gevinstoversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">120</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 25 -->
             <pnp:DataValue FieldName="GtSortOrder">490</pnp:DataValue>
@@ -223,14 +248,16 @@
             <pnp:DataValue FieldName="GtManagedProperty">GtGainsTypeOWSCHCS</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Text</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Gevinstoversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">100</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 26 -->
             <pnp:DataValue FieldName="GtSortOrder">500</pnp:DataValue>
             <pnp:DataValue FieldName="Title">Forutsetninger for gevinstoppnåelse</pnp:DataValue>
             <pnp:DataValue FieldName="GtInternalName">GtPrereqProfitAchievement</pnp:DataValue>
             <pnp:DataValue FieldName="GtManagedProperty">GtPrereqProfitAchievementOWSMTXT</pnp:DataValue>
-            <pnp:DataValue FieldName="GtFieldDataType">Text</pnp:DataValue>
+            <pnp:DataValue FieldName="GtFieldDataType">Note</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Gevinstoversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">220</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 27 -->
             <pnp:DataValue FieldName="GtSortOrder">510</pnp:DataValue>
@@ -239,6 +266,7 @@
             <pnp:DataValue FieldName="GtManagedProperty">GtRealizationTimeOWSDATE</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Date</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Gevinstoversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">140</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 28 -->
             <pnp:DataValue FieldName="GtSortOrder">520</pnp:DataValue>
@@ -247,6 +275,7 @@
             <pnp:DataValue FieldName="GtManagedProperty">MeasurementIndicator</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Text</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Gevinstoversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">180</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 29 -->
             <pnp:DataValue FieldName="GtSortOrder">530</pnp:DataValue>
@@ -255,6 +284,7 @@
             <pnp:DataValue FieldName="GtManagedProperty">LastMeasurementValue</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Number</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Gevinstoversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">100</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 30 -->
             <pnp:DataValue FieldName="GtSortOrder">540</pnp:DataValue>
@@ -263,6 +293,7 @@
             <pnp:DataValue FieldName="GtManagedProperty">MeasurementAchievement</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Trend</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Gevinstoversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">100</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 31 -->
             <pnp:DataValue FieldName="GtSortOrder">550</pnp:DataValue>
@@ -271,6 +302,7 @@
             <pnp:DataValue FieldName="GtManagedProperty">Measurements</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Modal</pnp:DataValue>
             <pnp:DataValue FieldName="GtDataSourceCategory">Gevinstoversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtColMinWidth">100</pnp:DataValue>
         </pnp:DataRow>
     </pnp:DataRows>
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="Objects/Lists/Security/DefaultSecurity.xml" />


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [X] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [X] Check the commit's or even all commits' message 
- [X] Check if your code additions will fail linting checks
- [X] Remember: Add issue description to [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the **ID of the issue** associated with this PR
- [X] Documentation: Have a look at the [PP365 User manual](https://puzzlepart.github.io/prosjektportalen-manual/) and consider the need for updates to be made. Updates can be done directly into the 'Kladd' branch or by providing information to test team for implementation.

### Description
Fixes issue were field types (dataType/renderAs) in webpart and 'Prosjektinnholdskolonner' list type field data were not in sync. When updating type from webpart, the item in the list will also be updated.

Additions: Added minWidth to 'Prosjektinnholdskolonner' list. Webpart uses the data from the list to render the width of the columns properly

### How to test

See #717 


### Relevant issues (if applicable)
#730 
