### PR TITLE
Add ViewId for views in aggregated web parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Every change is marked with issue ID.
 
+## 1.6.1 - XX.06.2022
+
+### Added
+
+- Added ViewId for views in aggregated web parts which is set in the url
+
 ## 1.6.0 - 16.06.2022
 
 ### Added
@@ -13,7 +19,7 @@ Every change is marked with issue ID.
   - This applies to Portfolio, Project and Program timelines
 - Added ability to run hooks in the txt provisioning template #700
   - Example: Trigger API's, Flows, Logic Apps, Azure Functions, etc...
-- Added 'Prosjektinnholdskolonner' list to define columns which are used for the aggregated webparts #706
+- Added 'Prosjektinnholdskolonner' list to define columns which are used for the aggregated web parts #706
   - 'Datakilder' has been expanded with 'Prosjekt odata spørring' column to filter the projects in the datasource query
 
 ### Changed

--- a/SharePointFramework/PortfolioWebParts/package-lock.json
+++ b/SharePointFramework/PortfolioWebParts/package-lock.json
@@ -22924,9 +22924,9 @@
       }
     },
     "pp365-shared": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/pp365-shared/-/pp365-shared-1.6.0.tgz",
-      "integrity": "sha512-JkJmfeXcf0liR0vOtdBGZr3OQK7t4FeHS2hVn+pWYqUqKX1k3u0mZekzsDNQ17afHK5o8kGuIvgs+z35kAKi6A==",
+      "version": "1.5.4-706.12",
+      "resolved": "https://registry.npmjs.org/pp365-shared/-/pp365-shared-1.5.4-706.12.tgz",
+      "integrity": "sha512-mynPYwtbsSZ0Gmf1EHjjsPXOoUmXD8HuKNeRIPBKRbpqNhuZoOYd6tVzcuk6MR7z/gWd7MQuW0YXp7ldhhFCyw==",
       "requires": {
         "@microsoft/sp-core-library": "1.12.1",
         "@microsoft/sp-page-context": "1.12.1",

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/index.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/index.tsx
@@ -17,6 +17,7 @@ import createReducer, {
   COLUMN_HEADER_CONTEXT_MENU,
   DATA_FETCHED,
   DATA_FETCH_ERROR,
+  SET_CURRENT_VIEW,
   GET_FILTERS,
   initState,
   ON_FILTER_CHANGE,
@@ -35,6 +36,11 @@ export const PortfolioAggregation = (props: IPortfolioAggregationProps) => {
   const layerHostId = getId('layerHost')
 
   useEffect(() => {
+    if (props.dataSourceCategory)
+      dispatch(SET_CURRENT_VIEW)
+  }, [props.dataSourceCategory, props.defaultViewId])
+
+  useEffect(() => {
     if (props.dataSourceCategory) {
       props.dataAdapter.configure().then((adapter) => {
         adapter
@@ -50,7 +56,7 @@ export const PortfolioAggregation = (props: IPortfolioAggregationProps) => {
           .catch((error) => dispatch(DATA_FETCH_ERROR({ error })))
       })
     }
-  }, [props.dataSourceCategory, state.dataSource])
+  }, [props.dataSourceCategory, props.defaultViewId])
 
   useEffect(() => {
     dispatch(START_FETCH())
@@ -79,7 +85,7 @@ export const PortfolioAggregation = (props: IPortfolioAggregationProps) => {
         })
         .catch((error) => dispatch(DATA_FETCH_ERROR({ error })))
     })
-  }, [state.columnAdded, state.columnDeleted, state.columnShowHide, state.dataSource])
+  }, [state.columnAdded, state.columnDeleted, state.columnShowHide, state.currentView])
 
   const items = useMemo(() => {
     const filteredItems = filterItems(state.items, state.columns, state.activeFilters)

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/types.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/types.ts
@@ -6,8 +6,15 @@ import { IProjectContentColumn } from 'interfaces/IProjectContentColumn'
 import { Target } from 'office-ui-fabric-react/lib/Callout'
 import { IColumn, IGroup } from 'office-ui-fabric-react/lib/DetailsList'
 import { IPanelProps } from 'office-ui-fabric-react/lib/Panel'
+import { MessageBarType } from 'office-ui-fabric-react/lib/MessageBar'
 import { DataSource } from 'pp365-shared/lib/models/DataSource'
 import { IBaseComponentProps } from '../types'
+
+export class PortfolioAggregationErrorMessage extends Error {
+  constructor(public message: string, public type: MessageBarType) {
+    super(message)
+  }
+}
 
 export interface IPortfolioAggregationProps<T = any> extends IBaseComponentProps {
   /**
@@ -64,6 +71,11 @@ export interface IPortfolioAggregationProps<T = any> extends IBaseComponentProps
    * Show Excel export button
    */
   showViewSelector?: boolean
+
+  /**
+   * Default view id
+   */
+  defaultViewId?: string
 
   /**
    * Locked columns
@@ -211,4 +223,16 @@ export interface IPortfolioAggregationState {
    * Current view
    */
   currentView?: DataSource
+}
+
+export interface IPortfolioAggregationHashState {
+  /**
+   * viewId found in hash (document.location.hash)
+   */
+  viewId?: string
+
+  /**
+   * groupBy found in hash (document.location.hash)
+   */
+  groupBy?: string
 }

--- a/SharePointFramework/PortfolioWebParts/src/loc/mystrings.d.ts
+++ b/SharePointFramework/PortfolioWebParts/src/loc/mystrings.d.ts
@@ -70,6 +70,7 @@ declare interface IPortfolioWebPartsStrings {
   DataSourceCategoryError: string
   DataSourceNotFound: string
   DefaultViewLabel: string
+  DefaultDataSourceViewLabel: string
   DeliveryDescriptionLabel: string
   DeliveryEndTimeLabel: string
   DeliveryStartTimeLabel: string

--- a/SharePointFramework/PortfolioWebParts/src/loc/nb-no.js
+++ b/SharePointFramework/PortfolioWebParts/src/loc/nb-no.js
@@ -69,6 +69,7 @@ define([], function() {
         DataSourceError: 'Det skjedde en feil under uthenting av data fra datakilde med navn **{0}**.',
         DataSourceNotFound: 'Finner ingen datakilde med navn **{0}**.',
         DefaultViewLabel: 'Standardvisning',
+        DefaultDataSourceViewLabel: 'Standardvisning (datakilde)',
         DeliveryDescriptionLabel: 'Leveransebeskrivelse',
         DeliveryEndTimeLabel: 'Sluttidspunkt',
         DeliveryStartTimeLabel: 'Starttidspunkt',

--- a/SharePointFramework/PortfolioWebParts/src/webparts/portfolioAggregation/index.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/webparts/portfolioAggregation/index.tsx
@@ -1,19 +1,26 @@
 import {
   IPropertyPaneConfiguration,
+  IPropertyPaneDropdownOption,
+  PropertyPaneDropdown,
   PropertyPaneTextField,
   PropertyPaneToggle
 } from '@microsoft/sp-property-pane'
 import { IPortfolioAggregationProps, PortfolioAggregation } from 'components/PortfolioAggregation'
 import { DataAdapter } from 'data'
+import { IAggregatedListConfiguration } from 'interfaces'
+import _ from 'lodash'
 import { IMessageBarProps, MessageBar } from 'office-ui-fabric-react/lib/MessageBar'
 import * as strings from 'PortfolioWebPartsStrings'
 import React from 'react'
+import { first } from 'underscore'
 import { BasePortfolioWebPart } from 'webparts/@basePortfolioWebPart'
 
 export default class PortfolioAggregationWebPart extends BasePortfolioWebPart<
   IPortfolioAggregationProps
 > {
-  public async render(): Promise<void> {
+  private _configuration: IAggregatedListConfiguration
+
+  public render(): void {
     if (!this.properties.dataSource) {
       this.renderComponent<IMessageBarProps>(MessageBar, {
         children: <span>{strings.PortfolioAggregationNotConfiguredMessage}</span>
@@ -22,9 +29,7 @@ export default class PortfolioAggregationWebPart extends BasePortfolioWebPart<
       this.renderComponent<IPortfolioAggregationProps>(PortfolioAggregation, {
         ...this.properties,
         dataAdapter: new DataAdapter(this.context),
-        configuration: await this.dataAdapter.getAggregatedListConfig(
-          this.properties.dataSourceCategory
-        ),
+        configuration: this._configuration,
         onUpdateProperty: this._onUpdateProperty.bind(this)
       })
     }
@@ -43,61 +48,78 @@ export default class PortfolioAggregationWebPart extends BasePortfolioWebPart<
 
   public async onInit(): Promise<void> {
     await super.onInit()
+    this._configuration = await this.dataAdapter.getAggregatedListConfig(
+      this.properties.dataSourceCategory
+    )
+  }
+
+  /**
+   * Get options for PropertyPaneDropdown
+   */
+  protected _getViewOptions(): IPropertyPaneDropdownOption[] {
+    if (this._configuration) {
+      return [
+        { key: null, text: '' },
+        ...this._configuration.views.map((view) => ({ key: view.id, text: view.title }))
+      ]
+    }
+    return[]
   }
 
   public getPropertyPaneConfiguration(): IPropertyPaneConfiguration {
-    return {
-      pages: [
-        {
-          groups: [
-            {
-              groupName: strings.DataSourceGroupName,
-              groupFields: [
-                PropertyPaneTextField('dataSource', {
-                  label: strings.DataSourceLabel,
-                  description: strings.DataSourceDescription
-                }),
-                PropertyPaneTextField('dataSourceCategory', {
-                  label: strings.DataSourceCategoryLabel,
-                  description: strings.DataSourceCategoryDescription
-                })
-              ]
-            },
-            {
-              groupName: strings.CommandBarGroupName,
-              groupFields: [
-                PropertyPaneToggle('showCommandBar', {
-                  label: strings.ShowCommandBarLabel
-                }),
-                PropertyPaneToggle('showFilters', {
-                  label: strings.ShowFiltersLabel,
-                  disabled: !this.properties.showCommandBar
-                }),
-                PropertyPaneToggle('showExcelExportButton', {
-                  label: strings.ShowExcelExportButtonLabel,
-                  disabled: !this.properties.showCommandBar
-                }),
-                PropertyPaneToggle('showViewSelector', {
-                  label: strings.ShowViewSelectorLabel,
-                  disabled: !this.properties.showCommandBar
-                })
-              ]
-            },
-            {
-              groupName: strings.SearchBoxGroupName,
-              groupFields: [
-                PropertyPaneToggle('showSearchBox', {
-                  label: strings.ShowSearchBoxLabel
-                }),
-                PropertyPaneTextField('searchBoxPlaceholderText', {
-                  label: strings.SearchBoxPlaceholderTextLabel,
-                  disabled: !this.properties.showSearchBox
-                })
-              ]
-            }
-          ]
-        }
-      ]
-    }
+  return {
+    pages: [
+      {
+        groups: [
+          {
+            groupName: strings.DataSourceGroupName,
+            groupFields: [
+              PropertyPaneTextField('dataSourceCategory', {
+                label: strings.DataSourceCategoryLabel,
+                description: strings.DataSourceCategoryDescription
+              }),
+              PropertyPaneDropdown('defaultViewId', {
+                label: strings.DefaultDataSourceViewLabel,
+                options: this._getViewOptions(),
+                selectedKey: (_.find(this._configuration.views, (v) => v.isDefault))?.id || first(this._configuration.views).id
+              })
+            ]
+          },
+          {
+            groupName: strings.CommandBarGroupName,
+            groupFields: [
+              PropertyPaneToggle('showCommandBar', {
+                label: strings.ShowCommandBarLabel
+              }),
+              PropertyPaneToggle('showFilters', {
+                label: strings.ShowFiltersLabel,
+                disabled: !this.properties.showCommandBar
+              }),
+              PropertyPaneToggle('showExcelExportButton', {
+                label: strings.ShowExcelExportButtonLabel,
+                disabled: !this.properties.showCommandBar
+              }),
+              PropertyPaneToggle('showViewSelector', {
+                label: strings.ShowViewSelectorLabel,
+                disabled: !this.properties.showCommandBar
+              })
+            ]
+          },
+          {
+            groupName: strings.SearchBoxGroupName,
+            groupFields: [
+              PropertyPaneToggle('showSearchBox', {
+                label: strings.ShowSearchBoxLabel
+              }),
+              PropertyPaneTextField('searchBoxPlaceholderText', {
+                label: strings.SearchBoxPlaceholderTextLabel,
+                disabled: !this.properties.showSearchBox
+              })
+            ]
+          }
+        ]
+      }
+    ]
   }
+}
 }

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectTimeline/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectTimeline/index.tsx
@@ -432,7 +432,7 @@ export class ProjectTimeline extends BaseWebPartComponent<
 
         projectDeliveries = projectDeliveries
           .map((item) => {
-            const config = _.find(timelineConfig, (col) => col.Title === this.props.configItemTitle)
+            const config = _.find(timelineConfig, (col) => col.Title === (this.props.configItemTitle || 'Prosjektleveranse'))
             const model = new TimelineContentListModel(
               this.props.siteId,
               this.props.webTitle,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pp365",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "engines": {
     "node": "^12"
   },


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [X] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [X] Check the commit's or even all commits' message 
- [X] Check if your code additions will fail linting checks
- [X] Remember: Add issue description to [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the **ID of the issue** associated with this PR
- [X] Documentation: Have a look at the [PP365 User manual](https://puzzlepart.github.io/prosjektportalen-manual/) and consider the need for updates to be made. Updates can be done directly into the 'Kladd' branch or by providing information to test team for implementation.

### Description

Added ViewId for views in aggregated web parts which is set in the url
- ViewId is set in the url when loading a page with an aggregated web part
- ViewId is then used to set the current datasource view
- Removed 'Datakilde' field from webpart as this is no longer used.
- Introduces default view dropdown in webpart properties, this sets the first datasource as default, if datasource is set as default in datasource list, that datasource will be used instead.

### How to test

1. Load a page with an aggregated web part
2. Try changing views, see change in url
3. Try changing default views, remove everything after '#' from url and see that if loads the default.
4. Also try setting a default view in the datasource list

### Relevant issues (if applicable)

#741 