### PR TITLE
issue-734: Changed ProjectPhaseCallout from hover to onClick

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Every change is marked with issue ID.
 
 - Added support to run hooks when changing phases
 
+### Changed
+
+- Changed ProjectPhaseCallout from hover to onClick #734
+
 ## 1.6.1 - 01.07.2022
 
 ### Added

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/ProjectPhase/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectPhases/ProjectPhase/index.tsx
@@ -22,12 +22,12 @@ export const ProjectPhase = ({ phase, isCurrentPhase, onOpenCallout }: IProjectP
           <span
             className={styles.phaseLetter}
             ref={targetRef}
-            onMouseOver={() => onOpenCallout(targetRef.current, phase)}>
+            onClick={() => onOpenCallout(targetRef.current, phase)}>
             {phase.letter}
           </span>
           <span
             className={styles.phaseText}
-            onMouseOver={() => onOpenCallout(targetRef.current, phase)}>
+            onClick={() => onOpenCallout(targetRef.current, phase)}>
             {phase.name}
           </span>
           <div


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [x] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [x] Check the commit's or even all commits' message 
- [x] Check if your code additions will fail linting checks
- [x] Remember: Add issue description to [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the **ID of the issue** associated with this PR

### Description

Updated so that ProjectPhaseCallout renders onClick, instead of on hovering. 

### How to test

Please describe how someone else (a regular user without coding skills) can test this PR. In the form of a numbered list and checkboxes for Jan when the testing period occurs.

Example:

1. Open [Prosjektportalen](https://prosjektportalen.sharepoint.com/sites/pp365/SitePages/Home.aspx)
2. Go into project
3. Click on the phases, to see change
