### PR TITLE
Fix for bug where default column values were wiped when importing documents through TemplateSelector dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Every change is marked with issue ID.
 
-## 1.6.2 - TBA
+## 1.7.0 - TBA
 
 ### Added
 
@@ -15,6 +15,10 @@ Every change is marked with issue ID.
 ### Changed
 
 - Changed phase callout from hover to clickable #734
+
+### Fixed
+
+- Fixed a bug where default column values were wiped when importing documents through TemplateSelector dialog #761
 
 ## 1.6.1 - 01.07.2022
 

--- a/SharePointFramework/@Shared/package-lock.json
+++ b/SharePointFramework/@Shared/package-lock.json
@@ -517,6 +517,14 @@
           "version": "1.0.16",
           "resolved": "https://registry.npmjs.org/adal-angular/-/adal-angular-1.0.16.tgz",
           "integrity": "sha1-4rwxvHEqr/ugU6pN1GvITrXSCQ8="
+        },
+        "msalLegacy": {
+          "version": "npm:msal@1.4.12",
+          "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.12.tgz",
+          "integrity": "sha512-gjupwQ6nvNL6mZkl5NIXyUmZhTiEMRu5giNdgHMh8l5EPOnV2Xj6nukY1NIxFacSTkEYUSDB47Pej9GxDYf+1w==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
         }
       }
     },
@@ -4117,14 +4125,6 @@
       "version": "1.4.13",
       "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.13.tgz",
       "integrity": "sha512-uFEa4KGlpGqNMwa7/1OQc6WQUF8iwHbaiHMVn0Cl66Ec7o30ZTtX9s9OWrf0wAxp8Mwg0JEE886z/PHpsiZUxQ==",
-      "requires": {
-        "tslib": "^1.9.3"
-      }
-    },
-    "msalLegacy": {
-      "version": "npm:msal@1.4.12",
-      "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.12.tgz",
-      "integrity": "sha512-gjupwQ6nvNL6mZkl5NIXyUmZhTiEMRu5giNdgHMh8l5EPOnV2Xj6nukY1NIxFacSTkEYUSDB47Pej9GxDYf+1w==",
       "requires": {
         "tslib": "^1.9.3"
       }

--- a/SharePointFramework/PortfolioWebParts/package-lock.json
+++ b/SharePointFramework/PortfolioWebParts/package-lock.json
@@ -288,6 +288,21 @@
         }
       }
     },
+    "@azure/msal-browser": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.22.0.tgz",
+      "integrity": "sha512-ZpnbnzjYGRGHjWDPOLjSp47CQvhK927+W9avtLoNNCMudqs2dBfwj76lnJwObDE7TAKmCUueTiieglBiPb1mgQ==",
+      "requires": {
+        "@azure/msal-common": "^6.1.0"
+      },
+      "dependencies": {
+        "@azure/msal-common": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-6.4.0.tgz",
+          "integrity": "sha512-WZdgq9f9O8cbxGzdRwLLMM5xjmLJ2mdtuzgXeiGxIRkVVlJ9nZ6sWnDFKa2TX8j72UXD1IfL0p/RYNoTXYoGfg=="
+        }
+      }
+    },
     "@azure/msal-common": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-4.5.1.tgz",
@@ -2852,6 +2867,22 @@
         "isomorphic-fetch": "^2.2.1"
       }
     },
+    "@microsoft/microsoft-graph-clientV3": {
+      "version": "npm:@microsoft/microsoft-graph-client@3.0.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/microsoft-graph-client/-/microsoft-graph-client-3.0.2.tgz",
+      "integrity": "sha512-eYDiApYmiGsm1s1jfAa/rhB2xQCsX4pWt0vCTd1LZmiApMQfT/c0hXj2hvpuGz5GrcLdugbu05xB79rIV57Pjw==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
     "@microsoft/office-ui-fabric-react-bundle": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@microsoft/office-ui-fabric-react-bundle/-/office-ui-fabric-react-bundle-1.12.1.tgz",
@@ -5218,6 +5249,524 @@
         "tslib": "~1.10.0"
       }
     },
+    "@microsoft/sp-image-helper": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-image-helper/-/sp-image-helper-1.15.2.tgz",
+      "integrity": "sha512-vNwymXZtGLFdgkNaV0j/Oi5t8Pz2FV9LgS2gnbAKuRzLSXtCSZ9hfP+5eC5LrVBWkSzxHC+8e+gAGaxqbr2asA==",
+      "requires": {
+        "@microsoft/office-ui-fabric-react-bundle": "1.15.2",
+        "@microsoft/sp-core-library": "1.15.2",
+        "@microsoft/sp-diagnostics": "1.15.2",
+        "@microsoft/sp-http": "1.15.2",
+        "@microsoft/sp-loader": "1.15.2",
+        "@microsoft/sp-lodash-subset": "1.15.2",
+        "@microsoft/sp-page-context": "1.15.2",
+        "tslib": "2.3.1"
+      },
+      "dependencies": {
+        "@fluentui/react-focus": {
+          "version": "7.18.9",
+          "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-7.18.9.tgz",
+          "integrity": "sha512-lATXTDEt+fXx2fQLFrJv2dSJr3hBqgmWkrqB00SAPXqN6jJQmmhzkiQG9+dugfk3JiobeEPCWm72L6USY31mXw==",
+          "requires": {
+            "@fluentui/keyboard-key": "^0.2.12",
+            "@uifabric/merge-styles": "^7.19.2",
+            "@uifabric/set-version": "^7.0.24",
+            "@uifabric/styling": "^7.22.0",
+            "@uifabric/utilities": "^7.36.0",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@fluentui/react-window-provider": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-1.0.3.tgz",
+          "integrity": "sha512-nFFhYlEWDSklAFjw87hQuOO5ZQP8or4J12ZJ7Glf+pcifRl0AySBshuGTJsTyZ0QyzgIeQYGSYf6wcPtycS0aA==",
+          "requires": {
+            "@uifabric/set-version": "^7.0.24",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@fluentui/theme": {
+          "version": "1.7.8",
+          "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-1.7.8.tgz",
+          "integrity": "sha512-RRXR7W+S+mgoZHso8KzpXhNx9n78WgZP2rYbjWejH91buPFp8ss+CqWxhTytBkd7QmRHOW5KhYGHbr0Oj4vA1g==",
+          "requires": {
+            "@uifabric/merge-styles": "^7.19.2",
+            "@uifabric/set-version": "^7.0.24",
+            "@uifabric/utilities": "^7.36.0",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@microsoft/microsoft-graph-client": {
+          "version": "1.7.2-spfx",
+          "resolved": "https://registry.npmjs.org/@microsoft/microsoft-graph-client/-/microsoft-graph-client-1.7.2-spfx.tgz",
+          "integrity": "sha512-BQN50r3tohWYOaQ0de7LJ5eCRjI6eg4RQqLhGDlgRmZIZhWzH0bhR6QBMmmxtYtwKWifhPhJSxYDW+cP67TJVw==",
+          "requires": {
+            "es6-promise": "^4.2.6",
+            "isomorphic-fetch": "^3.0.0",
+            "tslib": "^1.9.3"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@microsoft/office-ui-fabric-react-bundle": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/office-ui-fabric-react-bundle/-/office-ui-fabric-react-bundle-1.15.2.tgz",
+          "integrity": "sha512-iYQvIIRkjvwkoD9RHa3LUqbago9wSL0YUiifbQib7sG4fzl38Hmrht+WA0DPRPZbSwOWCsjzv7FXt1YWy9QxFQ==",
+          "requires": {
+            "@microsoft/sp-core-library": "1.15.2",
+            "@uifabric/icons": "7.7.2",
+            "office-ui-fabric-react": "7.185.7",
+            "react": "16.13.1",
+            "react-dom": "16.13.1",
+            "tslib": "2.3.1"
+          }
+        },
+        "@microsoft/sp-core-library": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.15.2.tgz",
+          "integrity": "sha512-sEotaC8+jUMZa5wc3lvtDYOGpAzzcl1fSZ0FnANIrJGyBC6tTqred0fzpkXptd4R0G/wi3746ivrccAOkzONkQ==",
+          "requires": {
+            "@microsoft/sp-lodash-subset": "1.15.2",
+            "@microsoft/sp-module-interfaces": "1.15.2",
+            "@microsoft/sp-odata-types": "1.15.2",
+            "tslib": "2.3.1"
+          }
+        },
+        "@microsoft/sp-diagnostics": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-diagnostics/-/sp-diagnostics-1.15.2.tgz",
+          "integrity": "sha512-9OJQwkdy3kqATQISpI4SG+5OUMB90KesupsWIE31aAyPcQiilh0XGhWmaYnCxCgGATAWcaYrFeptlDOTQNpuiA==",
+          "requires": {
+            "@microsoft/sp-core-library": "1.15.2",
+            "@microsoft/sp-lodash-subset": "1.15.2"
+          }
+        },
+        "@microsoft/sp-dynamic-data": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.15.2.tgz",
+          "integrity": "sha512-6ks5GUBSatsijQC8NUjaLjYCv4efAbEJcbSVTj8lySpTVCWu8aKsFtKB1b/Vc3I1g9Adq6z2e9sgTaPwm6HTlA==",
+          "requires": {
+            "@microsoft/sp-core-library": "1.15.2",
+            "@microsoft/sp-diagnostics": "1.15.2",
+            "@microsoft/sp-lodash-subset": "1.15.2",
+            "@microsoft/sp-module-interfaces": "1.15.2",
+            "tslib": "2.3.1"
+          }
+        },
+        "@microsoft/sp-http": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-http/-/sp-http-1.15.2.tgz",
+          "integrity": "sha512-vP3heQlje3YVTgyaGKZmrHksqmWP+zczuhQP116cCl6z52ZdUiuJIZpDcu+WGZaG1HdznAyrNGkkiZauTytIHw==",
+          "requires": {
+            "@azure/msal-browser": "2.22.0",
+            "@microsoft/microsoft-graph-client": "1.7.2-spfx",
+            "@microsoft/microsoft-graph-clientV3": "npm:@microsoft/microsoft-graph-client@3.0.2",
+            "@microsoft/sp-core-library": "1.15.2",
+            "@microsoft/sp-diagnostics": "1.15.2",
+            "@microsoft/sp-page-context": "1.15.2",
+            "@types/adal-angular": "1.0.1",
+            "adal-angular": "1.0.16",
+            "msalLegacy": "npm:msal@1.4.12",
+            "tslib": "2.3.1"
+          }
+        },
+        "@microsoft/sp-loader": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-loader/-/sp-loader-1.15.2.tgz",
+          "integrity": "sha512-w1EbIrP7AXH5Oq0cQwKW5OZUK6+c3amiImGUBSAlyHaEyC5/gSKMCDM0XJ0xkrihWs0ICWj/yX2o0aLaaReO3g==",
+          "requires": {
+            "@microsoft/office-ui-fabric-react-bundle": "1.15.2",
+            "@microsoft/sp-core-library": "1.15.2",
+            "@microsoft/sp-diagnostics": "1.15.2",
+            "@microsoft/sp-dynamic-data": "1.15.2",
+            "@microsoft/sp-http": "1.15.2",
+            "@microsoft/sp-lodash-subset": "1.15.2",
+            "@microsoft/sp-module-interfaces": "1.15.2",
+            "@microsoft/sp-odata-types": "1.15.2",
+            "@microsoft/sp-page-context": "1.15.2",
+            "@microsoft/sp-polyfills": "1.15.2",
+            "@rushstack/loader-raw-script": "1.3.228",
+            "@types/requirejs": "2.1.29",
+            "office-ui-fabric-react": "7.185.7",
+            "raw-loader": "~0.5.1",
+            "react": "16.13.1",
+            "react-dom": "16.13.1",
+            "requirejs": "2.3.6",
+            "tslib": "2.3.1"
+          }
+        },
+        "@microsoft/sp-lodash-subset": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.15.2.tgz",
+          "integrity": "sha512-XLqSltvz9W0hft76fylqVFNUIVS1sLjdUF3+lIQyj0g+4R9kDy9VsGhpxX7qLGAdW10yZ6Z40qfmBWgn8NN4MA==",
+          "requires": {
+            "@types/lodash": "4.14.117",
+            "tslib": "2.3.1"
+          }
+        },
+        "@microsoft/sp-module-interfaces": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.15.2.tgz",
+          "integrity": "sha512-JGOjK8f5ww+r4ax8TBAPDyZhDhGWVg1Jk4PvKE0cU6qjywM0DzWWkzHJFcyFXdjr8UE/+wzJOKasCCtu1RjWQg==",
+          "requires": {
+            "@rushstack/node-core-library": "3.45.5",
+            "z-schema": "4.2.4"
+          }
+        },
+        "@microsoft/sp-odata-types": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-odata-types/-/sp-odata-types-1.15.2.tgz",
+          "integrity": "sha512-Eb5MAWRAOkRAGXSdacg8p/KdSpYDJBNwyqNCZwrsCbgf/66h28oK0KUqQ6o8Hcy+vAZpa16x6bvpJQw5u1u8ZA==",
+          "requires": {
+            "tslib": "2.3.1"
+          }
+        },
+        "@microsoft/sp-page-context": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.15.2.tgz",
+          "integrity": "sha512-gq7q2vq5rzAwkOn4/jpdL/VgHCrtDWNZqjcU62W6iIW4TNT3nVykcof9llpghPcYx5dOuTtrRizXfa+vtQ+rzw==",
+          "requires": {
+            "@microsoft/sp-core-library": "1.15.2",
+            "@microsoft/sp-diagnostics": "1.15.2",
+            "@microsoft/sp-dynamic-data": "1.15.2",
+            "@microsoft/sp-lodash-subset": "1.15.2",
+            "@microsoft/sp-odata-types": "1.15.2",
+            "tslib": "2.3.1"
+          }
+        },
+        "@microsoft/sp-polyfills": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-polyfills/-/sp-polyfills-1.15.2.tgz",
+          "integrity": "sha512-XxbM/3p6yW/OIahcmzOVFQArKRxySHuDLSveSEdjIY3ycG8UWNX4QXDEd1tZchWCDz3vfO+j4aUsPPSOVW1Wcw==",
+          "requires": {
+            "es6-promise": "4.2.4",
+            "es6-symbol": "3.1.3",
+            "tslib": "2.3.1",
+            "whatwg-fetch": "2.0.3",
+            "whatwg-url": "4.7.1"
+          },
+          "dependencies": {
+            "es6-promise": {
+              "version": "4.2.4",
+              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+              "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+            },
+            "whatwg-fetch": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+              "integrity": "sha512-SA2KdOXATOroD3EBUYvcdugsusXS5YiQFqwskSbsp5b1gK8HpNi/YP0jcy/BDpdllp305HMnrsVf9K7Be9GiEQ=="
+            },
+            "whatwg-url": {
+              "version": "4.7.1",
+              "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.7.1.tgz",
+              "integrity": "sha512-7rwLuNiZQbujtIu7Ibp7mq9X/Swqq90X0+zOWESoViRYcIOoQWtThlRX9K2YQHZLwGZv4CBOdTc4N3/SzAdb6w==",
+              "requires": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+              }
+            }
+          }
+        },
+        "@rushstack/loader-raw-script": {
+          "version": "1.3.228",
+          "resolved": "https://registry.npmjs.org/@rushstack/loader-raw-script/-/loader-raw-script-1.3.228.tgz",
+          "integrity": "sha512-yJPiwe4vCEmiZck9qUktYqVgExJV18C5wjO6Vv/l4ZWyI8WgYCei1eIcIJBtz//v3E18b8s6tKnSZDAUw1mhUQ==",
+          "requires": {
+            "loader-utils": "~1.1.0"
+          }
+        },
+        "@rushstack/node-core-library": {
+          "version": "3.45.5",
+          "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.45.5.tgz",
+          "integrity": "sha512-KbN7Hp9vH3bD3YJfv6RnVtzzTAwGYIBl7y2HQLY4WEQqRbvE3LgI78W9l9X+cTAXCX//p0EeoiUYNTFdqJrMZg==",
+          "requires": {
+            "@types/node": "12.20.24",
+            "colors": "~1.2.1",
+            "fs-extra": "~7.0.1",
+            "import-lazy": "~4.0.0",
+            "jju": "~1.4.0",
+            "resolve": "~1.17.0",
+            "semver": "~7.3.0",
+            "timsort": "~0.3.0",
+            "z-schema": "~5.0.2"
+          },
+          "dependencies": {
+            "z-schema": {
+              "version": "5.0.4",
+              "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.4.tgz",
+              "integrity": "sha512-gm/lx3hDzJNcLwseIeQVm1UcwhWIKpSB4NqH89pTBtFns4k/HDHudsICtvG05Bvw/Mv3jMyk700y5dadueLHdA==",
+              "requires": {
+                "commander": "^2.20.3",
+                "lodash.get": "^4.4.2",
+                "lodash.isequal": "^4.5.0",
+                "validator": "^13.7.0"
+              }
+            }
+          }
+        },
+        "@types/node": {
+          "version": "12.20.24",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
+          "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ=="
+        },
+        "@uifabric/foundation": {
+          "version": "7.10.8",
+          "resolved": "https://registry.npmjs.org/@uifabric/foundation/-/foundation-7.10.8.tgz",
+          "integrity": "sha512-u82qnYEkBx27oHk4VB5DDTGkUI7NYlchR30Cpt0UzPz2Dsep+oSlV3Z1vyS196BXNF8a4vtvOXrjN4vqzjVi7w==",
+          "requires": {
+            "@uifabric/merge-styles": "^7.19.2",
+            "@uifabric/set-version": "^7.0.24",
+            "@uifabric/styling": "^7.22.0",
+            "@uifabric/utilities": "^7.36.0",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@uifabric/icons": {
+          "version": "7.7.2",
+          "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.7.2.tgz",
+          "integrity": "sha512-3f223BZ5TXTF37J7lG+saGBY7U8vAi5HyMP58ccIoUafOj5551h5sovPFD/hVIYzYFhvT+/VpbUzF3vw+RARHA==",
+          "requires": {
+            "@uifabric/set-version": "^7.0.24",
+            "@uifabric/styling": "^7.20.2",
+            "@uifabric/utilities": "^7.34.1",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@uifabric/react-hooks": {
+          "version": "7.15.2",
+          "resolved": "https://registry.npmjs.org/@uifabric/react-hooks/-/react-hooks-7.15.2.tgz",
+          "integrity": "sha512-ngil4McS64HDCrMRyzOtXuyve4zOxBOX20DkYLa6rIBM3if+sUzNBodiwZ6RZz/6hBZW1nqpVmz7eEMnqEL4JA==",
+          "requires": {
+            "@fluentui/react-window-provider": "^1.0.3",
+            "@uifabric/set-version": "^7.0.24",
+            "@uifabric/utilities": "^7.36.0",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@uifabric/styling": {
+          "version": "7.22.0",
+          "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.22.0.tgz",
+          "integrity": "sha512-y2SntsWVKq7cabcwHDastfw9V4ahMdJr0idsrOlmU3vqWFTXwP99qIwYLcqrFVV4Kjb6F4T/JrnzNQW+bBlRGg==",
+          "requires": {
+            "@fluentui/theme": "^1.7.8",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "@uifabric/merge-styles": "^7.19.2",
+            "@uifabric/set-version": "^7.0.24",
+            "@uifabric/utilities": "^7.36.0",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@uifabric/utilities": {
+          "version": "7.36.0",
+          "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.36.0.tgz",
+          "integrity": "sha512-Y+bu0Wc5nbS39Exy/WxhgwP7ZlNOJj2UTcgYd8Nk+hQiDkUZvt3pSCIbn10Cz/59WrCr0htctvF5Xkt+BkpICA==",
+          "requires": {
+            "@fluentui/dom-utilities": "^1.1.2",
+            "@uifabric/merge-styles": "^7.19.2",
+            "@uifabric/set-version": "^7.0.24",
+            "prop-types": "^15.7.2",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "isomorphic-fetch": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+          "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+          "requires": {
+            "node-fetch": "^2.6.1",
+            "whatwg-fetch": "^3.4.1"
+          }
+        },
+        "msalLegacy": {
+          "version": "npm:msal@1.4.12",
+          "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.12.tgz",
+          "integrity": "sha512-gjupwQ6nvNL6mZkl5NIXyUmZhTiEMRu5giNdgHMh8l5EPOnV2Xj6nukY1NIxFacSTkEYUSDB47Pej9GxDYf+1w==",
+          "requires": {
+            "tslib": "^1.9.3"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "office-ui-fabric-react": {
+          "version": "7.185.7",
+          "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.185.7.tgz",
+          "integrity": "sha512-JiWkrjT/T6OG63ATu6RUlME2PBe4pgxQOwRTOjvbsaq8mlyd9i21ImgwkTEvcNXJpx+4w0bJiuQTcdwSMyf6qA==",
+          "requires": {
+            "@fluentui/date-time-utilities": "^7.9.1",
+            "@fluentui/react-focus": "^7.18.4",
+            "@fluentui/react-window-provider": "^1.0.3",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "@uifabric/foundation": "^7.10.3",
+            "@uifabric/icons": "^7.7.2",
+            "@uifabric/merge-styles": "^7.19.2",
+            "@uifabric/react-hooks": "^7.14.2",
+            "@uifabric/set-version": "^7.0.24",
+            "@uifabric/styling": "^7.20.2",
+            "@uifabric/utilities": "^7.34.1",
+            "prop-types": "^15.7.2",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "react": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
+          "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "react-dom": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
+          "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "scheduler": "^0.19.1"
+          }
+        },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "scheduler": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        },
+        "validator": {
+          "version": "13.7.0",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+          "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        },
+        "z-schema": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.4.tgz",
+          "integrity": "sha512-YvBeW5RGNeNzKOUJs3rTL4+9rpcvHXt5I051FJbOcitV8bl40pEfcG0Q+dWSwS0/BIYrMZ/9HHoqLllMkFhD0w==",
+          "requires": {
+            "commander": "^2.7.1",
+            "lodash.get": "^4.4.2",
+            "lodash.isequal": "^4.5.0",
+            "validator": "^13.6.0"
+          }
+        }
+      }
+    },
     "@microsoft/sp-loader": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@microsoft/sp-loader/-/sp-loader-1.12.1.tgz",
@@ -6601,15 +7150,15 @@
       }
     },
     "@pnp/spfx-property-controls": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@pnp/spfx-property-controls/-/spfx-property-controls-3.7.0.tgz",
-      "integrity": "sha512-50INPEYUoYXPyh5pFnGZTW+AL9hN+rtI7W9f0vjLl2ou7QB3JkpkCVvT5LsKRhDNDivHSxZZ7JAJGp8QhnvNXA==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@pnp/spfx-property-controls/-/spfx-property-controls-3.9.0.tgz",
+      "integrity": "sha512-mfN2+8JuMMf9SXu85QygSjx7GnUwZyigBRsYIjpbcCO8dGNW6Llu71a1Wog9B+22aQZBiALi2aw7bA6uLY6WlQ==",
       "requires": {
-        "@microsoft/sp-core-library": "1.14.0",
-        "@microsoft/sp-lodash-subset": "1.14.0",
-        "@microsoft/sp-office-ui-fabric-core": "1.14.0",
-        "@microsoft/sp-property-pane": "1.14.0",
-        "@microsoft/sp-webpart-base": "1.14.0",
+        "@microsoft/sp-core-library": "1.15.2",
+        "@microsoft/sp-lodash-subset": "1.15.2",
+        "@microsoft/sp-office-ui-fabric-core": "1.15.2",
+        "@microsoft/sp-property-pane": "1.15.2",
+        "@microsoft/sp-webpart-base": "1.15.2",
         "@monaco-editor/loader": "^1.2.0",
         "@pnp/common": "1.3.11",
         "@pnp/logging": "1.3.11",
@@ -6622,450 +7171,333 @@
         "lodash.omit": "4.5.0",
         "markdown-to-jsx": "^6.11.4",
         "monaco-editor": "^0.32.1",
-        "office-ui-fabric-react": "7.174.1",
+        "office-ui-fabric-react": "7.185.7",
         "react": "16.13.1",
         "react-ace": "5.8.0",
         "react-dom": "16.13.1"
       },
       "dependencies": {
-        "@fluentui/theme": {
-          "version": "1.7.6",
-          "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-1.7.6.tgz",
-          "integrity": "sha512-AcQSs3MpCxl63HE/4iJMwNVvPB6e0evvMMvELSK1sro199j1t14WSwTPwTHYsBeBxdX3mH9NixrB02tzXgJK6A==",
+        "@fluentui/react-focus": {
+          "version": "7.18.9",
+          "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-7.18.9.tgz",
+          "integrity": "sha512-lATXTDEt+fXx2fQLFrJv2dSJr3hBqgmWkrqB00SAPXqN6jJQmmhzkiQG9+dugfk3JiobeEPCWm72L6USY31mXw==",
           "requires": {
+            "@fluentui/keyboard-key": "^0.2.12",
             "@uifabric/merge-styles": "^7.19.2",
             "@uifabric/set-version": "^7.0.24",
-            "@uifabric/utilities": "^7.34.1",
+            "@uifabric/styling": "^7.22.0",
+            "@uifabric/utilities": "^7.36.0",
             "tslib": "^1.10.0"
           },
           "dependencies": {
-            "@uifabric/utilities": {
-              "version": "7.34.1",
-              "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.34.1.tgz",
-              "integrity": "sha512-gmQ94x/wj/my7zByFMXapLF5jDmRugWuBngx6gdvnw9rRme0YoN0G3S47vr3aw6ZTsXEnb6SJFnbtVyAGMmZRg==",
-              "requires": {
-                "@fluentui/dom-utilities": "^1.1.2",
-                "@uifabric/merge-styles": "^7.19.2",
-                "@uifabric/set-version": "^7.0.24",
-                "prop-types": "^15.7.2",
-                "tslib": "^1.10.0"
-              }
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@fluentui/react-window-provider": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-1.0.3.tgz",
+          "integrity": "sha512-nFFhYlEWDSklAFjw87hQuOO5ZQP8or4J12ZJ7Glf+pcifRl0AySBshuGTJsTyZ0QyzgIeQYGSYf6wcPtycS0aA==",
+          "requires": {
+            "@uifabric/set-version": "^7.0.24",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@fluentui/theme": {
+          "version": "1.7.8",
+          "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-1.7.8.tgz",
+          "integrity": "sha512-RRXR7W+S+mgoZHso8KzpXhNx9n78WgZP2rYbjWejH91buPFp8ss+CqWxhTytBkd7QmRHOW5KhYGHbr0Oj4vA1g==",
+          "requires": {
+            "@uifabric/merge-styles": "^7.19.2",
+            "@uifabric/set-version": "^7.0.24",
+            "@uifabric/utilities": "^7.36.0",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@microsoft/microsoft-graph-client": {
+          "version": "1.7.2-spfx",
+          "resolved": "https://registry.npmjs.org/@microsoft/microsoft-graph-client/-/microsoft-graph-client-1.7.2-spfx.tgz",
+          "integrity": "sha512-BQN50r3tohWYOaQ0de7LJ5eCRjI6eg4RQqLhGDlgRmZIZhWzH0bhR6QBMmmxtYtwKWifhPhJSxYDW+cP67TJVw==",
+          "requires": {
+            "es6-promise": "^4.2.6",
+            "isomorphic-fetch": "^3.0.0",
+            "tslib": "^1.9.3"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
             }
           }
         },
         "@microsoft/office-ui-fabric-react-bundle": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/office-ui-fabric-react-bundle/-/office-ui-fabric-react-bundle-1.14.0.tgz",
-          "integrity": "sha512-JhRBHdJrnYjOctHwCH3QBJL2aqD+nrHSK7E2CUMz8mfbUR1xneZRYBwT5EKnpyMT+llx3wuWDkK+7N4zwYOPJg==",
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/office-ui-fabric-react-bundle/-/office-ui-fabric-react-bundle-1.15.2.tgz",
+          "integrity": "sha512-iYQvIIRkjvwkoD9RHa3LUqbago9wSL0YUiifbQib7sG4fzl38Hmrht+WA0DPRPZbSwOWCsjzv7FXt1YWy9QxFQ==",
           "requires": {
-            "@microsoft/sp-core-library": "1.14.0",
-            "@uifabric/icons": "7.6.2",
-            "office-ui-fabric-react": "7.180.0",
+            "@microsoft/sp-core-library": "1.15.2",
+            "@uifabric/icons": "7.7.2",
+            "office-ui-fabric-react": "7.185.7",
             "react": "16.13.1",
             "react-dom": "16.13.1",
-            "tslib": "~1.10.0"
+            "tslib": "2.3.1"
           },
           "dependencies": {
             "@uifabric/icons": {
-              "version": "7.6.2",
-              "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.6.2.tgz",
-              "integrity": "sha512-q7jEIwB5Tt2Egw9fqdgNPlBqBQ6hNNMQ3qs5y4S4YETRluB+AQTdKbrbYMsXo3Pm0FsJnRfiDojMzxusGX+MWA==",
+              "version": "7.7.2",
+              "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.7.2.tgz",
+              "integrity": "sha512-3f223BZ5TXTF37J7lG+saGBY7U8vAi5HyMP58ccIoUafOj5551h5sovPFD/hVIYzYFhvT+/VpbUzF3vw+RARHA==",
               "requires": {
                 "@uifabric/set-version": "^7.0.24",
-                "@uifabric/styling": "^7.20.0",
+                "@uifabric/styling": "^7.20.2",
+                "@uifabric/utilities": "^7.34.1",
                 "tslib": "^1.10.0"
-              }
-            },
-            "office-ui-fabric-react": {
-              "version": "7.180.0",
-              "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.180.0.tgz",
-              "integrity": "sha512-bayPgo2gyJEqYOOwsGT8KZtOj3yWe252PqMFw0Gx/2TKOXweQ/btror1D2SGxins8RogTtwhkmvgTbnWYMn2jw==",
-              "requires": {
-                "@fluentui/date-time-utilities": "^7.9.1",
-                "@fluentui/react-focus": "^7.18.1",
-                "@fluentui/react-window-provider": "^1.0.2",
-                "@microsoft/load-themed-styles": "^1.10.26",
-                "@uifabric/foundation": "^7.10.1",
-                "@uifabric/icons": "^7.6.2",
-                "@uifabric/merge-styles": "^7.19.2",
-                "@uifabric/react-hooks": "^7.14.0",
-                "@uifabric/set-version": "^7.0.24",
-                "@uifabric/styling": "^7.20.0",
-                "@uifabric/utilities": "^7.33.5",
-                "prop-types": "^15.7.2",
-                "tslib": "^1.10.0"
+              },
+              "dependencies": {
+                "tslib": {
+                  "version": "1.14.1",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                  "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
               }
             }
           }
         },
         "@microsoft/sp-component-base": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/sp-component-base/-/sp-component-base-1.14.0.tgz",
-          "integrity": "sha512-o9D4iVU9uu1dIxxqK3ScOiZHm7npKaLeyCxckwiMCdJRMsp00RBiyDhAjBykZci/WHs2t14sxEDPvIkQJon+3g==",
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-component-base/-/sp-component-base-1.15.2.tgz",
+          "integrity": "sha512-Uf7nZ6Ohf68FQ4ABDs+8GVyqAb87rybaTJh/xBYz7DAjUUk/G1urq9wqTih8hSaHGog4P7ovuVeBKNYpmOU3Tg==",
           "requires": {
-            "@microsoft/office-ui-fabric-react-bundle": "1.14.0",
-            "@microsoft/sp-core-library": "1.14.0",
-            "@microsoft/sp-diagnostics": "1.14.0",
-            "@microsoft/sp-dynamic-data": "1.14.0",
-            "@microsoft/sp-http": "1.14.0",
-            "@microsoft/sp-lodash-subset": "1.14.0",
-            "@microsoft/sp-module-interfaces": "1.14.0",
-            "@microsoft/sp-page-context": "1.14.0",
-            "tslib": "~1.10.0"
+            "@microsoft/office-ui-fabric-react-bundle": "1.15.2",
+            "@microsoft/sp-core-library": "1.15.2",
+            "@microsoft/sp-diagnostics": "1.15.2",
+            "@microsoft/sp-dynamic-data": "1.15.2",
+            "@microsoft/sp-http": "1.15.2",
+            "@microsoft/sp-lodash-subset": "1.15.2",
+            "@microsoft/sp-module-interfaces": "1.15.2",
+            "@microsoft/sp-page-context": "1.15.2",
+            "tslib": "2.3.1"
           }
         },
         "@microsoft/sp-core-library": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.14.0.tgz",
-          "integrity": "sha512-+Do8o0Y6vdCxW+kVZbdWtcU+h+zR9raV9eCPjEBPj4xScB+Y26AE7H8lebAdgNh7rB136JTV+d6/l94FlKKabQ==",
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.15.2.tgz",
+          "integrity": "sha512-sEotaC8+jUMZa5wc3lvtDYOGpAzzcl1fSZ0FnANIrJGyBC6tTqred0fzpkXptd4R0G/wi3746ivrccAOkzONkQ==",
           "requires": {
-            "@microsoft/sp-lodash-subset": "1.14.0",
-            "@microsoft/sp-module-interfaces": "1.14.0",
-            "@microsoft/sp-odata-types": "1.14.0",
-            "tslib": "~1.10.0"
+            "@microsoft/sp-lodash-subset": "1.15.2",
+            "@microsoft/sp-module-interfaces": "1.15.2",
+            "@microsoft/sp-odata-types": "1.15.2",
+            "tslib": "2.3.1"
           }
         },
         "@microsoft/sp-diagnostics": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/sp-diagnostics/-/sp-diagnostics-1.14.0.tgz",
-          "integrity": "sha512-vuv1JidY7m+uneiYo6c90AIZUub7QCwBqby1gi7x/d9dV7vFfUfdkvZA1on7lvSOx32DVedX/d0W83mvZQRtTA==",
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-diagnostics/-/sp-diagnostics-1.15.2.tgz",
+          "integrity": "sha512-9OJQwkdy3kqATQISpI4SG+5OUMB90KesupsWIE31aAyPcQiilh0XGhWmaYnCxCgGATAWcaYrFeptlDOTQNpuiA==",
           "requires": {
-            "@microsoft/sp-core-library": "1.14.0",
-            "@microsoft/sp-lodash-subset": "1.14.0"
+            "@microsoft/sp-core-library": "1.15.2",
+            "@microsoft/sp-lodash-subset": "1.15.2"
           }
         },
         "@microsoft/sp-dynamic-data": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.14.0.tgz",
-          "integrity": "sha512-zwFB1G/8HDX7BqIvJqQd7vlTM1d2PfvHEFucZX6fkqoaC05j0dk4Ah0LJFKY767Ke8RD3VfijyakV/gJCkvw6g==",
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.15.2.tgz",
+          "integrity": "sha512-6ks5GUBSatsijQC8NUjaLjYCv4efAbEJcbSVTj8lySpTVCWu8aKsFtKB1b/Vc3I1g9Adq6z2e9sgTaPwm6HTlA==",
           "requires": {
-            "@microsoft/sp-core-library": "1.14.0",
-            "@microsoft/sp-diagnostics": "1.14.0",
-            "@microsoft/sp-lodash-subset": "1.14.0",
-            "@microsoft/sp-module-interfaces": "1.14.0",
-            "tslib": "~1.10.0"
+            "@microsoft/sp-core-library": "1.15.2",
+            "@microsoft/sp-diagnostics": "1.15.2",
+            "@microsoft/sp-lodash-subset": "1.15.2",
+            "@microsoft/sp-module-interfaces": "1.15.2",
+            "tslib": "2.3.1"
           }
         },
         "@microsoft/sp-http": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/sp-http/-/sp-http-1.14.0.tgz",
-          "integrity": "sha512-Md/azXAMSD/DlBBKGuV30y/5lNTdPZ4XKXGc6PcPp8h5mMyqEewdqaCrDhvvDPXZzoNyqYoH1ingdU4W6LRMRA==",
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-http/-/sp-http-1.15.2.tgz",
+          "integrity": "sha512-vP3heQlje3YVTgyaGKZmrHksqmWP+zczuhQP116cCl6z52ZdUiuJIZpDcu+WGZaG1HdznAyrNGkkiZauTytIHw==",
           "requires": {
-            "@microsoft/microsoft-graph-client": "~1.1.0",
-            "@microsoft/sp-core-library": "1.14.0",
-            "@microsoft/sp-diagnostics": "1.14.0",
+            "@azure/msal-browser": "2.22.0",
+            "@microsoft/microsoft-graph-client": "1.7.2-spfx",
+            "@microsoft/microsoft-graph-clientV3": "npm:@microsoft/microsoft-graph-client@3.0.2",
+            "@microsoft/sp-core-library": "1.15.2",
+            "@microsoft/sp-diagnostics": "1.15.2",
+            "@microsoft/sp-page-context": "1.15.2",
             "@types/adal-angular": "1.0.1",
             "adal-angular": "1.0.16",
-            "msal": "1.4.13",
             "msalLegacy": "npm:msal@1.4.12",
-            "tslib": "~1.10.0"
+            "tslib": "2.3.1"
           }
         },
         "@microsoft/sp-loader": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/sp-loader/-/sp-loader-1.14.0.tgz",
-          "integrity": "sha512-2Hp8UKaEbIcmcJ7b8HuwzrMYQ3y5z3icVDEST2rzWs+rc+QgINJERF17v8Q35h6d8PSPSevqwwPycAax2T41ZA==",
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-loader/-/sp-loader-1.15.2.tgz",
+          "integrity": "sha512-w1EbIrP7AXH5Oq0cQwKW5OZUK6+c3amiImGUBSAlyHaEyC5/gSKMCDM0XJ0xkrihWs0ICWj/yX2o0aLaaReO3g==",
           "requires": {
-            "@microsoft/office-ui-fabric-react-bundle": "1.14.0",
-            "@microsoft/sp-core-library": "1.14.0",
-            "@microsoft/sp-diagnostics": "1.14.0",
-            "@microsoft/sp-dynamic-data": "1.14.0",
-            "@microsoft/sp-http": "1.14.0",
-            "@microsoft/sp-lodash-subset": "1.14.0",
-            "@microsoft/sp-module-interfaces": "1.14.0",
-            "@microsoft/sp-odata-types": "1.14.0",
-            "@microsoft/sp-page-context": "1.14.0",
-            "@microsoft/sp-polyfills": "1.14.0",
-            "@rushstack/loader-raw-script": "1.3.207",
+            "@microsoft/office-ui-fabric-react-bundle": "1.15.2",
+            "@microsoft/sp-core-library": "1.15.2",
+            "@microsoft/sp-diagnostics": "1.15.2",
+            "@microsoft/sp-dynamic-data": "1.15.2",
+            "@microsoft/sp-http": "1.15.2",
+            "@microsoft/sp-lodash-subset": "1.15.2",
+            "@microsoft/sp-module-interfaces": "1.15.2",
+            "@microsoft/sp-odata-types": "1.15.2",
+            "@microsoft/sp-page-context": "1.15.2",
+            "@microsoft/sp-polyfills": "1.15.2",
+            "@rushstack/loader-raw-script": "1.3.228",
             "@types/requirejs": "2.1.29",
-            "office-ui-fabric-react": "7.180.0",
+            "office-ui-fabric-react": "7.185.7",
             "raw-loader": "~0.5.1",
             "react": "16.13.1",
             "react-dom": "16.13.1",
             "requirejs": "2.3.6",
-            "tslib": "~1.10.0"
-          },
-          "dependencies": {
-            "@uifabric/icons": {
-              "version": "7.7.2",
-              "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.7.2.tgz",
-              "integrity": "sha512-3f223BZ5TXTF37J7lG+saGBY7U8vAi5HyMP58ccIoUafOj5551h5sovPFD/hVIYzYFhvT+/VpbUzF3vw+RARHA==",
-              "requires": {
-                "@uifabric/set-version": "^7.0.24",
-                "@uifabric/styling": "^7.20.2",
-                "@uifabric/utilities": "^7.34.1",
-                "tslib": "^1.10.0"
-              },
-              "dependencies": {
-                "@uifabric/styling": {
-                  "version": "7.20.2",
-                  "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.20.2.tgz",
-                  "integrity": "sha512-FiGdeTsfJAs8qrqU2aLx70C2MT8YsjraMzr0HSiXKFQ2/LM4hwAYpbC41NIHzUemm63uA8NJRLHJlSv3S7V2SQ==",
-                  "requires": {
-                    "@fluentui/theme": "^1.7.6",
-                    "@microsoft/load-themed-styles": "^1.10.26",
-                    "@uifabric/merge-styles": "^7.19.2",
-                    "@uifabric/set-version": "^7.0.24",
-                    "@uifabric/utilities": "^7.34.1",
-                    "tslib": "^1.10.0"
-                  }
-                },
-                "@uifabric/utilities": {
-                  "version": "7.34.1",
-                  "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.34.1.tgz",
-                  "integrity": "sha512-gmQ94x/wj/my7zByFMXapLF5jDmRugWuBngx6gdvnw9rRme0YoN0G3S47vr3aw6ZTsXEnb6SJFnbtVyAGMmZRg==",
-                  "requires": {
-                    "@fluentui/dom-utilities": "^1.1.2",
-                    "@uifabric/merge-styles": "^7.19.2",
-                    "@uifabric/set-version": "^7.0.24",
-                    "prop-types": "^15.7.2",
-                    "tslib": "^1.10.0"
-                  }
-                }
-              }
-            },
-            "office-ui-fabric-react": {
-              "version": "7.180.0",
-              "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.180.0.tgz",
-              "integrity": "sha512-bayPgo2gyJEqYOOwsGT8KZtOj3yWe252PqMFw0Gx/2TKOXweQ/btror1D2SGxins8RogTtwhkmvgTbnWYMn2jw==",
-              "requires": {
-                "@fluentui/date-time-utilities": "^7.9.1",
-                "@fluentui/react-focus": "^7.18.1",
-                "@fluentui/react-window-provider": "^1.0.2",
-                "@microsoft/load-themed-styles": "^1.10.26",
-                "@uifabric/foundation": "^7.10.1",
-                "@uifabric/icons": "^7.6.2",
-                "@uifabric/merge-styles": "^7.19.2",
-                "@uifabric/react-hooks": "^7.14.0",
-                "@uifabric/set-version": "^7.0.24",
-                "@uifabric/styling": "^7.20.0",
-                "@uifabric/utilities": "^7.33.5",
-                "prop-types": "^15.7.2",
-                "tslib": "^1.10.0"
-              }
-            }
+            "tslib": "2.3.1"
           }
         },
         "@microsoft/sp-lodash-subset": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.14.0.tgz",
-          "integrity": "sha512-0vY+JuqAsUT9AMEMvMHhcNCtqV1RThxxgMPhzR1lauzKSNkMeFXYwHRsVR6p3BZfaQ2nyeyG5811Wlwchs5SKA==",
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.15.2.tgz",
+          "integrity": "sha512-XLqSltvz9W0hft76fylqVFNUIVS1sLjdUF3+lIQyj0g+4R9kDy9VsGhpxX7qLGAdW10yZ6Z40qfmBWgn8NN4MA==",
           "requires": {
             "@types/lodash": "4.14.117",
-            "tslib": "~1.10.0"
+            "tslib": "2.3.1"
           }
         },
         "@microsoft/sp-module-interfaces": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.14.0.tgz",
-          "integrity": "sha512-OPQW3vVVADSYTTXUXmBMh3/TAPqiCunPd7Ggfk+fZC82qyI5s7hLCkto9BJ2IkqfxLeOB9/4qxXfQbrrS6wVPg=="
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.15.2.tgz",
+          "integrity": "sha512-JGOjK8f5ww+r4ax8TBAPDyZhDhGWVg1Jk4PvKE0cU6qjywM0DzWWkzHJFcyFXdjr8UE/+wzJOKasCCtu1RjWQg==",
+          "requires": {
+            "@rushstack/node-core-library": "3.45.5",
+            "z-schema": "4.2.4"
+          }
         },
         "@microsoft/sp-odata-types": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/sp-odata-types/-/sp-odata-types-1.14.0.tgz",
-          "integrity": "sha512-SmznMgMaeo0JRq6BBUl+SMPVvJbzECOZtpVowrR5Kz06QIn7pfAL21q1ZwYH9tRJvPDo/awSDXW5qIzt/1jamA==",
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-odata-types/-/sp-odata-types-1.15.2.tgz",
+          "integrity": "sha512-Eb5MAWRAOkRAGXSdacg8p/KdSpYDJBNwyqNCZwrsCbgf/66h28oK0KUqQ6o8Hcy+vAZpa16x6bvpJQw5u1u8ZA==",
           "requires": {
-            "tslib": "~1.10.0"
+            "tslib": "2.3.1"
           }
         },
         "@microsoft/sp-office-ui-fabric-core": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/sp-office-ui-fabric-core/-/sp-office-ui-fabric-core-1.14.0.tgz",
-          "integrity": "sha512-FCkyTyM7CiTjXxSDiVLpiqUAR9Pxg+PdTh+KBDvtVBYLeQJI0Zqrwl833SSNl9mixD6doaKwri27LxhCGEN1nQ==",
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-office-ui-fabric-core/-/sp-office-ui-fabric-core-1.15.2.tgz",
+          "integrity": "sha512-/AO94rEE8NJqyVRiKkTzmdVbwqht8fVULvsikpJUTGd4Cczp8nUs9YsTwGxbdlW9Mu3gQ7CM9Rq7J24pNmEJWA==",
           "requires": {
-            "office-ui-fabric-core": "9.6.1-fluent2",
-            "tslib": "~1.10.0"
+            "office-ui-fabric-core": "11.0.1",
+            "tslib": "2.3.1"
           }
         },
         "@microsoft/sp-page-context": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.14.0.tgz",
-          "integrity": "sha512-WaT3wFY+MoYNjc6Z+cO5uxS7whRG8wzWtNzIGyxi6pLPxSpYyYfmZaDwsf563+hHUldGJpZIwwh0Fy096ysiPg==",
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.15.2.tgz",
+          "integrity": "sha512-gq7q2vq5rzAwkOn4/jpdL/VgHCrtDWNZqjcU62W6iIW4TNT3nVykcof9llpghPcYx5dOuTtrRizXfa+vtQ+rzw==",
           "requires": {
-            "@microsoft/sp-core-library": "1.14.0",
-            "@microsoft/sp-diagnostics": "1.14.0",
-            "@microsoft/sp-dynamic-data": "1.14.0",
-            "@microsoft/sp-lodash-subset": "1.14.0",
-            "@microsoft/sp-odata-types": "1.14.0",
-            "tslib": "~1.10.0"
+            "@microsoft/sp-core-library": "1.15.2",
+            "@microsoft/sp-diagnostics": "1.15.2",
+            "@microsoft/sp-dynamic-data": "1.15.2",
+            "@microsoft/sp-lodash-subset": "1.15.2",
+            "@microsoft/sp-odata-types": "1.15.2",
+            "tslib": "2.3.1"
           }
         },
         "@microsoft/sp-polyfills": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/sp-polyfills/-/sp-polyfills-1.14.0.tgz",
-          "integrity": "sha512-TJbYNfsdk1qjODzKQnn5+wcfJm2xBb8uqHNPCxAsoz6+e02HSNkdVM5rAjEq5Sh1Czcn4JIe3AXrz3DJMQnMBA==",
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-polyfills/-/sp-polyfills-1.15.2.tgz",
+          "integrity": "sha512-XxbM/3p6yW/OIahcmzOVFQArKRxySHuDLSveSEdjIY3ycG8UWNX4QXDEd1tZchWCDz3vfO+j4aUsPPSOVW1Wcw==",
           "requires": {
             "es6-promise": "4.2.4",
             "es6-symbol": "3.1.3",
-            "tslib": "~1.10.0",
+            "tslib": "2.3.1",
             "whatwg-fetch": "2.0.3",
             "whatwg-url": "4.7.1"
+          },
+          "dependencies": {
+            "es6-promise": {
+              "version": "4.2.4",
+              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+              "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+            },
+            "whatwg-fetch": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+              "integrity": "sha512-SA2KdOXATOroD3EBUYvcdugsusXS5YiQFqwskSbsp5b1gK8HpNi/YP0jcy/BDpdllp305HMnrsVf9K7Be9GiEQ=="
+            },
+            "whatwg-url": {
+              "version": "4.7.1",
+              "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.7.1.tgz",
+              "integrity": "sha512-7rwLuNiZQbujtIu7Ibp7mq9X/Swqq90X0+zOWESoViRYcIOoQWtThlRX9K2YQHZLwGZv4CBOdTc4N3/SzAdb6w==",
+              "requires": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+              }
+            }
           }
         },
         "@microsoft/sp-property-pane": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/sp-property-pane/-/sp-property-pane-1.14.0.tgz",
-          "integrity": "sha512-1xwpz7RPSQCWnzYNWYPQsFARYp6JlseU2wsXpk02Pmzt9W+Zg0551BUvoCmU9OWeLX0zWjvsLO8sh2zYZkWe/w==",
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-property-pane/-/sp-property-pane-1.15.2.tgz",
+          "integrity": "sha512-V78aUGZa4gM/MMmOg14iWYPoknHe9jrormvTXpltjcIvipRm5H5bRr6D4SfuzJ7uu0roJ53zfGddCDdvn05ezA==",
           "requires": {
-            "@microsoft/office-ui-fabric-react-bundle": "1.14.0",
-            "@microsoft/sp-component-base": "1.14.0",
-            "@microsoft/sp-core-library": "1.14.0",
-            "@microsoft/sp-diagnostics": "1.14.0",
-            "@microsoft/sp-dynamic-data": "1.14.0",
-            "@microsoft/sp-lodash-subset": "1.14.0",
-            "office-ui-fabric-react": "7.180.0",
+            "@microsoft/office-ui-fabric-react-bundle": "1.15.2",
+            "@microsoft/sp-component-base": "1.15.2",
+            "@microsoft/sp-core-library": "1.15.2",
+            "@microsoft/sp-diagnostics": "1.15.2",
+            "@microsoft/sp-dynamic-data": "1.15.2",
+            "@microsoft/sp-image-helper": "1.15.2",
+            "@microsoft/sp-lodash-subset": "1.15.2",
+            "@microsoft/sp-page-context": "1.15.2",
+            "office-ui-fabric-react": "7.185.7",
             "react": "16.13.1",
             "react-dom": "16.13.1",
-            "tslib": "~1.10.0"
-          },
-          "dependencies": {
-            "@uifabric/icons": {
-              "version": "7.7.2",
-              "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.7.2.tgz",
-              "integrity": "sha512-3f223BZ5TXTF37J7lG+saGBY7U8vAi5HyMP58ccIoUafOj5551h5sovPFD/hVIYzYFhvT+/VpbUzF3vw+RARHA==",
-              "requires": {
-                "@uifabric/set-version": "^7.0.24",
-                "@uifabric/styling": "^7.20.2",
-                "@uifabric/utilities": "^7.34.1",
-                "tslib": "^1.10.0"
-              },
-              "dependencies": {
-                "@uifabric/styling": {
-                  "version": "7.20.2",
-                  "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.20.2.tgz",
-                  "integrity": "sha512-FiGdeTsfJAs8qrqU2aLx70C2MT8YsjraMzr0HSiXKFQ2/LM4hwAYpbC41NIHzUemm63uA8NJRLHJlSv3S7V2SQ==",
-                  "requires": {
-                    "@fluentui/theme": "^1.7.6",
-                    "@microsoft/load-themed-styles": "^1.10.26",
-                    "@uifabric/merge-styles": "^7.19.2",
-                    "@uifabric/set-version": "^7.0.24",
-                    "@uifabric/utilities": "^7.34.1",
-                    "tslib": "^1.10.0"
-                  }
-                },
-                "@uifabric/utilities": {
-                  "version": "7.34.1",
-                  "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.34.1.tgz",
-                  "integrity": "sha512-gmQ94x/wj/my7zByFMXapLF5jDmRugWuBngx6gdvnw9rRme0YoN0G3S47vr3aw6ZTsXEnb6SJFnbtVyAGMmZRg==",
-                  "requires": {
-                    "@fluentui/dom-utilities": "^1.1.2",
-                    "@uifabric/merge-styles": "^7.19.2",
-                    "@uifabric/set-version": "^7.0.24",
-                    "prop-types": "^15.7.2",
-                    "tslib": "^1.10.0"
-                  }
-                }
-              }
-            },
-            "office-ui-fabric-react": {
-              "version": "7.180.0",
-              "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.180.0.tgz",
-              "integrity": "sha512-bayPgo2gyJEqYOOwsGT8KZtOj3yWe252PqMFw0Gx/2TKOXweQ/btror1D2SGxins8RogTtwhkmvgTbnWYMn2jw==",
-              "requires": {
-                "@fluentui/date-time-utilities": "^7.9.1",
-                "@fluentui/react-focus": "^7.18.1",
-                "@fluentui/react-window-provider": "^1.0.2",
-                "@microsoft/load-themed-styles": "^1.10.26",
-                "@uifabric/foundation": "^7.10.1",
-                "@uifabric/icons": "^7.6.2",
-                "@uifabric/merge-styles": "^7.19.2",
-                "@uifabric/react-hooks": "^7.14.0",
-                "@uifabric/set-version": "^7.0.24",
-                "@uifabric/styling": "^7.20.0",
-                "@uifabric/utilities": "^7.33.5",
-                "prop-types": "^15.7.2",
-                "tslib": "^1.10.0"
-              }
-            }
+            "tslib": "2.3.1"
           }
         },
         "@microsoft/sp-webpart-base": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/sp-webpart-base/-/sp-webpart-base-1.14.0.tgz",
-          "integrity": "sha512-plQ03RxEiSZVDDCc5s12MbnicjdJ2WpgJZwwYTb+y8I4LqiNrdM9V4ls53KZWQbCiYntgm2phHcdHXzeas/DBg==",
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-webpart-base/-/sp-webpart-base-1.15.2.tgz",
+          "integrity": "sha512-dFQBwmRg81EDyV5RzA7JEhtdKyjk3vjKZBn3pWvaY/4Yo+oGyzKdQ8o/z2A9OO6KwXXlXkFiGJgoau57c/EALQ==",
           "requires": {
-            "@microsoft/sp-component-base": "1.14.0",
-            "@microsoft/sp-core-library": "1.14.0",
-            "@microsoft/sp-diagnostics": "1.14.0",
-            "@microsoft/sp-dynamic-data": "1.14.0",
-            "@microsoft/sp-http": "1.14.0",
-            "@microsoft/sp-loader": "1.14.0",
-            "@microsoft/sp-lodash-subset": "1.14.0",
-            "@microsoft/sp-module-interfaces": "1.14.0",
-            "@microsoft/sp-page-context": "1.14.0",
-            "@microsoft/sp-property-pane": "1.14.0",
-            "@microsoft/teams-js": "1.10.0",
+            "@microsoft/sp-component-base": "1.15.2",
+            "@microsoft/sp-core-library": "1.15.2",
+            "@microsoft/sp-diagnostics": "1.15.2",
+            "@microsoft/sp-dynamic-data": "1.15.2",
+            "@microsoft/sp-http": "1.15.2",
+            "@microsoft/sp-loader": "1.15.2",
+            "@microsoft/sp-lodash-subset": "1.15.2",
+            "@microsoft/sp-module-interfaces": "1.15.2",
+            "@microsoft/sp-page-context": "1.15.2",
+            "@microsoft/sp-property-pane": "1.15.2",
+            "@microsoft/teams-js": "1.12.1",
             "@types/office-js": "1.0.36",
-            "office-ui-fabric-react": "7.180.0",
+            "office-ui-fabric-react": "7.185.7",
             "react": "16.13.1",
             "react-dom": "16.13.1",
-            "tslib": "~1.10.0"
-          },
-          "dependencies": {
-            "@uifabric/icons": {
-              "version": "7.7.2",
-              "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.7.2.tgz",
-              "integrity": "sha512-3f223BZ5TXTF37J7lG+saGBY7U8vAi5HyMP58ccIoUafOj5551h5sovPFD/hVIYzYFhvT+/VpbUzF3vw+RARHA==",
-              "requires": {
-                "@uifabric/set-version": "^7.0.24",
-                "@uifabric/styling": "^7.20.2",
-                "@uifabric/utilities": "^7.34.1",
-                "tslib": "^1.10.0"
-              },
-              "dependencies": {
-                "@uifabric/styling": {
-                  "version": "7.20.2",
-                  "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.20.2.tgz",
-                  "integrity": "sha512-FiGdeTsfJAs8qrqU2aLx70C2MT8YsjraMzr0HSiXKFQ2/LM4hwAYpbC41NIHzUemm63uA8NJRLHJlSv3S7V2SQ==",
-                  "requires": {
-                    "@fluentui/theme": "^1.7.6",
-                    "@microsoft/load-themed-styles": "^1.10.26",
-                    "@uifabric/merge-styles": "^7.19.2",
-                    "@uifabric/set-version": "^7.0.24",
-                    "@uifabric/utilities": "^7.34.1",
-                    "tslib": "^1.10.0"
-                  }
-                },
-                "@uifabric/utilities": {
-                  "version": "7.34.1",
-                  "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.34.1.tgz",
-                  "integrity": "sha512-gmQ94x/wj/my7zByFMXapLF5jDmRugWuBngx6gdvnw9rRme0YoN0G3S47vr3aw6ZTsXEnb6SJFnbtVyAGMmZRg==",
-                  "requires": {
-                    "@fluentui/dom-utilities": "^1.1.2",
-                    "@uifabric/merge-styles": "^7.19.2",
-                    "@uifabric/set-version": "^7.0.24",
-                    "prop-types": "^15.7.2",
-                    "tslib": "^1.10.0"
-                  }
-                }
-              }
-            },
-            "office-ui-fabric-react": {
-              "version": "7.180.0",
-              "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.180.0.tgz",
-              "integrity": "sha512-bayPgo2gyJEqYOOwsGT8KZtOj3yWe252PqMFw0Gx/2TKOXweQ/btror1D2SGxins8RogTtwhkmvgTbnWYMn2jw==",
-              "requires": {
-                "@fluentui/date-time-utilities": "^7.9.1",
-                "@fluentui/react-focus": "^7.18.1",
-                "@fluentui/react-window-provider": "^1.0.2",
-                "@microsoft/load-themed-styles": "^1.10.26",
-                "@uifabric/foundation": "^7.10.1",
-                "@uifabric/icons": "^7.6.2",
-                "@uifabric/merge-styles": "^7.19.2",
-                "@uifabric/react-hooks": "^7.14.0",
-                "@uifabric/set-version": "^7.0.24",
-                "@uifabric/styling": "^7.20.0",
-                "@uifabric/utilities": "^7.33.5",
-                "prop-types": "^15.7.2",
-                "tslib": "^1.10.0"
-              }
-            }
+            "tslib": "2.3.1"
           }
         },
         "@microsoft/teams-js": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/teams-js/-/teams-js-1.10.0.tgz",
-          "integrity": "sha512-g8+ox5nWe9IjDFRHnCXk7mkQRGjHFcAMSn7JpUtJfuWu2tDUmXAp/4LUSgewvBbbmy68YtS+KTFPHRyUoTzk6w=="
+          "version": "1.12.1",
+          "resolved": "https://registry.npmjs.org/@microsoft/teams-js/-/teams-js-1.12.1.tgz",
+          "integrity": "sha512-BRy6vZOseN9F/MG0NWTojYpenuo9XlZ4AfAvwnsG+C36UDPPgW0skWlZ6ub+7RBPhOHcxz8sNg2uHOdGRebWkQ=="
         },
         "@pnp/common": {
           "version": "1.3.11",
@@ -7080,6 +7512,11 @@
               "version": "1.0.17",
               "resolved": "https://registry.npmjs.org/adal-angular/-/adal-angular-1.0.17.tgz",
               "integrity": "sha512-+Z9aq7L25OncsaVcnhSsi7AMR/dlg0gWVNptsdtkL9Ih7hA1oJ14mhWB60CB83JF6DlzamVKLMGbrAcgFQqhCg=="
+            },
+            "tslib": {
+              "version": "1.10.0",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+              "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
             }
           }
         },
@@ -7089,6 +7526,13 @@
           "integrity": "sha512-hADlIXwvF/wjee7425nFJ6NhqaWpWTJ5yg02bpwBUsiSuFqEUf+LwuAcyHQre2lMs6KyNa65FWoRQok9BlZuxA==",
           "requires": {
             "tslib": "1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.10.0",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+              "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+            }
           }
         },
         "@pnp/odata": {
@@ -7097,6 +7541,13 @@
           "integrity": "sha512-yMaRiuVZRei2pkryCOqsw3ZXD2Lw30IJv136WQmQPQPOxG4cvsS9+woXkfMqbWV2KQ1evFUqVXbitIz6eDVfNA==",
           "requires": {
             "tslib": "1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.10.0",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+              "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+            }
           }
         },
         "@pnp/sp": {
@@ -7105,6 +7556,13 @@
           "integrity": "sha512-NjdeGe81aukiSPelSPjgAFRC1+SrNPTXvTdEqTH+Q1ZvgNtk8bdZp6K6xf9emfeM2qZDOu9GpKZpg0W/emq++g==",
           "requires": {
             "tslib": "1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.10.0",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+              "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+            }
           }
         },
         "@pnp/sp-clientsvc": {
@@ -7113,6 +7571,13 @@
           "integrity": "sha512-eIUnmDWjizcWJzhWxAbfsxEyHF1dabkGlihnDnlcYGhtvh8BwuM67A57qc5fbxzCS59c0YU57szB1EucoNmV4A==",
           "requires": {
             "tslib": "1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.10.0",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+              "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+            }
           }
         },
         "@pnp/sp-taxonomy": {
@@ -7121,6 +7586,13 @@
           "integrity": "sha512-shzCSjmOlr6mojCXJkfD8Xf9lJnhphq4Fj6mdUQGwpak+VIU+Fogf6AI0j6AReCKtKsKyqfud9X7C8tH07C3DA==",
           "requires": {
             "tslib": "1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.10.0",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+              "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+            }
           }
         },
         "@pnp/telemetry-js": {
@@ -7139,11 +7611,64 @@
           }
         },
         "@rushstack/loader-raw-script": {
-          "version": "1.3.207",
-          "resolved": "https://registry.npmjs.org/@rushstack/loader-raw-script/-/loader-raw-script-1.3.207.tgz",
-          "integrity": "sha512-sOF21pgIKhXREKepRMFMCi0UmChVj2LtjhUP38W5EwJG8sTtv8dOsZ3qT2lW7s+n6TzoPXE8NvY0/dK40VKhug==",
+          "version": "1.3.228",
+          "resolved": "https://registry.npmjs.org/@rushstack/loader-raw-script/-/loader-raw-script-1.3.228.tgz",
+          "integrity": "sha512-yJPiwe4vCEmiZck9qUktYqVgExJV18C5wjO6Vv/l4ZWyI8WgYCei1eIcIJBtz//v3E18b8s6tKnSZDAUw1mhUQ==",
           "requires": {
             "loader-utils": "~1.1.0"
+          }
+        },
+        "@rushstack/node-core-library": {
+          "version": "3.45.5",
+          "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.45.5.tgz",
+          "integrity": "sha512-KbN7Hp9vH3bD3YJfv6RnVtzzTAwGYIBl7y2HQLY4WEQqRbvE3LgI78W9l9X+cTAXCX//p0EeoiUYNTFdqJrMZg==",
+          "requires": {
+            "@types/node": "12.20.24",
+            "colors": "~1.2.1",
+            "fs-extra": "~7.0.1",
+            "import-lazy": "~4.0.0",
+            "jju": "~1.4.0",
+            "resolve": "~1.17.0",
+            "semver": "~7.3.0",
+            "timsort": "~0.3.0",
+            "z-schema": "~5.0.2"
+          },
+          "dependencies": {
+            "z-schema": {
+              "version": "5.0.4",
+              "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.4.tgz",
+              "integrity": "sha512-gm/lx3hDzJNcLwseIeQVm1UcwhWIKpSB4NqH89pTBtFns4k/HDHudsICtvG05Bvw/Mv3jMyk700y5dadueLHdA==",
+              "requires": {
+                "commander": "^2.20.3",
+                "lodash.get": "^4.4.2",
+                "lodash.isequal": "^4.5.0",
+                "validator": "^13.7.0"
+              }
+            }
+          }
+        },
+        "@types/node": {
+          "version": "12.20.24",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
+          "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ=="
+        },
+        "@uifabric/foundation": {
+          "version": "7.10.8",
+          "resolved": "https://registry.npmjs.org/@uifabric/foundation/-/foundation-7.10.8.tgz",
+          "integrity": "sha512-u82qnYEkBx27oHk4VB5DDTGkUI7NYlchR30Cpt0UzPz2Dsep+oSlV3Z1vyS196BXNF8a4vtvOXrjN4vqzjVi7w==",
+          "requires": {
+            "@uifabric/merge-styles": "^7.19.2",
+            "@uifabric/set-version": "^7.0.24",
+            "@uifabric/styling": "^7.22.0",
+            "@uifabric/utilities": "^7.36.0",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
           }
         },
         "@uifabric/icons": {
@@ -7154,78 +7679,144 @@
             "@uifabric/set-version": "^7.0.23",
             "@uifabric/styling": "^7.16.18",
             "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
           }
         },
-        "es6-promise": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-          "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+        "@uifabric/react-hooks": {
+          "version": "7.15.2",
+          "resolved": "https://registry.npmjs.org/@uifabric/react-hooks/-/react-hooks-7.15.2.tgz",
+          "integrity": "sha512-ngil4McS64HDCrMRyzOtXuyve4zOxBOX20DkYLa6rIBM3if+sUzNBodiwZ6RZz/6hBZW1nqpVmz7eEMnqEL4JA==",
+          "requires": {
+            "@fluentui/react-window-provider": "^1.0.3",
+            "@uifabric/set-version": "^7.0.24",
+            "@uifabric/utilities": "^7.36.0",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
         },
-        "msal": {
-          "version": "1.4.13",
-          "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.13.tgz",
-          "integrity": "sha512-uFEa4KGlpGqNMwa7/1OQc6WQUF8iwHbaiHMVn0Cl66Ec7o30ZTtX9s9OWrf0wAxp8Mwg0JEE886z/PHpsiZUxQ==",
+        "@uifabric/styling": {
+          "version": "7.22.0",
+          "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.22.0.tgz",
+          "integrity": "sha512-y2SntsWVKq7cabcwHDastfw9V4ahMdJr0idsrOlmU3vqWFTXwP99qIwYLcqrFVV4Kjb6F4T/JrnzNQW+bBlRGg==",
+          "requires": {
+            "@fluentui/theme": "^1.7.8",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "@uifabric/merge-styles": "^7.19.2",
+            "@uifabric/set-version": "^7.0.24",
+            "@uifabric/utilities": "^7.36.0",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@uifabric/utilities": {
+          "version": "7.36.0",
+          "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.36.0.tgz",
+          "integrity": "sha512-Y+bu0Wc5nbS39Exy/WxhgwP7ZlNOJj2UTcgYd8Nk+hQiDkUZvt3pSCIbn10Cz/59WrCr0htctvF5Xkt+BkpICA==",
+          "requires": {
+            "@fluentui/dom-utilities": "^1.1.2",
+            "@uifabric/merge-styles": "^7.19.2",
+            "@uifabric/set-version": "^7.0.24",
+            "prop-types": "^15.7.2",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "isomorphic-fetch": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+          "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+          "requires": {
+            "node-fetch": "^2.6.1",
+            "whatwg-fetch": "^3.4.1"
+          }
+        },
+        "msalLegacy": {
+          "version": "npm:msal@1.4.12",
+          "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.12.tgz",
+          "integrity": "sha512-gjupwQ6nvNL6mZkl5NIXyUmZhTiEMRu5giNdgHMh8l5EPOnV2Xj6nukY1NIxFacSTkEYUSDB47Pej9GxDYf+1w==",
           "requires": {
             "tslib": "^1.9.3"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
           }
         },
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "office-ui-fabric-core": {
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/office-ui-fabric-core/-/office-ui-fabric-core-11.0.1.tgz",
+          "integrity": "sha512-jcfycbVOm2aUoI+AGtHW24HvM7nUVFr44hR5NIE56EobK67bVwbNAQL15CJj3vNz5PBrnitsV9ROOB+KOEWn8g=="
+        },
         "office-ui-fabric-react": {
-          "version": "7.174.1",
-          "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.174.1.tgz",
-          "integrity": "sha512-zRUpUqZtVncvb+Tt+5SVNEcI3MfpwTLU+v2u7ZdF9ukPbD+UBKJSkIbydyO0P2S5jVizgdqioSOarfUA70ICvw==",
+          "version": "7.185.7",
+          "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.185.7.tgz",
+          "integrity": "sha512-JiWkrjT/T6OG63ATu6RUlME2PBe4pgxQOwRTOjvbsaq8mlyd9i21ImgwkTEvcNXJpx+4w0bJiuQTcdwSMyf6qA==",
           "requires": {
             "@fluentui/date-time-utilities": "^7.9.1",
-            "@fluentui/react-focus": "^7.17.6",
-            "@fluentui/react-window-provider": "^1.0.2",
+            "@fluentui/react-focus": "^7.18.4",
+            "@fluentui/react-window-provider": "^1.0.3",
             "@microsoft/load-themed-styles": "^1.10.26",
-            "@uifabric/foundation": "^7.9.26",
-            "@uifabric/icons": "^7.5.23",
+            "@uifabric/foundation": "^7.10.3",
+            "@uifabric/icons": "^7.7.2",
             "@uifabric/merge-styles": "^7.19.2",
-            "@uifabric/react-hooks": "^7.14.0",
+            "@uifabric/react-hooks": "^7.14.2",
             "@uifabric/set-version": "^7.0.24",
-            "@uifabric/styling": "^7.19.0",
-            "@uifabric/utilities": "^7.33.5",
+            "@uifabric/styling": "^7.20.2",
+            "@uifabric/utilities": "^7.34.1",
             "prop-types": "^15.7.2",
             "tslib": "^1.10.0"
           },
           "dependencies": {
             "@uifabric/icons": {
-              "version": "7.7.2",
-              "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.7.2.tgz",
-              "integrity": "sha512-3f223BZ5TXTF37J7lG+saGBY7U8vAi5HyMP58ccIoUafOj5551h5sovPFD/hVIYzYFhvT+/VpbUzF3vw+RARHA==",
+              "version": "7.8.0",
+              "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.8.0.tgz",
+              "integrity": "sha512-BNKJofCeVVNV4usMvmsiUiSguke84kBacq3bmG5waupL6Gmx0QayHV+gvjZWC5wTplYQ4yZ2CvE6rkmoH5hK9w==",
               "requires": {
                 "@uifabric/set-version": "^7.0.24",
-                "@uifabric/styling": "^7.20.2",
-                "@uifabric/utilities": "^7.34.1",
+                "@uifabric/styling": "^7.22.0",
+                "@uifabric/utilities": "^7.36.0",
                 "tslib": "^1.10.0"
-              },
-              "dependencies": {
-                "@uifabric/styling": {
-                  "version": "7.20.2",
-                  "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.20.2.tgz",
-                  "integrity": "sha512-FiGdeTsfJAs8qrqU2aLx70C2MT8YsjraMzr0HSiXKFQ2/LM4hwAYpbC41NIHzUemm63uA8NJRLHJlSv3S7V2SQ==",
-                  "requires": {
-                    "@fluentui/theme": "^1.7.6",
-                    "@microsoft/load-themed-styles": "^1.10.26",
-                    "@uifabric/merge-styles": "^7.19.2",
-                    "@uifabric/set-version": "^7.0.24",
-                    "@uifabric/utilities": "^7.34.1",
-                    "tslib": "^1.10.0"
-                  }
-                },
-                "@uifabric/utilities": {
-                  "version": "7.34.1",
-                  "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.34.1.tgz",
-                  "integrity": "sha512-gmQ94x/wj/my7zByFMXapLF5jDmRugWuBngx6gdvnw9rRme0YoN0G3S47vr3aw6ZTsXEnb6SJFnbtVyAGMmZRg==",
-                  "requires": {
-                    "@fluentui/dom-utilities": "^1.1.2",
-                    "@uifabric/merge-styles": "^7.19.2",
-                    "@uifabric/set-version": "^7.0.24",
-                    "prop-types": "^15.7.2",
-                    "tslib": "^1.10.0"
-                  }
-                }
               }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
             }
           }
         },
@@ -7250,6 +7841,14 @@
             "scheduler": "^0.19.1"
           }
         },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
         "scheduler": {
           "version": "0.19.1",
           "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
@@ -7259,10 +7858,43 @@
             "object-assign": "^4.1.1"
           }
         },
-        "whatwg-fetch": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
-          "integrity": "sha512-SA2KdOXATOroD3EBUYvcdugsusXS5YiQFqwskSbsp5b1gK8HpNi/YP0jcy/BDpdllp305HMnrsVf9K7Be9GiEQ=="
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        },
+        "validator": {
+          "version": "13.7.0",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+          "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        },
+        "z-schema": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.4.tgz",
+          "integrity": "sha512-YvBeW5RGNeNzKOUJs3rTL4+9rpcvHXt5I051FJbOcitV8bl40pEfcG0Q+dWSwS0/BIYrMZ/9HHoqLllMkFhD0w==",
+          "requires": {
+            "commander": "^2.7.1",
+            "lodash.get": "^4.4.2",
+            "lodash.isequal": "^4.5.0",
+            "validator": "^13.6.0"
+          }
         }
       }
     },
@@ -8358,9 +8990,9 @@
       "integrity": "sha512-HKJFVLCGrWQ/1unEw8JdaTxu6n3EUxmwTxJ6D0O1x0gD8joCsgoTWxEgevb7fp2XIogNjof3KEd+3bJoGne/nw=="
     },
     "@types/eslint": {
-      "version": "8.4.5",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.5.tgz",
-      "integrity": "sha512-dhsC09y1gpJWnK+Ff4SGvCuSnk9DaU0BJZSzOwa6GVSg65XtTugLBITDAAzRU5duGBoXBHpdR/9jHGxJjNflJQ==",
+      "version": "8.4.6",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
+      "integrity": "sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==",
       "requires": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -8549,8 +9181,7 @@
     "@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
-      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
-      "dev": true
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w=="
     },
     "@types/q": {
       "version": "1.5.5",
@@ -9454,9 +10085,9 @@
       }
     },
     "acorn": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A=="
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="
     },
     "acorn-globals": {
       "version": "4.3.4",
@@ -11389,8 +12020,7 @@
     "colors": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
-      "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
-      "dev": true
+      "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -13082,20 +13712,13 @@
       }
     },
     "dom-serializer": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
-      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "requires": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
-      },
-      "dependencies": {
-        "entities": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-          "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
-        }
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
       }
     },
     "dom-to-image": {
@@ -13132,21 +13755,21 @@
       }
     },
     "domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
       "requires": {
-        "domelementtype": "^2.2.0"
+        "domelementtype": "^2.3.0"
       }
     },
     "domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
       "requires": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.1"
       }
     },
     "dot-prop": {
@@ -13346,9 +13969,9 @@
       }
     },
     "entities": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
-      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
+      "integrity": "sha512-o4q/dYJlmyjP2zfnaWDUC6A3BQFmVTX+tZPezK7k0GLSU9QYCauscf5Y+qcEPzKL+EixVouYDgLQK5H9GrLpkg=="
     },
     "errno": {
       "version": "0.1.8",
@@ -14954,7 +15577,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -15952,25 +16574,24 @@
       }
     },
     "html-to-react": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.4.8.tgz",
-      "integrity": "sha512-BDOPUYTej5eiOco0V0wxJ5FS+Zckp2O0kb13X1SxQFzyusIeUmnxAK0Cl5M6692bmGBs1WBjh9qF3oQ2AJUZmg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.5.0.tgz",
+      "integrity": "sha512-tjihXBgaJZRRYzmkrJZ/Qf9jFayilFYcb+sJxXXE2BVLk2XsNrGeuNCVvhXmvREULZb9dz6NFTBC96DTR/lQCQ==",
       "requires": {
-        "domhandler": "^4.0",
-        "htmlparser2": "^7.0",
-        "lodash.camelcase": "^4.3.0",
-        "ramda": "^0.28.0"
+        "domhandler": "^5.0",
+        "htmlparser2": "^8.0",
+        "lodash.camelcase": "^4.3.0"
       }
     },
     "htmlparser2": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
-      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.1.tgz",
+      "integrity": "sha512-4lVbmc1diZC7GUJQtRQ5yBAeUCL1exyMwmForWkRLnwyzWBFxN633SALPMGYaWZvKe9j1pRZJpauvmxENSp/EA==",
       "requires": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.2",
-        "domutils": "^2.8.0",
-        "entities": "^3.0.1"
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "entities": "^4.3.0"
       }
     },
     "http-deceiver": {
@@ -16186,8 +16807,7 @@
     "import-lazy": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
-      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
-      "dev": true
+      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw=="
     },
     "import-local": {
       "version": "3.1.0",
@@ -18934,8 +19554,7 @@
     "jju": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
-      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
-      "dev": true
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA=="
     },
     "js-base64": {
       "version": "2.6.4",
@@ -19150,7 +19769,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -19853,7 +20471,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -20304,14 +20921,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.0.tgz",
       "integrity": "sha512-NTxMFQh6t5g2QWMlvZTWTxL1bmcqiCv0cs2lxTHhUbWEuxWCfvaVRZfjxN8i+T0VltVVGaVIdML8QEoBnlbaSw==",
-      "requires": {
-        "tslib": "^1.9.3"
-      }
-    },
-    "msalLegacy": {
-      "version": "npm:msal@1.4.12",
-      "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.12.tgz",
-      "integrity": "sha512-gjupwQ6nvNL6mZkl5NIXyUmZhTiEMRu5giNdgHMh8l5EPOnV2Xj6nukY1NIxFacSTkEYUSDB47Pej9GxDYf+1w==",
       "requires": {
         "tslib": "^1.9.3"
       }
@@ -23135,10 +23744,24 @@
       "requires": {
         "office-ui-fabric-react": "7.106.3",
         "react": "16.8.5",
-        "react-dom": "16.8.5",
-        "react-markdown": "^8.0.3"
+        "react-dom": "16.8.5"
       },
       "dependencies": {
+        "bail": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+          "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw=="
+        },
+        "is-buffer": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+          "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+        },
+        "is-plain-obj": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+          "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="
+        },
         "office-ui-fabric-react": {
           "version": "7.106.3",
           "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.106.3.tgz",
@@ -23159,18 +23782,113 @@
           }
         },
         "react-markdown": {
-          "version": "4.3.1",
-          "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-4.3.1.tgz",
-          "integrity": "sha512-HQlWFTbDxTtNY6bjgp3C3uv1h2xcjCSi1zAEzfBW9OwJJvENSYiLXWNXN5hHLsoqai7RnZiiHzcnWdXk2Splzw==",
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-8.0.3.tgz",
+          "integrity": "sha512-We36SfqaKoVNpN1QqsZwWSv/OZt5J15LNgTLWynwAN5b265hrQrsjMtlRNwUvS+YyR3yDM8HpTNc4pK9H/Gc0A==",
           "requires": {
-            "html-to-react": "^1.3.4",
-            "mdast-add-list-metadata": "1.0.1",
-            "prop-types": "^15.7.2",
-            "react-is": "^16.8.6",
-            "remark-parse": "^5.0.0",
-            "unified": "^6.1.5",
-            "unist-util-visit": "^1.3.0",
-            "xtend": "^4.0.1"
+            "@types/hast": "^2.0.0",
+            "@types/prop-types": "^15.0.0",
+            "@types/unist": "^2.0.0",
+            "comma-separated-tokens": "^2.0.0",
+            "hast-util-whitespace": "^2.0.0",
+            "prop-types": "^15.0.0",
+            "property-information": "^6.0.0",
+            "react-is": "^18.0.0",
+            "remark-parse": "^10.0.0",
+            "remark-rehype": "^10.0.0",
+            "space-separated-tokens": "^2.0.0",
+            "style-to-object": "^0.3.0",
+            "unified": "^10.0.0",
+            "unist-util-visit": "^4.0.0",
+            "vfile": "^5.0.0"
+          },
+          "dependencies": {
+            "react-is": {
+              "version": "18.2.0",
+              "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+              "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+            },
+            "remark-parse": {
+              "version": "10.0.1",
+              "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.1.tgz",
+              "integrity": "sha512-1fUyHr2jLsVOkhbvPRBJ5zTKZZyD6yZzYaWCS6BPBdQ8vEMBCH+9zNCDA6tET/zHCi/jLqjCWtlJZUPk+DbnFw==",
+              "requires": {
+                "@types/mdast": "^3.0.0",
+                "mdast-util-from-markdown": "^1.0.0",
+                "unified": "^10.0.0"
+              }
+            },
+            "unified": {
+              "version": "10.1.2",
+              "resolved": "https://registry.npmjs.org/unified/-/unified-10.1.2.tgz",
+              "integrity": "sha512-pUSWAi/RAnVy1Pif2kAoeWNBa3JVrx0MId2LASj8G+7AiHWoKZNTomq6LG326T68U7/e263X6fTdcXIy7XnF7Q==",
+              "requires": {
+                "@types/unist": "^2.0.0",
+                "bail": "^2.0.0",
+                "extend": "^3.0.0",
+                "is-buffer": "^2.0.0",
+                "is-plain-obj": "^4.0.0",
+                "trough": "^2.0.0",
+                "vfile": "^5.0.0"
+              }
+            },
+            "unist-util-visit": {
+              "version": "4.1.1",
+              "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-4.1.1.tgz",
+              "integrity": "sha512-n9KN3WV9k4h1DxYR1LoajgN93wpEi/7ZplVe02IoB4gH5ctI1AaF2670BLHQYbwj+pY83gFtyeySFiyMHJklrg==",
+              "requires": {
+                "@types/unist": "^2.0.0",
+                "unist-util-is": "^5.0.0",
+                "unist-util-visit-parents": "^5.1.1"
+              }
+            }
+          }
+        },
+        "trough": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
+          "integrity": "sha512-AqTiAOLcj85xS7vQ8QkAV41hPDIJ71XJB4RCUrzo/1GM2CQwhkJGaf9Hgr7BOugMRpgGUrqRg/DrBDl4H40+8g=="
+        },
+        "unist-util-is": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-5.1.1.tgz",
+          "integrity": "sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ=="
+        },
+        "unist-util-stringify-position": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-3.0.2.tgz",
+          "integrity": "sha512-7A6eiDCs9UtjcwZOcCpM4aPII3bAAGv13E96IkawkOAW0OhH+yRxtY0lzo8KiHpzEMfH7Q+FizUmwp8Iqy5EWg==",
+          "requires": {
+            "@types/unist": "^2.0.0"
+          }
+        },
+        "unist-util-visit-parents": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-5.1.1.tgz",
+          "integrity": "sha512-gks4baapT/kNRaWxuGkl5BIhoanZo7sC/cUT/JToSRNL1dYoXRFl75d++NkjYk4TAu2uv2Px+l8guMajogeuiw==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-is": "^5.0.0"
+          }
+        },
+        "vfile": {
+          "version": "5.3.4",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-5.3.4.tgz",
+          "integrity": "sha512-KI+7cnst03KbEyN1+JE504zF5bJBZa+J+CrevLeyIMq0aPU681I2rQ5p4PlnQ6exFtWiUrg26QUdFMnAKR6PIw==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "is-buffer": "^2.0.0",
+            "unist-util-stringify-position": "^3.0.0",
+            "vfile-message": "^3.0.0"
+          }
+        },
+        "vfile-message": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-3.1.2.tgz",
+          "integrity": "sha512-QjSNP6Yxzyycd4SVOtmKKyTsSvClqBPJcd00Z0zuPj3hOIjg0rUPG6DbFGPvUKRgYyaIWLPKpuEclcuvb3H8qA==",
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "unist-util-stringify-position": "^3.0.0"
           }
         }
       }
@@ -23219,11 +23937,6 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
-    },
-    "ramda": {
-      "version": "0.28.0",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.28.0.tgz",
-      "integrity": "sha512-9QnLuG/kPVgWvMQ4aODhsBUFKOUmnbUnsSXACv+NCQZcHbeb+v8Lodp8OVxtRULN1/xOyYLLaL6npE6dMq5QTA=="
     },
     "randombytes": {
       "version": "2.1.0",
@@ -25729,9 +26442,9 @@
       }
     },
     "terser": {
-      "version": "5.14.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.1.tgz",
-      "integrity": "sha512-+ahUAE+iheqBTDxXhTisdA8hgvbEG1hHOQ9xmNjeUJSoi6DU/gMrKNcfZjHkyY6Alnuyc+ikYJaxxfHkT3+WuQ==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
+      "integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
       "requires": {
         "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
@@ -25740,15 +26453,26 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz",
-      "integrity": "sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
+      "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
       "requires": {
-        "@jridgewell/trace-mapping": "^0.3.7",
+        "@jridgewell/trace-mapping": "^0.3.14",
         "jest-worker": "^27.4.5",
         "schema-utils": "^3.1.1",
         "serialize-javascript": "^6.0.0",
-        "terser": "^5.7.2"
+        "terser": "^5.14.1"
+      },
+      "dependencies": {
+        "@jridgewell/trace-mapping": {
+          "version": "0.3.15",
+          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
+          "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
+          "requires": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        }
       }
     },
     "test-exclude": {
@@ -25839,8 +26563,7 @@
     "timsort": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
-      "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==",
-      "dev": true
+      "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A=="
     },
     "tiny-lr": {
       "version": "0.2.1",
@@ -26459,8 +27182,7 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -26881,20 +27603,20 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "webpack": {
-      "version": "5.73.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.73.0.tgz",
-      "integrity": "sha512-svjudQRPPa0YiOYa2lM/Gacw0r6PvxptHj4FuEKQ2kX05ZLkjbVc5MnPs6its5j7IZljnIqSVo/OsY2X0IpHGA==",
+      "version": "5.74.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
+      "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/wasm-edit": "1.11.1",
         "@webassemblyjs/wasm-parser": "1.11.1",
-        "acorn": "^8.4.1",
+        "acorn": "^8.7.1",
         "acorn-import-assertions": "^1.7.6",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.9.3",
+        "enhanced-resolve": "^5.10.0",
         "es-module-lexer": "^0.9.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
@@ -26907,7 +27629,7 @@
         "schema-utils": "^3.1.0",
         "tapable": "^2.1.1",
         "terser-webpack-plugin": "^5.1.3",
-        "watchpack": "^2.3.1",
+        "watchpack": "^2.4.0",
         "webpack-sources": "^3.2.3"
       }
     },
@@ -28107,8 +28829,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "14.2.0",

--- a/SharePointFramework/ProgramWebParts/package-lock.json
+++ b/SharePointFramework/ProgramWebParts/package-lock.json
@@ -288,6 +288,21 @@
         }
       }
     },
+    "@azure/msal-browser": {
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-2.22.0.tgz",
+      "integrity": "sha512-ZpnbnzjYGRGHjWDPOLjSp47CQvhK927+W9avtLoNNCMudqs2dBfwj76lnJwObDE7TAKmCUueTiieglBiPb1mgQ==",
+      "requires": {
+        "@azure/msal-common": "^6.1.0"
+      },
+      "dependencies": {
+        "@azure/msal-common": {
+          "version": "6.4.0",
+          "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-6.4.0.tgz",
+          "integrity": "sha512-WZdgq9f9O8cbxGzdRwLLMM5xjmLJ2mdtuzgXeiGxIRkVVlJ9nZ6sWnDFKa2TX8j72UXD1IfL0p/RYNoTXYoGfg=="
+        }
+      }
+    },
     "@azure/msal-common": {
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-4.5.1.tgz",
@@ -2902,6 +2917,22 @@
         "isomorphic-fetch": "^2.2.1"
       }
     },
+    "@microsoft/microsoft-graph-clientV3": {
+      "version": "npm:@microsoft/microsoft-graph-client@3.0.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/microsoft-graph-client/-/microsoft-graph-client-3.0.2.tgz",
+      "integrity": "sha512-eYDiApYmiGsm1s1jfAa/rhB2xQCsX4pWt0vCTd1LZmiApMQfT/c0hXj2hvpuGz5GrcLdugbu05xB79rIV57Pjw==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "tslib": "^2.2.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
+        }
+      }
+    },
     "@microsoft/office-ui-fabric-react-bundle": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/@microsoft/office-ui-fabric-react-bundle/-/office-ui-fabric-react-bundle-1.12.1.tgz",
@@ -5245,6 +5276,524 @@
         "adal-angular": "1.0.16",
         "msal": "1.4.0",
         "tslib": "~1.10.0"
+      }
+    },
+    "@microsoft/sp-image-helper": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/@microsoft/sp-image-helper/-/sp-image-helper-1.15.2.tgz",
+      "integrity": "sha512-vNwymXZtGLFdgkNaV0j/Oi5t8Pz2FV9LgS2gnbAKuRzLSXtCSZ9hfP+5eC5LrVBWkSzxHC+8e+gAGaxqbr2asA==",
+      "requires": {
+        "@microsoft/office-ui-fabric-react-bundle": "1.15.2",
+        "@microsoft/sp-core-library": "1.15.2",
+        "@microsoft/sp-diagnostics": "1.15.2",
+        "@microsoft/sp-http": "1.15.2",
+        "@microsoft/sp-loader": "1.15.2",
+        "@microsoft/sp-lodash-subset": "1.15.2",
+        "@microsoft/sp-page-context": "1.15.2",
+        "tslib": "2.3.1"
+      },
+      "dependencies": {
+        "@fluentui/react-focus": {
+          "version": "7.18.9",
+          "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-7.18.9.tgz",
+          "integrity": "sha512-lATXTDEt+fXx2fQLFrJv2dSJr3hBqgmWkrqB00SAPXqN6jJQmmhzkiQG9+dugfk3JiobeEPCWm72L6USY31mXw==",
+          "requires": {
+            "@fluentui/keyboard-key": "^0.2.12",
+            "@uifabric/merge-styles": "^7.19.2",
+            "@uifabric/set-version": "^7.0.24",
+            "@uifabric/styling": "^7.22.0",
+            "@uifabric/utilities": "^7.36.0",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@fluentui/react-window-provider": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-1.0.3.tgz",
+          "integrity": "sha512-nFFhYlEWDSklAFjw87hQuOO5ZQP8or4J12ZJ7Glf+pcifRl0AySBshuGTJsTyZ0QyzgIeQYGSYf6wcPtycS0aA==",
+          "requires": {
+            "@uifabric/set-version": "^7.0.24",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@fluentui/theme": {
+          "version": "1.7.8",
+          "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-1.7.8.tgz",
+          "integrity": "sha512-RRXR7W+S+mgoZHso8KzpXhNx9n78WgZP2rYbjWejH91buPFp8ss+CqWxhTytBkd7QmRHOW5KhYGHbr0Oj4vA1g==",
+          "requires": {
+            "@uifabric/merge-styles": "^7.19.2",
+            "@uifabric/set-version": "^7.0.24",
+            "@uifabric/utilities": "^7.36.0",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@microsoft/microsoft-graph-client": {
+          "version": "1.7.2-spfx",
+          "resolved": "https://registry.npmjs.org/@microsoft/microsoft-graph-client/-/microsoft-graph-client-1.7.2-spfx.tgz",
+          "integrity": "sha512-BQN50r3tohWYOaQ0de7LJ5eCRjI6eg4RQqLhGDlgRmZIZhWzH0bhR6QBMmmxtYtwKWifhPhJSxYDW+cP67TJVw==",
+          "requires": {
+            "es6-promise": "^4.2.6",
+            "isomorphic-fetch": "^3.0.0",
+            "tslib": "^1.9.3"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@microsoft/office-ui-fabric-react-bundle": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/office-ui-fabric-react-bundle/-/office-ui-fabric-react-bundle-1.15.2.tgz",
+          "integrity": "sha512-iYQvIIRkjvwkoD9RHa3LUqbago9wSL0YUiifbQib7sG4fzl38Hmrht+WA0DPRPZbSwOWCsjzv7FXt1YWy9QxFQ==",
+          "requires": {
+            "@microsoft/sp-core-library": "1.15.2",
+            "@uifabric/icons": "7.7.2",
+            "office-ui-fabric-react": "7.185.7",
+            "react": "16.13.1",
+            "react-dom": "16.13.1",
+            "tslib": "2.3.1"
+          }
+        },
+        "@microsoft/sp-core-library": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.15.2.tgz",
+          "integrity": "sha512-sEotaC8+jUMZa5wc3lvtDYOGpAzzcl1fSZ0FnANIrJGyBC6tTqred0fzpkXptd4R0G/wi3746ivrccAOkzONkQ==",
+          "requires": {
+            "@microsoft/sp-lodash-subset": "1.15.2",
+            "@microsoft/sp-module-interfaces": "1.15.2",
+            "@microsoft/sp-odata-types": "1.15.2",
+            "tslib": "2.3.1"
+          }
+        },
+        "@microsoft/sp-diagnostics": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-diagnostics/-/sp-diagnostics-1.15.2.tgz",
+          "integrity": "sha512-9OJQwkdy3kqATQISpI4SG+5OUMB90KesupsWIE31aAyPcQiilh0XGhWmaYnCxCgGATAWcaYrFeptlDOTQNpuiA==",
+          "requires": {
+            "@microsoft/sp-core-library": "1.15.2",
+            "@microsoft/sp-lodash-subset": "1.15.2"
+          }
+        },
+        "@microsoft/sp-dynamic-data": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.15.2.tgz",
+          "integrity": "sha512-6ks5GUBSatsijQC8NUjaLjYCv4efAbEJcbSVTj8lySpTVCWu8aKsFtKB1b/Vc3I1g9Adq6z2e9sgTaPwm6HTlA==",
+          "requires": {
+            "@microsoft/sp-core-library": "1.15.2",
+            "@microsoft/sp-diagnostics": "1.15.2",
+            "@microsoft/sp-lodash-subset": "1.15.2",
+            "@microsoft/sp-module-interfaces": "1.15.2",
+            "tslib": "2.3.1"
+          }
+        },
+        "@microsoft/sp-http": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-http/-/sp-http-1.15.2.tgz",
+          "integrity": "sha512-vP3heQlje3YVTgyaGKZmrHksqmWP+zczuhQP116cCl6z52ZdUiuJIZpDcu+WGZaG1HdznAyrNGkkiZauTytIHw==",
+          "requires": {
+            "@azure/msal-browser": "2.22.0",
+            "@microsoft/microsoft-graph-client": "1.7.2-spfx",
+            "@microsoft/microsoft-graph-clientV3": "npm:@microsoft/microsoft-graph-client@3.0.2",
+            "@microsoft/sp-core-library": "1.15.2",
+            "@microsoft/sp-diagnostics": "1.15.2",
+            "@microsoft/sp-page-context": "1.15.2",
+            "@types/adal-angular": "1.0.1",
+            "adal-angular": "1.0.16",
+            "msalLegacy": "npm:msal@1.4.12",
+            "tslib": "2.3.1"
+          }
+        },
+        "@microsoft/sp-loader": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-loader/-/sp-loader-1.15.2.tgz",
+          "integrity": "sha512-w1EbIrP7AXH5Oq0cQwKW5OZUK6+c3amiImGUBSAlyHaEyC5/gSKMCDM0XJ0xkrihWs0ICWj/yX2o0aLaaReO3g==",
+          "requires": {
+            "@microsoft/office-ui-fabric-react-bundle": "1.15.2",
+            "@microsoft/sp-core-library": "1.15.2",
+            "@microsoft/sp-diagnostics": "1.15.2",
+            "@microsoft/sp-dynamic-data": "1.15.2",
+            "@microsoft/sp-http": "1.15.2",
+            "@microsoft/sp-lodash-subset": "1.15.2",
+            "@microsoft/sp-module-interfaces": "1.15.2",
+            "@microsoft/sp-odata-types": "1.15.2",
+            "@microsoft/sp-page-context": "1.15.2",
+            "@microsoft/sp-polyfills": "1.15.2",
+            "@rushstack/loader-raw-script": "1.3.228",
+            "@types/requirejs": "2.1.29",
+            "office-ui-fabric-react": "7.185.7",
+            "raw-loader": "~0.5.1",
+            "react": "16.13.1",
+            "react-dom": "16.13.1",
+            "requirejs": "2.3.6",
+            "tslib": "2.3.1"
+          }
+        },
+        "@microsoft/sp-lodash-subset": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.15.2.tgz",
+          "integrity": "sha512-XLqSltvz9W0hft76fylqVFNUIVS1sLjdUF3+lIQyj0g+4R9kDy9VsGhpxX7qLGAdW10yZ6Z40qfmBWgn8NN4MA==",
+          "requires": {
+            "@types/lodash": "4.14.117",
+            "tslib": "2.3.1"
+          }
+        },
+        "@microsoft/sp-module-interfaces": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.15.2.tgz",
+          "integrity": "sha512-JGOjK8f5ww+r4ax8TBAPDyZhDhGWVg1Jk4PvKE0cU6qjywM0DzWWkzHJFcyFXdjr8UE/+wzJOKasCCtu1RjWQg==",
+          "requires": {
+            "@rushstack/node-core-library": "3.45.5",
+            "z-schema": "4.2.4"
+          }
+        },
+        "@microsoft/sp-odata-types": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-odata-types/-/sp-odata-types-1.15.2.tgz",
+          "integrity": "sha512-Eb5MAWRAOkRAGXSdacg8p/KdSpYDJBNwyqNCZwrsCbgf/66h28oK0KUqQ6o8Hcy+vAZpa16x6bvpJQw5u1u8ZA==",
+          "requires": {
+            "tslib": "2.3.1"
+          }
+        },
+        "@microsoft/sp-page-context": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.15.2.tgz",
+          "integrity": "sha512-gq7q2vq5rzAwkOn4/jpdL/VgHCrtDWNZqjcU62W6iIW4TNT3nVykcof9llpghPcYx5dOuTtrRizXfa+vtQ+rzw==",
+          "requires": {
+            "@microsoft/sp-core-library": "1.15.2",
+            "@microsoft/sp-diagnostics": "1.15.2",
+            "@microsoft/sp-dynamic-data": "1.15.2",
+            "@microsoft/sp-lodash-subset": "1.15.2",
+            "@microsoft/sp-odata-types": "1.15.2",
+            "tslib": "2.3.1"
+          }
+        },
+        "@microsoft/sp-polyfills": {
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-polyfills/-/sp-polyfills-1.15.2.tgz",
+          "integrity": "sha512-XxbM/3p6yW/OIahcmzOVFQArKRxySHuDLSveSEdjIY3ycG8UWNX4QXDEd1tZchWCDz3vfO+j4aUsPPSOVW1Wcw==",
+          "requires": {
+            "es6-promise": "4.2.4",
+            "es6-symbol": "3.1.3",
+            "tslib": "2.3.1",
+            "whatwg-fetch": "2.0.3",
+            "whatwg-url": "4.7.1"
+          },
+          "dependencies": {
+            "es6-promise": {
+              "version": "4.2.4",
+              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+              "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+            },
+            "whatwg-fetch": {
+              "version": "2.0.3",
+              "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
+              "integrity": "sha512-SA2KdOXATOroD3EBUYvcdugsusXS5YiQFqwskSbsp5b1gK8HpNi/YP0jcy/BDpdllp305HMnrsVf9K7Be9GiEQ=="
+            },
+            "whatwg-url": {
+              "version": "4.7.1",
+              "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.7.1.tgz",
+              "integrity": "sha512-7rwLuNiZQbujtIu7Ibp7mq9X/Swqq90X0+zOWESoViRYcIOoQWtThlRX9K2YQHZLwGZv4CBOdTc4N3/SzAdb6w==",
+              "requires": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+              }
+            }
+          }
+        },
+        "@rushstack/loader-raw-script": {
+          "version": "1.3.228",
+          "resolved": "https://registry.npmjs.org/@rushstack/loader-raw-script/-/loader-raw-script-1.3.228.tgz",
+          "integrity": "sha512-yJPiwe4vCEmiZck9qUktYqVgExJV18C5wjO6Vv/l4ZWyI8WgYCei1eIcIJBtz//v3E18b8s6tKnSZDAUw1mhUQ==",
+          "requires": {
+            "loader-utils": "~1.1.0"
+          }
+        },
+        "@rushstack/node-core-library": {
+          "version": "3.45.5",
+          "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.45.5.tgz",
+          "integrity": "sha512-KbN7Hp9vH3bD3YJfv6RnVtzzTAwGYIBl7y2HQLY4WEQqRbvE3LgI78W9l9X+cTAXCX//p0EeoiUYNTFdqJrMZg==",
+          "requires": {
+            "@types/node": "12.20.24",
+            "colors": "~1.2.1",
+            "fs-extra": "~7.0.1",
+            "import-lazy": "~4.0.0",
+            "jju": "~1.4.0",
+            "resolve": "~1.17.0",
+            "semver": "~7.3.0",
+            "timsort": "~0.3.0",
+            "z-schema": "~5.0.2"
+          },
+          "dependencies": {
+            "z-schema": {
+              "version": "5.0.4",
+              "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.4.tgz",
+              "integrity": "sha512-gm/lx3hDzJNcLwseIeQVm1UcwhWIKpSB4NqH89pTBtFns4k/HDHudsICtvG05Bvw/Mv3jMyk700y5dadueLHdA==",
+              "requires": {
+                "commander": "^2.20.3",
+                "lodash.get": "^4.4.2",
+                "lodash.isequal": "^4.5.0",
+                "validator": "^13.7.0"
+              }
+            }
+          }
+        },
+        "@types/node": {
+          "version": "12.20.24",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
+          "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ=="
+        },
+        "@uifabric/foundation": {
+          "version": "7.10.8",
+          "resolved": "https://registry.npmjs.org/@uifabric/foundation/-/foundation-7.10.8.tgz",
+          "integrity": "sha512-u82qnYEkBx27oHk4VB5DDTGkUI7NYlchR30Cpt0UzPz2Dsep+oSlV3Z1vyS196BXNF8a4vtvOXrjN4vqzjVi7w==",
+          "requires": {
+            "@uifabric/merge-styles": "^7.19.2",
+            "@uifabric/set-version": "^7.0.24",
+            "@uifabric/styling": "^7.22.0",
+            "@uifabric/utilities": "^7.36.0",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@uifabric/icons": {
+          "version": "7.7.2",
+          "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.7.2.tgz",
+          "integrity": "sha512-3f223BZ5TXTF37J7lG+saGBY7U8vAi5HyMP58ccIoUafOj5551h5sovPFD/hVIYzYFhvT+/VpbUzF3vw+RARHA==",
+          "requires": {
+            "@uifabric/set-version": "^7.0.24",
+            "@uifabric/styling": "^7.20.2",
+            "@uifabric/utilities": "^7.34.1",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@uifabric/react-hooks": {
+          "version": "7.15.2",
+          "resolved": "https://registry.npmjs.org/@uifabric/react-hooks/-/react-hooks-7.15.2.tgz",
+          "integrity": "sha512-ngil4McS64HDCrMRyzOtXuyve4zOxBOX20DkYLa6rIBM3if+sUzNBodiwZ6RZz/6hBZW1nqpVmz7eEMnqEL4JA==",
+          "requires": {
+            "@fluentui/react-window-provider": "^1.0.3",
+            "@uifabric/set-version": "^7.0.24",
+            "@uifabric/utilities": "^7.36.0",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@uifabric/styling": {
+          "version": "7.22.0",
+          "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.22.0.tgz",
+          "integrity": "sha512-y2SntsWVKq7cabcwHDastfw9V4ahMdJr0idsrOlmU3vqWFTXwP99qIwYLcqrFVV4Kjb6F4T/JrnzNQW+bBlRGg==",
+          "requires": {
+            "@fluentui/theme": "^1.7.8",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "@uifabric/merge-styles": "^7.19.2",
+            "@uifabric/set-version": "^7.0.24",
+            "@uifabric/utilities": "^7.36.0",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@uifabric/utilities": {
+          "version": "7.36.0",
+          "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.36.0.tgz",
+          "integrity": "sha512-Y+bu0Wc5nbS39Exy/WxhgwP7ZlNOJj2UTcgYd8Nk+hQiDkUZvt3pSCIbn10Cz/59WrCr0htctvF5Xkt+BkpICA==",
+          "requires": {
+            "@fluentui/dom-utilities": "^1.1.2",
+            "@uifabric/merge-styles": "^7.19.2",
+            "@uifabric/set-version": "^7.0.24",
+            "prop-types": "^15.7.2",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "isomorphic-fetch": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+          "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+          "requires": {
+            "node-fetch": "^2.6.1",
+            "whatwg-fetch": "^3.4.1"
+          }
+        },
+        "msalLegacy": {
+          "version": "npm:msal@1.4.12",
+          "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.12.tgz",
+          "integrity": "sha512-gjupwQ6nvNL6mZkl5NIXyUmZhTiEMRu5giNdgHMh8l5EPOnV2Xj6nukY1NIxFacSTkEYUSDB47Pej9GxDYf+1w==",
+          "requires": {
+            "tslib": "^1.9.3"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "office-ui-fabric-react": {
+          "version": "7.185.7",
+          "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.185.7.tgz",
+          "integrity": "sha512-JiWkrjT/T6OG63ATu6RUlME2PBe4pgxQOwRTOjvbsaq8mlyd9i21ImgwkTEvcNXJpx+4w0bJiuQTcdwSMyf6qA==",
+          "requires": {
+            "@fluentui/date-time-utilities": "^7.9.1",
+            "@fluentui/react-focus": "^7.18.4",
+            "@fluentui/react-window-provider": "^1.0.3",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "@uifabric/foundation": "^7.10.3",
+            "@uifabric/icons": "^7.7.2",
+            "@uifabric/merge-styles": "^7.19.2",
+            "@uifabric/react-hooks": "^7.14.2",
+            "@uifabric/set-version": "^7.0.24",
+            "@uifabric/styling": "^7.20.2",
+            "@uifabric/utilities": "^7.34.1",
+            "prop-types": "^15.7.2",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "react": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
+          "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2"
+          }
+        },
+        "react-dom": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
+          "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1",
+            "prop-types": "^15.6.2",
+            "scheduler": "^0.19.1"
+          }
+        },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
+        "scheduler": {
+          "version": "0.19.1",
+          "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+          "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
+          "requires": {
+            "loose-envify": "^1.1.0",
+            "object-assign": "^4.1.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        },
+        "validator": {
+          "version": "13.7.0",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+          "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        },
+        "z-schema": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.4.tgz",
+          "integrity": "sha512-YvBeW5RGNeNzKOUJs3rTL4+9rpcvHXt5I051FJbOcitV8bl40pEfcG0Q+dWSwS0/BIYrMZ/9HHoqLllMkFhD0w==",
+          "requires": {
+            "commander": "^2.7.1",
+            "lodash.get": "^4.4.2",
+            "lodash.isequal": "^4.5.0",
+            "validator": "^13.6.0"
+          }
+        }
       }
     },
     "@microsoft/sp-loader": {
@@ -8135,9 +8684,9 @@
       "integrity": "sha512-HKJFVLCGrWQ/1unEw8JdaTxu6n3EUxmwTxJ6D0O1x0gD8joCsgoTWxEgevb7fp2XIogNjof3KEd+3bJoGne/nw=="
     },
     "@types/eslint": {
-      "version": "8.4.5",
-      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.5.tgz",
-      "integrity": "sha512-dhsC09y1gpJWnK+Ff4SGvCuSnk9DaU0BJZSzOwa6GVSg65XtTugLBITDAAzRU5duGBoXBHpdR/9jHGxJjNflJQ==",
+      "version": "8.4.6",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.4.6.tgz",
+      "integrity": "sha512-/fqTbjxyFUaYNO7VcW5g+4npmqVACz1bB7RTHYuLj+PRjw9hrCwrUXVQFpChUS0JsyEFvMZ7U/PfmvWgxJhI9g==",
       "requires": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -9238,9 +9787,9 @@
       }
     },
     "acorn": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A=="
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w=="
     },
     "acorn-dynamic-import": {
       "version": "3.0.0",
@@ -11190,8 +11739,7 @@
     "colors": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.5.tgz",
-      "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg==",
-      "dev": true
+      "integrity": "sha512-erNRLao/Y3Fv54qUa0LBB+//Uf3YwMUmdJinN20yMXm9zdKKqH9wt7R9IIVZ+K7ShzfpLV/Zg8+VyrBJYB4lpg=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -14805,7 +15353,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -16037,8 +16584,7 @@
     "import-lazy": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
-      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
-      "dev": true
+      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw=="
     },
     "import-local": {
       "version": "3.1.0",
@@ -18785,8 +19331,7 @@
     "jju": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
-      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
-      "dev": true
+      "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA=="
     },
     "js-base64": {
       "version": "2.6.4",
@@ -19001,7 +19546,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -19704,7 +20248,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -20155,14 +20698,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.0.tgz",
       "integrity": "sha512-NTxMFQh6t5g2QWMlvZTWTxL1bmcqiCv0cs2lxTHhUbWEuxWCfvaVRZfjxN8i+T0VltVVGaVIdML8QEoBnlbaSw==",
-      "requires": {
-        "tslib": "^1.9.3"
-      }
-    },
-    "msalLegacy": {
-      "version": "npm:msal@1.4.12",
-      "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.12.tgz",
-      "integrity": "sha512-gjupwQ6nvNL6mZkl5NIXyUmZhTiEMRu5giNdgHMh8l5EPOnV2Xj6nukY1NIxFacSTkEYUSDB47Pej9GxDYf+1w==",
       "requires": {
         "tslib": "^1.9.3"
       }
@@ -22512,21 +23047,23 @@
         "webpack": "^5.70.0"
       },
       "dependencies": {
-        "@fluentui/theme": {
-          "version": "1.7.6",
-          "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-1.7.6.tgz",
-          "integrity": "sha512-AcQSs3MpCxl63HE/4iJMwNVvPB6e0evvMMvELSK1sro199j1t14WSwTPwTHYsBeBxdX3mH9NixrB02tzXgJK6A==",
+        "@fluentui/react-focus": {
+          "version": "7.18.9",
+          "resolved": "https://registry.npmjs.org/@fluentui/react-focus/-/react-focus-7.18.9.tgz",
+          "integrity": "sha512-lATXTDEt+fXx2fQLFrJv2dSJr3hBqgmWkrqB00SAPXqN6jJQmmhzkiQG9+dugfk3JiobeEPCWm72L6USY31mXw==",
           "requires": {
+            "@fluentui/keyboard-key": "^0.2.12",
             "@uifabric/merge-styles": "^7.19.2",
             "@uifabric/set-version": "^7.0.24",
-            "@uifabric/utilities": "^7.34.1",
+            "@uifabric/styling": "^7.22.0",
+            "@uifabric/utilities": "^7.36.0",
             "tslib": "^1.10.0"
           },
           "dependencies": {
             "@uifabric/utilities": {
-              "version": "7.34.1",
-              "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.34.1.tgz",
-              "integrity": "sha512-gmQ94x/wj/my7zByFMXapLF5jDmRugWuBngx6gdvnw9rRme0YoN0G3S47vr3aw6ZTsXEnb6SJFnbtVyAGMmZRg==",
+              "version": "7.36.0",
+              "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.36.0.tgz",
+              "integrity": "sha512-Y+bu0Wc5nbS39Exy/WxhgwP7ZlNOJj2UTcgYd8Nk+hQiDkUZvt3pSCIbn10Cz/59WrCr0htctvF5Xkt+BkpICA==",
               "requires": {
                 "@fluentui/dom-utilities": "^1.1.2",
                 "@uifabric/merge-styles": "^7.19.2",
@@ -22534,82 +23071,172 @@
                 "prop-types": "^15.7.2",
                 "tslib": "^1.10.0"
               }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@fluentui/react-window-provider": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/@fluentui/react-window-provider/-/react-window-provider-1.0.3.tgz",
+          "integrity": "sha512-nFFhYlEWDSklAFjw87hQuOO5ZQP8or4J12ZJ7Glf+pcifRl0AySBshuGTJsTyZ0QyzgIeQYGSYf6wcPtycS0aA==",
+          "requires": {
+            "@uifabric/set-version": "^7.0.24",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@fluentui/theme": {
+          "version": "1.7.8",
+          "resolved": "https://registry.npmjs.org/@fluentui/theme/-/theme-1.7.8.tgz",
+          "integrity": "sha512-RRXR7W+S+mgoZHso8KzpXhNx9n78WgZP2rYbjWejH91buPFp8ss+CqWxhTytBkd7QmRHOW5KhYGHbr0Oj4vA1g==",
+          "requires": {
+            "@uifabric/merge-styles": "^7.19.2",
+            "@uifabric/set-version": "^7.0.24",
+            "@uifabric/utilities": "^7.36.0",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "@uifabric/utilities": {
+              "version": "7.36.0",
+              "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.36.0.tgz",
+              "integrity": "sha512-Y+bu0Wc5nbS39Exy/WxhgwP7ZlNOJj2UTcgYd8Nk+hQiDkUZvt3pSCIbn10Cz/59WrCr0htctvF5Xkt+BkpICA==",
+              "requires": {
+                "@fluentui/dom-utilities": "^1.1.2",
+                "@uifabric/merge-styles": "^7.19.2",
+                "@uifabric/set-version": "^7.0.24",
+                "prop-types": "^15.7.2",
+                "tslib": "^1.10.0"
+              }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@microsoft/microsoft-graph-client": {
+          "version": "1.7.2-spfx",
+          "resolved": "https://registry.npmjs.org/@microsoft/microsoft-graph-client/-/microsoft-graph-client-1.7.2-spfx.tgz",
+          "integrity": "sha512-BQN50r3tohWYOaQ0de7LJ5eCRjI6eg4RQqLhGDlgRmZIZhWzH0bhR6QBMmmxtYtwKWifhPhJSxYDW+cP67TJVw==",
+          "requires": {
+            "es6-promise": "^4.2.6",
+            "isomorphic-fetch": "^3.0.0",
+            "tslib": "^1.9.3"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
             }
           }
         },
         "@microsoft/office-ui-fabric-react-bundle": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/office-ui-fabric-react-bundle/-/office-ui-fabric-react-bundle-1.14.0.tgz",
-          "integrity": "sha512-JhRBHdJrnYjOctHwCH3QBJL2aqD+nrHSK7E2CUMz8mfbUR1xneZRYBwT5EKnpyMT+llx3wuWDkK+7N4zwYOPJg==",
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/office-ui-fabric-react-bundle/-/office-ui-fabric-react-bundle-1.15.2.tgz",
+          "integrity": "sha512-iYQvIIRkjvwkoD9RHa3LUqbago9wSL0YUiifbQib7sG4fzl38Hmrht+WA0DPRPZbSwOWCsjzv7FXt1YWy9QxFQ==",
           "requires": {
-            "@microsoft/sp-core-library": "1.14.0",
-            "@uifabric/icons": "7.6.2",
-            "office-ui-fabric-react": "7.180.0",
+            "@microsoft/sp-core-library": "1.15.2",
+            "@uifabric/icons": "7.7.2",
+            "office-ui-fabric-react": "7.185.7",
             "react": "16.13.1",
             "react-dom": "16.13.1",
-            "tslib": "~1.10.0"
+            "tslib": "2.3.1"
           },
           "dependencies": {
             "@microsoft/sp-core-library": {
-              "version": "1.14.0",
-              "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.14.0.tgz",
-              "integrity": "sha512-+Do8o0Y6vdCxW+kVZbdWtcU+h+zR9raV9eCPjEBPj4xScB+Y26AE7H8lebAdgNh7rB136JTV+d6/l94FlKKabQ==",
+              "version": "1.15.2",
+              "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.15.2.tgz",
+              "integrity": "sha512-sEotaC8+jUMZa5wc3lvtDYOGpAzzcl1fSZ0FnANIrJGyBC6tTqred0fzpkXptd4R0G/wi3746ivrccAOkzONkQ==",
               "requires": {
-                "@microsoft/sp-lodash-subset": "1.14.0",
-                "@microsoft/sp-module-interfaces": "1.14.0",
-                "@microsoft/sp-odata-types": "1.14.0",
-                "tslib": "~1.10.0"
+                "@microsoft/sp-lodash-subset": "1.15.2",
+                "@microsoft/sp-module-interfaces": "1.15.2",
+                "@microsoft/sp-odata-types": "1.15.2",
+                "tslib": "2.3.1"
               }
             },
             "@microsoft/sp-lodash-subset": {
-              "version": "1.14.0",
-              "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.14.0.tgz",
-              "integrity": "sha512-0vY+JuqAsUT9AMEMvMHhcNCtqV1RThxxgMPhzR1lauzKSNkMeFXYwHRsVR6p3BZfaQ2nyeyG5811Wlwchs5SKA==",
+              "version": "1.15.2",
+              "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.15.2.tgz",
+              "integrity": "sha512-XLqSltvz9W0hft76fylqVFNUIVS1sLjdUF3+lIQyj0g+4R9kDy9VsGhpxX7qLGAdW10yZ6Z40qfmBWgn8NN4MA==",
               "requires": {
                 "@types/lodash": "4.14.117",
-                "tslib": "~1.10.0"
+                "tslib": "2.3.1"
               }
             },
             "@uifabric/icons": {
-              "version": "7.6.2",
-              "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.6.2.tgz",
-              "integrity": "sha512-q7jEIwB5Tt2Egw9fqdgNPlBqBQ6hNNMQ3qs5y4S4YETRluB+AQTdKbrbYMsXo3Pm0FsJnRfiDojMzxusGX+MWA==",
+              "version": "7.7.2",
+              "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.7.2.tgz",
+              "integrity": "sha512-3f223BZ5TXTF37J7lG+saGBY7U8vAi5HyMP58ccIoUafOj5551h5sovPFD/hVIYzYFhvT+/VpbUzF3vw+RARHA==",
               "requires": {
                 "@uifabric/set-version": "^7.0.24",
-                "@uifabric/styling": "^7.20.0",
+                "@uifabric/styling": "^7.20.2",
+                "@uifabric/utilities": "^7.34.1",
                 "tslib": "^1.10.0"
+              },
+              "dependencies": {
+                "tslib": {
+                  "version": "1.14.1",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                  "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
               }
             },
             "@uifabric/utilities": {
-              "version": "7.34.1",
-              "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.34.1.tgz",
-              "integrity": "sha512-gmQ94x/wj/my7zByFMXapLF5jDmRugWuBngx6gdvnw9rRme0YoN0G3S47vr3aw6ZTsXEnb6SJFnbtVyAGMmZRg==",
+              "version": "7.36.0",
+              "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.36.0.tgz",
+              "integrity": "sha512-Y+bu0Wc5nbS39Exy/WxhgwP7ZlNOJj2UTcgYd8Nk+hQiDkUZvt3pSCIbn10Cz/59WrCr0htctvF5Xkt+BkpICA==",
               "requires": {
                 "@fluentui/dom-utilities": "^1.1.2",
                 "@uifabric/merge-styles": "^7.19.2",
                 "@uifabric/set-version": "^7.0.24",
                 "prop-types": "^15.7.2",
                 "tslib": "^1.10.0"
+              },
+              "dependencies": {
+                "tslib": {
+                  "version": "1.14.1",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                  "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
               }
             },
             "office-ui-fabric-react": {
-              "version": "7.180.0",
-              "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.180.0.tgz",
-              "integrity": "sha512-bayPgo2gyJEqYOOwsGT8KZtOj3yWe252PqMFw0Gx/2TKOXweQ/btror1D2SGxins8RogTtwhkmvgTbnWYMn2jw==",
+              "version": "7.185.7",
+              "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.185.7.tgz",
+              "integrity": "sha512-JiWkrjT/T6OG63ATu6RUlME2PBe4pgxQOwRTOjvbsaq8mlyd9i21ImgwkTEvcNXJpx+4w0bJiuQTcdwSMyf6qA==",
               "requires": {
                 "@fluentui/date-time-utilities": "^7.9.1",
-                "@fluentui/react-focus": "^7.18.1",
-                "@fluentui/react-window-provider": "^1.0.2",
+                "@fluentui/react-focus": "^7.18.4",
+                "@fluentui/react-window-provider": "^1.0.3",
                 "@microsoft/load-themed-styles": "^1.10.26",
-                "@uifabric/foundation": "^7.10.1",
-                "@uifabric/icons": "^7.6.2",
+                "@uifabric/foundation": "^7.10.3",
+                "@uifabric/icons": "^7.7.2",
                 "@uifabric/merge-styles": "^7.19.2",
-                "@uifabric/react-hooks": "^7.14.0",
+                "@uifabric/react-hooks": "^7.14.2",
                 "@uifabric/set-version": "^7.0.24",
-                "@uifabric/styling": "^7.20.0",
-                "@uifabric/utilities": "^7.33.5",
+                "@uifabric/styling": "^7.20.2",
+                "@uifabric/utilities": "^7.34.1",
                 "prop-types": "^15.7.2",
                 "tslib": "^1.10.0"
+              },
+              "dependencies": {
+                "tslib": {
+                  "version": "1.14.1",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                  "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
               }
             },
             "react": {
@@ -22636,272 +23263,293 @@
           }
         },
         "@microsoft/sp-component-base": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/sp-component-base/-/sp-component-base-1.14.0.tgz",
-          "integrity": "sha512-o9D4iVU9uu1dIxxqK3ScOiZHm7npKaLeyCxckwiMCdJRMsp00RBiyDhAjBykZci/WHs2t14sxEDPvIkQJon+3g==",
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-component-base/-/sp-component-base-1.15.2.tgz",
+          "integrity": "sha512-Uf7nZ6Ohf68FQ4ABDs+8GVyqAb87rybaTJh/xBYz7DAjUUk/G1urq9wqTih8hSaHGog4P7ovuVeBKNYpmOU3Tg==",
           "requires": {
-            "@microsoft/office-ui-fabric-react-bundle": "1.14.0",
-            "@microsoft/sp-core-library": "1.14.0",
-            "@microsoft/sp-diagnostics": "1.14.0",
-            "@microsoft/sp-dynamic-data": "1.14.0",
-            "@microsoft/sp-http": "1.14.0",
-            "@microsoft/sp-lodash-subset": "1.14.0",
-            "@microsoft/sp-module-interfaces": "1.14.0",
-            "@microsoft/sp-page-context": "1.14.0",
-            "tslib": "~1.10.0"
+            "@microsoft/office-ui-fabric-react-bundle": "1.15.2",
+            "@microsoft/sp-core-library": "1.15.2",
+            "@microsoft/sp-diagnostics": "1.15.2",
+            "@microsoft/sp-dynamic-data": "1.15.2",
+            "@microsoft/sp-http": "1.15.2",
+            "@microsoft/sp-lodash-subset": "1.15.2",
+            "@microsoft/sp-module-interfaces": "1.15.2",
+            "@microsoft/sp-page-context": "1.15.2",
+            "tslib": "2.3.1"
           },
           "dependencies": {
             "@microsoft/sp-core-library": {
-              "version": "1.14.0",
-              "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.14.0.tgz",
-              "integrity": "sha512-+Do8o0Y6vdCxW+kVZbdWtcU+h+zR9raV9eCPjEBPj4xScB+Y26AE7H8lebAdgNh7rB136JTV+d6/l94FlKKabQ==",
+              "version": "1.15.2",
+              "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.15.2.tgz",
+              "integrity": "sha512-sEotaC8+jUMZa5wc3lvtDYOGpAzzcl1fSZ0FnANIrJGyBC6tTqred0fzpkXptd4R0G/wi3746ivrccAOkzONkQ==",
               "requires": {
-                "@microsoft/sp-lodash-subset": "1.14.0",
-                "@microsoft/sp-module-interfaces": "1.14.0",
-                "@microsoft/sp-odata-types": "1.14.0",
-                "tslib": "~1.10.0"
+                "@microsoft/sp-lodash-subset": "1.15.2",
+                "@microsoft/sp-module-interfaces": "1.15.2",
+                "@microsoft/sp-odata-types": "1.15.2",
+                "tslib": "2.3.1"
               }
             },
             "@microsoft/sp-lodash-subset": {
-              "version": "1.14.0",
-              "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.14.0.tgz",
-              "integrity": "sha512-0vY+JuqAsUT9AMEMvMHhcNCtqV1RThxxgMPhzR1lauzKSNkMeFXYwHRsVR6p3BZfaQ2nyeyG5811Wlwchs5SKA==",
+              "version": "1.15.2",
+              "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.15.2.tgz",
+              "integrity": "sha512-XLqSltvz9W0hft76fylqVFNUIVS1sLjdUF3+lIQyj0g+4R9kDy9VsGhpxX7qLGAdW10yZ6Z40qfmBWgn8NN4MA==",
               "requires": {
                 "@types/lodash": "4.14.117",
-                "tslib": "~1.10.0"
+                "tslib": "2.3.1"
               }
             },
             "@microsoft/sp-page-context": {
-              "version": "1.14.0",
-              "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.14.0.tgz",
-              "integrity": "sha512-WaT3wFY+MoYNjc6Z+cO5uxS7whRG8wzWtNzIGyxi6pLPxSpYyYfmZaDwsf563+hHUldGJpZIwwh0Fy096ysiPg==",
+              "version": "1.15.2",
+              "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.15.2.tgz",
+              "integrity": "sha512-gq7q2vq5rzAwkOn4/jpdL/VgHCrtDWNZqjcU62W6iIW4TNT3nVykcof9llpghPcYx5dOuTtrRizXfa+vtQ+rzw==",
               "requires": {
-                "@microsoft/sp-core-library": "1.14.0",
-                "@microsoft/sp-diagnostics": "1.14.0",
-                "@microsoft/sp-dynamic-data": "1.14.0",
-                "@microsoft/sp-lodash-subset": "1.14.0",
-                "@microsoft/sp-odata-types": "1.14.0",
-                "tslib": "~1.10.0"
+                "@microsoft/sp-core-library": "1.15.2",
+                "@microsoft/sp-diagnostics": "1.15.2",
+                "@microsoft/sp-dynamic-data": "1.15.2",
+                "@microsoft/sp-lodash-subset": "1.15.2",
+                "@microsoft/sp-odata-types": "1.15.2",
+                "tslib": "2.3.1"
               }
             }
           }
         },
         "@microsoft/sp-diagnostics": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/sp-diagnostics/-/sp-diagnostics-1.14.0.tgz",
-          "integrity": "sha512-vuv1JidY7m+uneiYo6c90AIZUub7QCwBqby1gi7x/d9dV7vFfUfdkvZA1on7lvSOx32DVedX/d0W83mvZQRtTA==",
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-diagnostics/-/sp-diagnostics-1.15.2.tgz",
+          "integrity": "sha512-9OJQwkdy3kqATQISpI4SG+5OUMB90KesupsWIE31aAyPcQiilh0XGhWmaYnCxCgGATAWcaYrFeptlDOTQNpuiA==",
           "requires": {
-            "@microsoft/sp-core-library": "1.14.0",
-            "@microsoft/sp-lodash-subset": "1.14.0"
+            "@microsoft/sp-core-library": "1.15.2",
+            "@microsoft/sp-lodash-subset": "1.15.2"
           },
           "dependencies": {
             "@microsoft/sp-core-library": {
-              "version": "1.14.0",
-              "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.14.0.tgz",
-              "integrity": "sha512-+Do8o0Y6vdCxW+kVZbdWtcU+h+zR9raV9eCPjEBPj4xScB+Y26AE7H8lebAdgNh7rB136JTV+d6/l94FlKKabQ==",
+              "version": "1.15.2",
+              "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.15.2.tgz",
+              "integrity": "sha512-sEotaC8+jUMZa5wc3lvtDYOGpAzzcl1fSZ0FnANIrJGyBC6tTqred0fzpkXptd4R0G/wi3746ivrccAOkzONkQ==",
               "requires": {
-                "@microsoft/sp-lodash-subset": "1.14.0",
-                "@microsoft/sp-module-interfaces": "1.14.0",
-                "@microsoft/sp-odata-types": "1.14.0",
-                "tslib": "~1.10.0"
+                "@microsoft/sp-lodash-subset": "1.15.2",
+                "@microsoft/sp-module-interfaces": "1.15.2",
+                "@microsoft/sp-odata-types": "1.15.2",
+                "tslib": "2.3.1"
               }
             },
             "@microsoft/sp-lodash-subset": {
-              "version": "1.14.0",
-              "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.14.0.tgz",
-              "integrity": "sha512-0vY+JuqAsUT9AMEMvMHhcNCtqV1RThxxgMPhzR1lauzKSNkMeFXYwHRsVR6p3BZfaQ2nyeyG5811Wlwchs5SKA==",
+              "version": "1.15.2",
+              "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.15.2.tgz",
+              "integrity": "sha512-XLqSltvz9W0hft76fylqVFNUIVS1sLjdUF3+lIQyj0g+4R9kDy9VsGhpxX7qLGAdW10yZ6Z40qfmBWgn8NN4MA==",
               "requires": {
                 "@types/lodash": "4.14.117",
-                "tslib": "~1.10.0"
+                "tslib": "2.3.1"
               }
             }
           }
         },
         "@microsoft/sp-dynamic-data": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.14.0.tgz",
-          "integrity": "sha512-zwFB1G/8HDX7BqIvJqQd7vlTM1d2PfvHEFucZX6fkqoaC05j0dk4Ah0LJFKY767Ke8RD3VfijyakV/gJCkvw6g==",
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-dynamic-data/-/sp-dynamic-data-1.15.2.tgz",
+          "integrity": "sha512-6ks5GUBSatsijQC8NUjaLjYCv4efAbEJcbSVTj8lySpTVCWu8aKsFtKB1b/Vc3I1g9Adq6z2e9sgTaPwm6HTlA==",
           "requires": {
-            "@microsoft/sp-core-library": "1.14.0",
-            "@microsoft/sp-diagnostics": "1.14.0",
-            "@microsoft/sp-lodash-subset": "1.14.0",
-            "@microsoft/sp-module-interfaces": "1.14.0",
-            "tslib": "~1.10.0"
+            "@microsoft/sp-core-library": "1.15.2",
+            "@microsoft/sp-diagnostics": "1.15.2",
+            "@microsoft/sp-lodash-subset": "1.15.2",
+            "@microsoft/sp-module-interfaces": "1.15.2",
+            "tslib": "2.3.1"
           },
           "dependencies": {
             "@microsoft/sp-core-library": {
-              "version": "1.14.0",
-              "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.14.0.tgz",
-              "integrity": "sha512-+Do8o0Y6vdCxW+kVZbdWtcU+h+zR9raV9eCPjEBPj4xScB+Y26AE7H8lebAdgNh7rB136JTV+d6/l94FlKKabQ==",
+              "version": "1.15.2",
+              "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.15.2.tgz",
+              "integrity": "sha512-sEotaC8+jUMZa5wc3lvtDYOGpAzzcl1fSZ0FnANIrJGyBC6tTqred0fzpkXptd4R0G/wi3746ivrccAOkzONkQ==",
               "requires": {
-                "@microsoft/sp-lodash-subset": "1.14.0",
-                "@microsoft/sp-module-interfaces": "1.14.0",
-                "@microsoft/sp-odata-types": "1.14.0",
-                "tslib": "~1.10.0"
+                "@microsoft/sp-lodash-subset": "1.15.2",
+                "@microsoft/sp-module-interfaces": "1.15.2",
+                "@microsoft/sp-odata-types": "1.15.2",
+                "tslib": "2.3.1"
               }
             },
             "@microsoft/sp-lodash-subset": {
-              "version": "1.14.0",
-              "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.14.0.tgz",
-              "integrity": "sha512-0vY+JuqAsUT9AMEMvMHhcNCtqV1RThxxgMPhzR1lauzKSNkMeFXYwHRsVR6p3BZfaQ2nyeyG5811Wlwchs5SKA==",
+              "version": "1.15.2",
+              "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.15.2.tgz",
+              "integrity": "sha512-XLqSltvz9W0hft76fylqVFNUIVS1sLjdUF3+lIQyj0g+4R9kDy9VsGhpxX7qLGAdW10yZ6Z40qfmBWgn8NN4MA==",
               "requires": {
                 "@types/lodash": "4.14.117",
-                "tslib": "~1.10.0"
+                "tslib": "2.3.1"
               }
             }
           }
         },
         "@microsoft/sp-http": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/sp-http/-/sp-http-1.14.0.tgz",
-          "integrity": "sha512-Md/azXAMSD/DlBBKGuV30y/5lNTdPZ4XKXGc6PcPp8h5mMyqEewdqaCrDhvvDPXZzoNyqYoH1ingdU4W6LRMRA==",
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-http/-/sp-http-1.15.2.tgz",
+          "integrity": "sha512-vP3heQlje3YVTgyaGKZmrHksqmWP+zczuhQP116cCl6z52ZdUiuJIZpDcu+WGZaG1HdznAyrNGkkiZauTytIHw==",
           "requires": {
-            "@microsoft/microsoft-graph-client": "~1.1.0",
-            "@microsoft/sp-core-library": "1.14.0",
-            "@microsoft/sp-diagnostics": "1.14.0",
+            "@azure/msal-browser": "2.22.0",
+            "@microsoft/microsoft-graph-client": "1.7.2-spfx",
+            "@microsoft/microsoft-graph-clientV3": "npm:@microsoft/microsoft-graph-client@3.0.2",
+            "@microsoft/sp-core-library": "1.15.2",
+            "@microsoft/sp-diagnostics": "1.15.2",
+            "@microsoft/sp-page-context": "1.15.2",
             "@types/adal-angular": "1.0.1",
             "adal-angular": "1.0.16",
-            "msal": "1.4.13",
             "msalLegacy": "npm:msal@1.4.12",
-            "tslib": "~1.10.0"
+            "tslib": "2.3.1"
           },
           "dependencies": {
             "@microsoft/sp-core-library": {
-              "version": "1.14.0",
-              "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.14.0.tgz",
-              "integrity": "sha512-+Do8o0Y6vdCxW+kVZbdWtcU+h+zR9raV9eCPjEBPj4xScB+Y26AE7H8lebAdgNh7rB136JTV+d6/l94FlKKabQ==",
+              "version": "1.15.2",
+              "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.15.2.tgz",
+              "integrity": "sha512-sEotaC8+jUMZa5wc3lvtDYOGpAzzcl1fSZ0FnANIrJGyBC6tTqred0fzpkXptd4R0G/wi3746ivrccAOkzONkQ==",
               "requires": {
-                "@microsoft/sp-lodash-subset": "1.14.0",
-                "@microsoft/sp-module-interfaces": "1.14.0",
-                "@microsoft/sp-odata-types": "1.14.0",
-                "tslib": "~1.10.0"
+                "@microsoft/sp-lodash-subset": "1.15.2",
+                "@microsoft/sp-module-interfaces": "1.15.2",
+                "@microsoft/sp-odata-types": "1.15.2",
+                "tslib": "2.3.1"
               }
             },
             "@microsoft/sp-lodash-subset": {
-              "version": "1.14.0",
-              "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.14.0.tgz",
-              "integrity": "sha512-0vY+JuqAsUT9AMEMvMHhcNCtqV1RThxxgMPhzR1lauzKSNkMeFXYwHRsVR6p3BZfaQ2nyeyG5811Wlwchs5SKA==",
+              "version": "1.15.2",
+              "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.15.2.tgz",
+              "integrity": "sha512-XLqSltvz9W0hft76fylqVFNUIVS1sLjdUF3+lIQyj0g+4R9kDy9VsGhpxX7qLGAdW10yZ6Z40qfmBWgn8NN4MA==",
               "requires": {
                 "@types/lodash": "4.14.117",
-                "tslib": "~1.10.0"
+                "tslib": "2.3.1"
+              }
+            },
+            "@microsoft/sp-page-context": {
+              "version": "1.15.2",
+              "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.15.2.tgz",
+              "integrity": "sha512-gq7q2vq5rzAwkOn4/jpdL/VgHCrtDWNZqjcU62W6iIW4TNT3nVykcof9llpghPcYx5dOuTtrRizXfa+vtQ+rzw==",
+              "requires": {
+                "@microsoft/sp-core-library": "1.15.2",
+                "@microsoft/sp-diagnostics": "1.15.2",
+                "@microsoft/sp-dynamic-data": "1.15.2",
+                "@microsoft/sp-lodash-subset": "1.15.2",
+                "@microsoft/sp-odata-types": "1.15.2",
+                "tslib": "2.3.1"
               }
             }
           }
         },
         "@microsoft/sp-loader": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/sp-loader/-/sp-loader-1.14.0.tgz",
-          "integrity": "sha512-2Hp8UKaEbIcmcJ7b8HuwzrMYQ3y5z3icVDEST2rzWs+rc+QgINJERF17v8Q35h6d8PSPSevqwwPycAax2T41ZA==",
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-loader/-/sp-loader-1.15.2.tgz",
+          "integrity": "sha512-w1EbIrP7AXH5Oq0cQwKW5OZUK6+c3amiImGUBSAlyHaEyC5/gSKMCDM0XJ0xkrihWs0ICWj/yX2o0aLaaReO3g==",
           "requires": {
-            "@microsoft/office-ui-fabric-react-bundle": "1.14.0",
-            "@microsoft/sp-core-library": "1.14.0",
-            "@microsoft/sp-diagnostics": "1.14.0",
-            "@microsoft/sp-dynamic-data": "1.14.0",
-            "@microsoft/sp-http": "1.14.0",
-            "@microsoft/sp-lodash-subset": "1.14.0",
-            "@microsoft/sp-module-interfaces": "1.14.0",
-            "@microsoft/sp-odata-types": "1.14.0",
-            "@microsoft/sp-page-context": "1.14.0",
-            "@microsoft/sp-polyfills": "1.14.0",
-            "@rushstack/loader-raw-script": "1.3.207",
+            "@microsoft/office-ui-fabric-react-bundle": "1.15.2",
+            "@microsoft/sp-core-library": "1.15.2",
+            "@microsoft/sp-diagnostics": "1.15.2",
+            "@microsoft/sp-dynamic-data": "1.15.2",
+            "@microsoft/sp-http": "1.15.2",
+            "@microsoft/sp-lodash-subset": "1.15.2",
+            "@microsoft/sp-module-interfaces": "1.15.2",
+            "@microsoft/sp-odata-types": "1.15.2",
+            "@microsoft/sp-page-context": "1.15.2",
+            "@microsoft/sp-polyfills": "1.15.2",
+            "@rushstack/loader-raw-script": "1.3.228",
             "@types/requirejs": "2.1.29",
-            "office-ui-fabric-react": "7.180.0",
+            "office-ui-fabric-react": "7.185.7",
             "raw-loader": "~0.5.1",
             "react": "16.13.1",
             "react-dom": "16.13.1",
             "requirejs": "2.3.6",
-            "tslib": "~1.10.0"
+            "tslib": "2.3.1"
           },
           "dependencies": {
             "@microsoft/sp-core-library": {
-              "version": "1.14.0",
-              "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.14.0.tgz",
-              "integrity": "sha512-+Do8o0Y6vdCxW+kVZbdWtcU+h+zR9raV9eCPjEBPj4xScB+Y26AE7H8lebAdgNh7rB136JTV+d6/l94FlKKabQ==",
+              "version": "1.15.2",
+              "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.15.2.tgz",
+              "integrity": "sha512-sEotaC8+jUMZa5wc3lvtDYOGpAzzcl1fSZ0FnANIrJGyBC6tTqred0fzpkXptd4R0G/wi3746ivrccAOkzONkQ==",
               "requires": {
-                "@microsoft/sp-lodash-subset": "1.14.0",
-                "@microsoft/sp-module-interfaces": "1.14.0",
-                "@microsoft/sp-odata-types": "1.14.0",
-                "tslib": "~1.10.0"
+                "@microsoft/sp-lodash-subset": "1.15.2",
+                "@microsoft/sp-module-interfaces": "1.15.2",
+                "@microsoft/sp-odata-types": "1.15.2",
+                "tslib": "2.3.1"
               }
             },
             "@microsoft/sp-lodash-subset": {
-              "version": "1.14.0",
-              "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.14.0.tgz",
-              "integrity": "sha512-0vY+JuqAsUT9AMEMvMHhcNCtqV1RThxxgMPhzR1lauzKSNkMeFXYwHRsVR6p3BZfaQ2nyeyG5811Wlwchs5SKA==",
+              "version": "1.15.2",
+              "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.15.2.tgz",
+              "integrity": "sha512-XLqSltvz9W0hft76fylqVFNUIVS1sLjdUF3+lIQyj0g+4R9kDy9VsGhpxX7qLGAdW10yZ6Z40qfmBWgn8NN4MA==",
               "requires": {
                 "@types/lodash": "4.14.117",
-                "tslib": "~1.10.0"
+                "tslib": "2.3.1"
               }
             },
             "@microsoft/sp-page-context": {
-              "version": "1.14.0",
-              "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.14.0.tgz",
-              "integrity": "sha512-WaT3wFY+MoYNjc6Z+cO5uxS7whRG8wzWtNzIGyxi6pLPxSpYyYfmZaDwsf563+hHUldGJpZIwwh0Fy096ysiPg==",
+              "version": "1.15.2",
+              "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.15.2.tgz",
+              "integrity": "sha512-gq7q2vq5rzAwkOn4/jpdL/VgHCrtDWNZqjcU62W6iIW4TNT3nVykcof9llpghPcYx5dOuTtrRizXfa+vtQ+rzw==",
               "requires": {
-                "@microsoft/sp-core-library": "1.14.0",
-                "@microsoft/sp-diagnostics": "1.14.0",
-                "@microsoft/sp-dynamic-data": "1.14.0",
-                "@microsoft/sp-lodash-subset": "1.14.0",
-                "@microsoft/sp-odata-types": "1.14.0",
-                "tslib": "~1.10.0"
+                "@microsoft/sp-core-library": "1.15.2",
+                "@microsoft/sp-diagnostics": "1.15.2",
+                "@microsoft/sp-dynamic-data": "1.15.2",
+                "@microsoft/sp-lodash-subset": "1.15.2",
+                "@microsoft/sp-odata-types": "1.15.2",
+                "tslib": "2.3.1"
               }
             },
             "@uifabric/icons": {
-              "version": "7.7.2",
-              "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.7.2.tgz",
-              "integrity": "sha512-3f223BZ5TXTF37J7lG+saGBY7U8vAi5HyMP58ccIoUafOj5551h5sovPFD/hVIYzYFhvT+/VpbUzF3vw+RARHA==",
+              "version": "7.8.0",
+              "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.8.0.tgz",
+              "integrity": "sha512-BNKJofCeVVNV4usMvmsiUiSguke84kBacq3bmG5waupL6Gmx0QayHV+gvjZWC5wTplYQ4yZ2CvE6rkmoH5hK9w==",
               "requires": {
                 "@uifabric/set-version": "^7.0.24",
-                "@uifabric/styling": "^7.20.2",
-                "@uifabric/utilities": "^7.34.1",
+                "@uifabric/styling": "^7.22.0",
+                "@uifabric/utilities": "^7.36.0",
                 "tslib": "^1.10.0"
               },
               "dependencies": {
-                "@uifabric/styling": {
-                  "version": "7.20.2",
-                  "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.20.2.tgz",
-                  "integrity": "sha512-FiGdeTsfJAs8qrqU2aLx70C2MT8YsjraMzr0HSiXKFQ2/LM4hwAYpbC41NIHzUemm63uA8NJRLHJlSv3S7V2SQ==",
-                  "requires": {
-                    "@fluentui/theme": "^1.7.6",
-                    "@microsoft/load-themed-styles": "^1.10.26",
-                    "@uifabric/merge-styles": "^7.19.2",
-                    "@uifabric/set-version": "^7.0.24",
-                    "@uifabric/utilities": "^7.34.1",
-                    "tslib": "^1.10.0"
-                  }
+                "tslib": {
+                  "version": "1.14.1",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                  "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
               }
             },
             "@uifabric/utilities": {
-              "version": "7.34.1",
-              "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.34.1.tgz",
-              "integrity": "sha512-gmQ94x/wj/my7zByFMXapLF5jDmRugWuBngx6gdvnw9rRme0YoN0G3S47vr3aw6ZTsXEnb6SJFnbtVyAGMmZRg==",
+              "version": "7.36.0",
+              "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.36.0.tgz",
+              "integrity": "sha512-Y+bu0Wc5nbS39Exy/WxhgwP7ZlNOJj2UTcgYd8Nk+hQiDkUZvt3pSCIbn10Cz/59WrCr0htctvF5Xkt+BkpICA==",
               "requires": {
                 "@fluentui/dom-utilities": "^1.1.2",
                 "@uifabric/merge-styles": "^7.19.2",
                 "@uifabric/set-version": "^7.0.24",
                 "prop-types": "^15.7.2",
                 "tslib": "^1.10.0"
+              },
+              "dependencies": {
+                "tslib": {
+                  "version": "1.14.1",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                  "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
               }
             },
             "office-ui-fabric-react": {
-              "version": "7.180.0",
-              "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.180.0.tgz",
-              "integrity": "sha512-bayPgo2gyJEqYOOwsGT8KZtOj3yWe252PqMFw0Gx/2TKOXweQ/btror1D2SGxins8RogTtwhkmvgTbnWYMn2jw==",
+              "version": "7.185.7",
+              "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.185.7.tgz",
+              "integrity": "sha512-JiWkrjT/T6OG63ATu6RUlME2PBe4pgxQOwRTOjvbsaq8mlyd9i21ImgwkTEvcNXJpx+4w0bJiuQTcdwSMyf6qA==",
               "requires": {
                 "@fluentui/date-time-utilities": "^7.9.1",
-                "@fluentui/react-focus": "^7.18.1",
-                "@fluentui/react-window-provider": "^1.0.2",
+                "@fluentui/react-focus": "^7.18.4",
+                "@fluentui/react-window-provider": "^1.0.3",
                 "@microsoft/load-themed-styles": "^1.10.26",
-                "@uifabric/foundation": "^7.10.1",
-                "@uifabric/icons": "^7.6.2",
+                "@uifabric/foundation": "^7.10.3",
+                "@uifabric/icons": "^7.7.2",
                 "@uifabric/merge-styles": "^7.19.2",
-                "@uifabric/react-hooks": "^7.14.0",
+                "@uifabric/react-hooks": "^7.14.2",
                 "@uifabric/set-version": "^7.0.24",
-                "@uifabric/styling": "^7.20.0",
-                "@uifabric/utilities": "^7.33.5",
+                "@uifabric/styling": "^7.20.2",
+                "@uifabric/utilities": "^7.34.1",
                 "prop-types": "^15.7.2",
                 "tslib": "^1.10.0"
+              },
+              "dependencies": {
+                "tslib": {
+                  "version": "1.14.1",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                  "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
               }
             },
             "react": {
@@ -22928,41 +23576,59 @@
           }
         },
         "@microsoft/sp-module-interfaces": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.14.0.tgz",
-          "integrity": "sha512-OPQW3vVVADSYTTXUXmBMh3/TAPqiCunPd7Ggfk+fZC82qyI5s7hLCkto9BJ2IkqfxLeOB9/4qxXfQbrrS6wVPg=="
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-module-interfaces/-/sp-module-interfaces-1.15.2.tgz",
+          "integrity": "sha512-JGOjK8f5ww+r4ax8TBAPDyZhDhGWVg1Jk4PvKE0cU6qjywM0DzWWkzHJFcyFXdjr8UE/+wzJOKasCCtu1RjWQg==",
+          "requires": {
+            "@rushstack/node-core-library": "3.45.5",
+            "z-schema": "4.2.4"
+          }
         },
         "@microsoft/sp-odata-types": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/sp-odata-types/-/sp-odata-types-1.14.0.tgz",
-          "integrity": "sha512-SmznMgMaeo0JRq6BBUl+SMPVvJbzECOZtpVowrR5Kz06QIn7pfAL21q1ZwYH9tRJvPDo/awSDXW5qIzt/1jamA==",
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-odata-types/-/sp-odata-types-1.15.2.tgz",
+          "integrity": "sha512-Eb5MAWRAOkRAGXSdacg8p/KdSpYDJBNwyqNCZwrsCbgf/66h28oK0KUqQ6o8Hcy+vAZpa16x6bvpJQw5u1u8ZA==",
           "requires": {
-            "tslib": "~1.10.0"
+            "tslib": "2.3.1"
           }
         },
         "@microsoft/sp-polyfills": {
-          "version": "1.14.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/sp-polyfills/-/sp-polyfills-1.14.0.tgz",
-          "integrity": "sha512-TJbYNfsdk1qjODzKQnn5+wcfJm2xBb8uqHNPCxAsoz6+e02HSNkdVM5rAjEq5Sh1Czcn4JIe3AXrz3DJMQnMBA==",
+          "version": "1.15.2",
+          "resolved": "https://registry.npmjs.org/@microsoft/sp-polyfills/-/sp-polyfills-1.15.2.tgz",
+          "integrity": "sha512-XxbM/3p6yW/OIahcmzOVFQArKRxySHuDLSveSEdjIY3ycG8UWNX4QXDEd1tZchWCDz3vfO+j4aUsPPSOVW1Wcw==",
           "requires": {
             "es6-promise": "4.2.4",
             "es6-symbol": "3.1.3",
-            "tslib": "~1.10.0",
+            "tslib": "2.3.1",
             "whatwg-fetch": "2.0.3",
             "whatwg-url": "4.7.1"
           },
           "dependencies": {
+            "es6-promise": {
+              "version": "4.2.4",
+              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+              "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
+            },
             "whatwg-fetch": {
               "version": "2.0.3",
               "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz",
               "integrity": "sha512-SA2KdOXATOroD3EBUYvcdugsusXS5YiQFqwskSbsp5b1gK8HpNi/YP0jcy/BDpdllp305HMnrsVf9K7Be9GiEQ=="
+            },
+            "whatwg-url": {
+              "version": "4.7.1",
+              "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-4.7.1.tgz",
+              "integrity": "sha512-7rwLuNiZQbujtIu7Ibp7mq9X/Swqq90X0+zOWESoViRYcIOoQWtThlRX9K2YQHZLwGZv4CBOdTc4N3/SzAdb6w==",
+              "requires": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
+              }
             }
           }
         },
         "@microsoft/teams-js": {
-          "version": "1.10.0",
-          "resolved": "https://registry.npmjs.org/@microsoft/teams-js/-/teams-js-1.10.0.tgz",
-          "integrity": "sha512-g8+ox5nWe9IjDFRHnCXk7mkQRGjHFcAMSn7JpUtJfuWu2tDUmXAp/4LUSgewvBbbmy68YtS+KTFPHRyUoTzk6w=="
+          "version": "1.12.1",
+          "resolved": "https://registry.npmjs.org/@microsoft/teams-js/-/teams-js-1.12.1.tgz",
+          "integrity": "sha512-BRy6vZOseN9F/MG0NWTojYpenuo9XlZ4AfAvwnsG+C36UDPPgW0skWlZ6ub+7RBPhOHcxz8sNg2uHOdGRebWkQ=="
         },
         "@pnp/polyfill-ie11": {
           "version": "1.0.1",
@@ -22976,15 +23642,15 @@
           }
         },
         "@pnp/spfx-property-controls": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/@pnp/spfx-property-controls/-/spfx-property-controls-3.7.0.tgz",
-          "integrity": "sha512-50INPEYUoYXPyh5pFnGZTW+AL9hN+rtI7W9f0vjLl2ou7QB3JkpkCVvT5LsKRhDNDivHSxZZ7JAJGp8QhnvNXA==",
+          "version": "3.9.0",
+          "resolved": "https://registry.npmjs.org/@pnp/spfx-property-controls/-/spfx-property-controls-3.9.0.tgz",
+          "integrity": "sha512-mfN2+8JuMMf9SXu85QygSjx7GnUwZyigBRsYIjpbcCO8dGNW6Llu71a1Wog9B+22aQZBiALi2aw7bA6uLY6WlQ==",
           "requires": {
-            "@microsoft/sp-core-library": "1.14.0",
-            "@microsoft/sp-lodash-subset": "1.14.0",
-            "@microsoft/sp-office-ui-fabric-core": "1.14.0",
-            "@microsoft/sp-property-pane": "1.14.0",
-            "@microsoft/sp-webpart-base": "1.14.0",
+            "@microsoft/sp-core-library": "1.15.2",
+            "@microsoft/sp-lodash-subset": "1.15.2",
+            "@microsoft/sp-office-ui-fabric-core": "1.15.2",
+            "@microsoft/sp-property-pane": "1.15.2",
+            "@microsoft/sp-webpart-base": "1.15.2",
             "@monaco-editor/loader": "^1.2.0",
             "@pnp/common": "1.3.11",
             "@pnp/logging": "1.3.11",
@@ -22997,188 +23663,94 @@
             "lodash.omit": "4.5.0",
             "markdown-to-jsx": "^6.11.4",
             "monaco-editor": "^0.32.1",
-            "office-ui-fabric-react": "7.174.1",
+            "office-ui-fabric-react": "7.185.7",
             "react": "16.13.1",
             "react-ace": "5.8.0",
             "react-dom": "16.13.1"
           },
           "dependencies": {
             "@microsoft/sp-core-library": {
-              "version": "1.14.0",
-              "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.14.0.tgz",
-              "integrity": "sha512-+Do8o0Y6vdCxW+kVZbdWtcU+h+zR9raV9eCPjEBPj4xScB+Y26AE7H8lebAdgNh7rB136JTV+d6/l94FlKKabQ==",
+              "version": "1.15.2",
+              "resolved": "https://registry.npmjs.org/@microsoft/sp-core-library/-/sp-core-library-1.15.2.tgz",
+              "integrity": "sha512-sEotaC8+jUMZa5wc3lvtDYOGpAzzcl1fSZ0FnANIrJGyBC6tTqred0fzpkXptd4R0G/wi3746ivrccAOkzONkQ==",
               "requires": {
-                "@microsoft/sp-lodash-subset": "1.14.0",
-                "@microsoft/sp-module-interfaces": "1.14.0",
-                "@microsoft/sp-odata-types": "1.14.0",
-                "tslib": "~1.10.0"
+                "@microsoft/sp-lodash-subset": "1.15.2",
+                "@microsoft/sp-module-interfaces": "1.15.2",
+                "@microsoft/sp-odata-types": "1.15.2",
+                "tslib": "2.3.1"
               }
             },
             "@microsoft/sp-lodash-subset": {
-              "version": "1.14.0",
-              "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.14.0.tgz",
-              "integrity": "sha512-0vY+JuqAsUT9AMEMvMHhcNCtqV1RThxxgMPhzR1lauzKSNkMeFXYwHRsVR6p3BZfaQ2nyeyG5811Wlwchs5SKA==",
+              "version": "1.15.2",
+              "resolved": "https://registry.npmjs.org/@microsoft/sp-lodash-subset/-/sp-lodash-subset-1.15.2.tgz",
+              "integrity": "sha512-XLqSltvz9W0hft76fylqVFNUIVS1sLjdUF3+lIQyj0g+4R9kDy9VsGhpxX7qLGAdW10yZ6Z40qfmBWgn8NN4MA==",
               "requires": {
                 "@types/lodash": "4.14.117",
-                "tslib": "~1.10.0"
+                "tslib": "2.3.1"
               }
             },
             "@microsoft/sp-office-ui-fabric-core": {
-              "version": "1.14.0",
-              "resolved": "https://registry.npmjs.org/@microsoft/sp-office-ui-fabric-core/-/sp-office-ui-fabric-core-1.14.0.tgz",
-              "integrity": "sha512-FCkyTyM7CiTjXxSDiVLpiqUAR9Pxg+PdTh+KBDvtVBYLeQJI0Zqrwl833SSNl9mixD6doaKwri27LxhCGEN1nQ==",
+              "version": "1.15.2",
+              "resolved": "https://registry.npmjs.org/@microsoft/sp-office-ui-fabric-core/-/sp-office-ui-fabric-core-1.15.2.tgz",
+              "integrity": "sha512-/AO94rEE8NJqyVRiKkTzmdVbwqht8fVULvsikpJUTGd4Cczp8nUs9YsTwGxbdlW9Mu3gQ7CM9Rq7J24pNmEJWA==",
               "requires": {
-                "office-ui-fabric-core": "9.6.1-fluent2",
-                "tslib": "~1.10.0"
+                "office-ui-fabric-core": "11.0.1",
+                "tslib": "2.3.1"
               }
             },
             "@microsoft/sp-page-context": {
-              "version": "1.14.0",
-              "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.14.0.tgz",
-              "integrity": "sha512-WaT3wFY+MoYNjc6Z+cO5uxS7whRG8wzWtNzIGyxi6pLPxSpYyYfmZaDwsf563+hHUldGJpZIwwh0Fy096ysiPg==",
+              "version": "1.15.2",
+              "resolved": "https://registry.npmjs.org/@microsoft/sp-page-context/-/sp-page-context-1.15.2.tgz",
+              "integrity": "sha512-gq7q2vq5rzAwkOn4/jpdL/VgHCrtDWNZqjcU62W6iIW4TNT3nVykcof9llpghPcYx5dOuTtrRizXfa+vtQ+rzw==",
               "requires": {
-                "@microsoft/sp-core-library": "1.14.0",
-                "@microsoft/sp-diagnostics": "1.14.0",
-                "@microsoft/sp-dynamic-data": "1.14.0",
-                "@microsoft/sp-lodash-subset": "1.14.0",
-                "@microsoft/sp-odata-types": "1.14.0",
-                "tslib": "~1.10.0"
+                "@microsoft/sp-core-library": "1.15.2",
+                "@microsoft/sp-diagnostics": "1.15.2",
+                "@microsoft/sp-dynamic-data": "1.15.2",
+                "@microsoft/sp-lodash-subset": "1.15.2",
+                "@microsoft/sp-odata-types": "1.15.2",
+                "tslib": "2.3.1"
               }
             },
             "@microsoft/sp-property-pane": {
-              "version": "1.14.0",
-              "resolved": "https://registry.npmjs.org/@microsoft/sp-property-pane/-/sp-property-pane-1.14.0.tgz",
-              "integrity": "sha512-1xwpz7RPSQCWnzYNWYPQsFARYp6JlseU2wsXpk02Pmzt9W+Zg0551BUvoCmU9OWeLX0zWjvsLO8sh2zYZkWe/w==",
+              "version": "1.15.2",
+              "resolved": "https://registry.npmjs.org/@microsoft/sp-property-pane/-/sp-property-pane-1.15.2.tgz",
+              "integrity": "sha512-V78aUGZa4gM/MMmOg14iWYPoknHe9jrormvTXpltjcIvipRm5H5bRr6D4SfuzJ7uu0roJ53zfGddCDdvn05ezA==",
               "requires": {
-                "@microsoft/office-ui-fabric-react-bundle": "1.14.0",
-                "@microsoft/sp-component-base": "1.14.0",
-                "@microsoft/sp-core-library": "1.14.0",
-                "@microsoft/sp-diagnostics": "1.14.0",
-                "@microsoft/sp-dynamic-data": "1.14.0",
-                "@microsoft/sp-lodash-subset": "1.14.0",
-                "office-ui-fabric-react": "7.180.0",
+                "@microsoft/office-ui-fabric-react-bundle": "1.15.2",
+                "@microsoft/sp-component-base": "1.15.2",
+                "@microsoft/sp-core-library": "1.15.2",
+                "@microsoft/sp-diagnostics": "1.15.2",
+                "@microsoft/sp-dynamic-data": "1.15.2",
+                "@microsoft/sp-image-helper": "1.15.2",
+                "@microsoft/sp-lodash-subset": "1.15.2",
+                "@microsoft/sp-page-context": "1.15.2",
+                "office-ui-fabric-react": "7.185.7",
                 "react": "16.13.1",
                 "react-dom": "16.13.1",
-                "tslib": "~1.10.0"
-              },
-              "dependencies": {
-                "@uifabric/icons": {
-                  "version": "7.7.2",
-                  "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.7.2.tgz",
-                  "integrity": "sha512-3f223BZ5TXTF37J7lG+saGBY7U8vAi5HyMP58ccIoUafOj5551h5sovPFD/hVIYzYFhvT+/VpbUzF3vw+RARHA==",
-                  "requires": {
-                    "@uifabric/set-version": "^7.0.24",
-                    "@uifabric/styling": "^7.20.2",
-                    "@uifabric/utilities": "^7.34.1",
-                    "tslib": "^1.10.0"
-                  },
-                  "dependencies": {
-                    "@uifabric/styling": {
-                      "version": "7.20.2",
-                      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.20.2.tgz",
-                      "integrity": "sha512-FiGdeTsfJAs8qrqU2aLx70C2MT8YsjraMzr0HSiXKFQ2/LM4hwAYpbC41NIHzUemm63uA8NJRLHJlSv3S7V2SQ==",
-                      "requires": {
-                        "@fluentui/theme": "^1.7.6",
-                        "@microsoft/load-themed-styles": "^1.10.26",
-                        "@uifabric/merge-styles": "^7.19.2",
-                        "@uifabric/set-version": "^7.0.24",
-                        "@uifabric/utilities": "^7.34.1",
-                        "tslib": "^1.10.0"
-                      }
-                    }
-                  }
-                },
-                "office-ui-fabric-react": {
-                  "version": "7.180.0",
-                  "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.180.0.tgz",
-                  "integrity": "sha512-bayPgo2gyJEqYOOwsGT8KZtOj3yWe252PqMFw0Gx/2TKOXweQ/btror1D2SGxins8RogTtwhkmvgTbnWYMn2jw==",
-                  "requires": {
-                    "@fluentui/date-time-utilities": "^7.9.1",
-                    "@fluentui/react-focus": "^7.18.1",
-                    "@fluentui/react-window-provider": "^1.0.2",
-                    "@microsoft/load-themed-styles": "^1.10.26",
-                    "@uifabric/foundation": "^7.10.1",
-                    "@uifabric/icons": "^7.6.2",
-                    "@uifabric/merge-styles": "^7.19.2",
-                    "@uifabric/react-hooks": "^7.14.0",
-                    "@uifabric/set-version": "^7.0.24",
-                    "@uifabric/styling": "^7.20.0",
-                    "@uifabric/utilities": "^7.33.5",
-                    "prop-types": "^15.7.2",
-                    "tslib": "^1.10.0"
-                  }
-                }
+                "tslib": "2.3.1"
               }
             },
             "@microsoft/sp-webpart-base": {
-              "version": "1.14.0",
-              "resolved": "https://registry.npmjs.org/@microsoft/sp-webpart-base/-/sp-webpart-base-1.14.0.tgz",
-              "integrity": "sha512-plQ03RxEiSZVDDCc5s12MbnicjdJ2WpgJZwwYTb+y8I4LqiNrdM9V4ls53KZWQbCiYntgm2phHcdHXzeas/DBg==",
+              "version": "1.15.2",
+              "resolved": "https://registry.npmjs.org/@microsoft/sp-webpart-base/-/sp-webpart-base-1.15.2.tgz",
+              "integrity": "sha512-dFQBwmRg81EDyV5RzA7JEhtdKyjk3vjKZBn3pWvaY/4Yo+oGyzKdQ8o/z2A9OO6KwXXlXkFiGJgoau57c/EALQ==",
               "requires": {
-                "@microsoft/sp-component-base": "1.14.0",
-                "@microsoft/sp-core-library": "1.14.0",
-                "@microsoft/sp-diagnostics": "1.14.0",
-                "@microsoft/sp-dynamic-data": "1.14.0",
-                "@microsoft/sp-http": "1.14.0",
-                "@microsoft/sp-loader": "1.14.0",
-                "@microsoft/sp-lodash-subset": "1.14.0",
-                "@microsoft/sp-module-interfaces": "1.14.0",
-                "@microsoft/sp-page-context": "1.14.0",
-                "@microsoft/sp-property-pane": "1.14.0",
-                "@microsoft/teams-js": "1.10.0",
+                "@microsoft/sp-component-base": "1.15.2",
+                "@microsoft/sp-core-library": "1.15.2",
+                "@microsoft/sp-diagnostics": "1.15.2",
+                "@microsoft/sp-dynamic-data": "1.15.2",
+                "@microsoft/sp-http": "1.15.2",
+                "@microsoft/sp-loader": "1.15.2",
+                "@microsoft/sp-lodash-subset": "1.15.2",
+                "@microsoft/sp-module-interfaces": "1.15.2",
+                "@microsoft/sp-page-context": "1.15.2",
+                "@microsoft/sp-property-pane": "1.15.2",
+                "@microsoft/teams-js": "1.12.1",
                 "@types/office-js": "1.0.36",
-                "office-ui-fabric-react": "7.180.0",
+                "office-ui-fabric-react": "7.185.7",
                 "react": "16.13.1",
                 "react-dom": "16.13.1",
-                "tslib": "~1.10.0"
-              },
-              "dependencies": {
-                "@uifabric/icons": {
-                  "version": "7.7.2",
-                  "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.7.2.tgz",
-                  "integrity": "sha512-3f223BZ5TXTF37J7lG+saGBY7U8vAi5HyMP58ccIoUafOj5551h5sovPFD/hVIYzYFhvT+/VpbUzF3vw+RARHA==",
-                  "requires": {
-                    "@uifabric/set-version": "^7.0.24",
-                    "@uifabric/styling": "^7.20.2",
-                    "@uifabric/utilities": "^7.34.1",
-                    "tslib": "^1.10.0"
-                  },
-                  "dependencies": {
-                    "@uifabric/styling": {
-                      "version": "7.20.2",
-                      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.20.2.tgz",
-                      "integrity": "sha512-FiGdeTsfJAs8qrqU2aLx70C2MT8YsjraMzr0HSiXKFQ2/LM4hwAYpbC41NIHzUemm63uA8NJRLHJlSv3S7V2SQ==",
-                      "requires": {
-                        "@fluentui/theme": "^1.7.6",
-                        "@microsoft/load-themed-styles": "^1.10.26",
-                        "@uifabric/merge-styles": "^7.19.2",
-                        "@uifabric/set-version": "^7.0.24",
-                        "@uifabric/utilities": "^7.34.1",
-                        "tslib": "^1.10.0"
-                      }
-                    }
-                  }
-                },
-                "office-ui-fabric-react": {
-                  "version": "7.180.0",
-                  "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.180.0.tgz",
-                  "integrity": "sha512-bayPgo2gyJEqYOOwsGT8KZtOj3yWe252PqMFw0Gx/2TKOXweQ/btror1D2SGxins8RogTtwhkmvgTbnWYMn2jw==",
-                  "requires": {
-                    "@fluentui/date-time-utilities": "^7.9.1",
-                    "@fluentui/react-focus": "^7.18.1",
-                    "@fluentui/react-window-provider": "^1.0.2",
-                    "@microsoft/load-themed-styles": "^1.10.26",
-                    "@uifabric/foundation": "^7.10.1",
-                    "@uifabric/icons": "^7.6.2",
-                    "@uifabric/merge-styles": "^7.19.2",
-                    "@uifabric/react-hooks": "^7.14.0",
-                    "@uifabric/set-version": "^7.0.24",
-                    "@uifabric/styling": "^7.20.0",
-                    "@uifabric/utilities": "^7.33.5",
-                    "prop-types": "^15.7.2",
-                    "tslib": "^1.10.0"
-                  }
-                }
+                "tslib": "2.3.1"
               }
             },
             "@pnp/common": {
@@ -23188,6 +23760,13 @@
               "requires": {
                 "adal-angular": "1.0.17",
                 "tslib": "1.10.0"
+              },
+              "dependencies": {
+                "tslib": {
+                  "version": "1.10.0",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+                  "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+                }
               }
             },
             "@pnp/logging": {
@@ -23196,6 +23775,13 @@
               "integrity": "sha512-hADlIXwvF/wjee7425nFJ6NhqaWpWTJ5yg02bpwBUsiSuFqEUf+LwuAcyHQre2lMs6KyNa65FWoRQok9BlZuxA==",
               "requires": {
                 "tslib": "1.10.0"
+              },
+              "dependencies": {
+                "tslib": {
+                  "version": "1.10.0",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+                  "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+                }
               }
             },
             "@pnp/odata": {
@@ -23204,6 +23790,13 @@
               "integrity": "sha512-yMaRiuVZRei2pkryCOqsw3ZXD2Lw30IJv136WQmQPQPOxG4cvsS9+woXkfMqbWV2KQ1evFUqVXbitIz6eDVfNA==",
               "requires": {
                 "tslib": "1.10.0"
+              },
+              "dependencies": {
+                "tslib": {
+                  "version": "1.10.0",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+                  "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+                }
               }
             },
             "@pnp/sp": {
@@ -23212,6 +23805,13 @@
               "integrity": "sha512-NjdeGe81aukiSPelSPjgAFRC1+SrNPTXvTdEqTH+Q1ZvgNtk8bdZp6K6xf9emfeM2qZDOu9GpKZpg0W/emq++g==",
               "requires": {
                 "tslib": "1.10.0"
+              },
+              "dependencies": {
+                "tslib": {
+                  "version": "1.10.0",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+                  "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+                }
               }
             },
             "@pnp/sp-clientsvc": {
@@ -23220,6 +23820,13 @@
               "integrity": "sha512-eIUnmDWjizcWJzhWxAbfsxEyHF1dabkGlihnDnlcYGhtvh8BwuM67A57qc5fbxzCS59c0YU57szB1EucoNmV4A==",
               "requires": {
                 "tslib": "1.10.0"
+              },
+              "dependencies": {
+                "tslib": {
+                  "version": "1.10.0",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+                  "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+                }
               }
             },
             "@pnp/sp-taxonomy": {
@@ -23228,18 +23835,32 @@
               "integrity": "sha512-shzCSjmOlr6mojCXJkfD8Xf9lJnhphq4Fj6mdUQGwpak+VIU+Fogf6AI0j6AReCKtKsKyqfud9X7C8tH07C3DA==",
               "requires": {
                 "tslib": "1.10.0"
+              },
+              "dependencies": {
+                "tslib": {
+                  "version": "1.10.0",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
+                  "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
+                }
               }
             },
             "@uifabric/utilities": {
-              "version": "7.34.1",
-              "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.34.1.tgz",
-              "integrity": "sha512-gmQ94x/wj/my7zByFMXapLF5jDmRugWuBngx6gdvnw9rRme0YoN0G3S47vr3aw6ZTsXEnb6SJFnbtVyAGMmZRg==",
+              "version": "7.36.0",
+              "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.36.0.tgz",
+              "integrity": "sha512-Y+bu0Wc5nbS39Exy/WxhgwP7ZlNOJj2UTcgYd8Nk+hQiDkUZvt3pSCIbn10Cz/59WrCr0htctvF5Xkt+BkpICA==",
               "requires": {
                 "@fluentui/dom-utilities": "^1.1.2",
                 "@uifabric/merge-styles": "^7.19.2",
                 "@uifabric/set-version": "^7.0.24",
                 "prop-types": "^15.7.2",
                 "tslib": "^1.10.0"
+              },
+              "dependencies": {
+                "tslib": {
+                  "version": "1.14.1",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                  "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+                }
               }
             },
             "adal-angular": {
@@ -23248,50 +23869,40 @@
               "integrity": "sha512-+Z9aq7L25OncsaVcnhSsi7AMR/dlg0gWVNptsdtkL9Ih7hA1oJ14mhWB60CB83JF6DlzamVKLMGbrAcgFQqhCg=="
             },
             "office-ui-fabric-react": {
-              "version": "7.174.1",
-              "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.174.1.tgz",
-              "integrity": "sha512-zRUpUqZtVncvb+Tt+5SVNEcI3MfpwTLU+v2u7ZdF9ukPbD+UBKJSkIbydyO0P2S5jVizgdqioSOarfUA70ICvw==",
+              "version": "7.185.7",
+              "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.185.7.tgz",
+              "integrity": "sha512-JiWkrjT/T6OG63ATu6RUlME2PBe4pgxQOwRTOjvbsaq8mlyd9i21ImgwkTEvcNXJpx+4w0bJiuQTcdwSMyf6qA==",
               "requires": {
                 "@fluentui/date-time-utilities": "^7.9.1",
-                "@fluentui/react-focus": "^7.17.6",
-                "@fluentui/react-window-provider": "^1.0.2",
+                "@fluentui/react-focus": "^7.18.4",
+                "@fluentui/react-window-provider": "^1.0.3",
                 "@microsoft/load-themed-styles": "^1.10.26",
-                "@uifabric/foundation": "^7.9.26",
-                "@uifabric/icons": "^7.5.23",
+                "@uifabric/foundation": "^7.10.3",
+                "@uifabric/icons": "^7.7.2",
                 "@uifabric/merge-styles": "^7.19.2",
-                "@uifabric/react-hooks": "^7.14.0",
+                "@uifabric/react-hooks": "^7.14.2",
                 "@uifabric/set-version": "^7.0.24",
-                "@uifabric/styling": "^7.19.0",
-                "@uifabric/utilities": "^7.33.5",
+                "@uifabric/styling": "^7.20.2",
+                "@uifabric/utilities": "^7.34.1",
                 "prop-types": "^15.7.2",
                 "tslib": "^1.10.0"
               },
               "dependencies": {
                 "@uifabric/icons": {
-                  "version": "7.7.2",
-                  "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.7.2.tgz",
-                  "integrity": "sha512-3f223BZ5TXTF37J7lG+saGBY7U8vAi5HyMP58ccIoUafOj5551h5sovPFD/hVIYzYFhvT+/VpbUzF3vw+RARHA==",
+                  "version": "7.8.0",
+                  "resolved": "https://registry.npmjs.org/@uifabric/icons/-/icons-7.8.0.tgz",
+                  "integrity": "sha512-BNKJofCeVVNV4usMvmsiUiSguke84kBacq3bmG5waupL6Gmx0QayHV+gvjZWC5wTplYQ4yZ2CvE6rkmoH5hK9w==",
                   "requires": {
                     "@uifabric/set-version": "^7.0.24",
-                    "@uifabric/styling": "^7.20.2",
-                    "@uifabric/utilities": "^7.34.1",
+                    "@uifabric/styling": "^7.22.0",
+                    "@uifabric/utilities": "^7.36.0",
                     "tslib": "^1.10.0"
-                  },
-                  "dependencies": {
-                    "@uifabric/styling": {
-                      "version": "7.20.2",
-                      "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.20.2.tgz",
-                      "integrity": "sha512-FiGdeTsfJAs8qrqU2aLx70C2MT8YsjraMzr0HSiXKFQ2/LM4hwAYpbC41NIHzUemm63uA8NJRLHJlSv3S7V2SQ==",
-                      "requires": {
-                        "@fluentui/theme": "^1.7.6",
-                        "@microsoft/load-themed-styles": "^1.10.26",
-                        "@uifabric/merge-styles": "^7.19.2",
-                        "@uifabric/set-version": "^7.0.24",
-                        "@uifabric/utilities": "^7.34.1",
-                        "tslib": "^1.10.0"
-                      }
-                    }
                   }
+                },
+                "tslib": {
+                  "version": "1.14.1",
+                  "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                  "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
               }
             },
@@ -23334,11 +23945,76 @@
           }
         },
         "@rushstack/loader-raw-script": {
-          "version": "1.3.207",
-          "resolved": "https://registry.npmjs.org/@rushstack/loader-raw-script/-/loader-raw-script-1.3.207.tgz",
-          "integrity": "sha512-sOF21pgIKhXREKepRMFMCi0UmChVj2LtjhUP38W5EwJG8sTtv8dOsZ3qT2lW7s+n6TzoPXE8NvY0/dK40VKhug==",
+          "version": "1.3.228",
+          "resolved": "https://registry.npmjs.org/@rushstack/loader-raw-script/-/loader-raw-script-1.3.228.tgz",
+          "integrity": "sha512-yJPiwe4vCEmiZck9qUktYqVgExJV18C5wjO6Vv/l4ZWyI8WgYCei1eIcIJBtz//v3E18b8s6tKnSZDAUw1mhUQ==",
           "requires": {
             "loader-utils": "~1.1.0"
+          }
+        },
+        "@rushstack/node-core-library": {
+          "version": "3.45.5",
+          "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-3.45.5.tgz",
+          "integrity": "sha512-KbN7Hp9vH3bD3YJfv6RnVtzzTAwGYIBl7y2HQLY4WEQqRbvE3LgI78W9l9X+cTAXCX//p0EeoiUYNTFdqJrMZg==",
+          "requires": {
+            "@types/node": "12.20.24",
+            "colors": "~1.2.1",
+            "fs-extra": "~7.0.1",
+            "import-lazy": "~4.0.0",
+            "jju": "~1.4.0",
+            "resolve": "~1.17.0",
+            "semver": "~7.3.0",
+            "timsort": "~0.3.0",
+            "z-schema": "~5.0.2"
+          },
+          "dependencies": {
+            "z-schema": {
+              "version": "5.0.4",
+              "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-5.0.4.tgz",
+              "integrity": "sha512-gm/lx3hDzJNcLwseIeQVm1UcwhWIKpSB4NqH89pTBtFns4k/HDHudsICtvG05Bvw/Mv3jMyk700y5dadueLHdA==",
+              "requires": {
+                "commander": "^2.20.3",
+                "lodash.get": "^4.4.2",
+                "lodash.isequal": "^4.5.0",
+                "validator": "^13.7.0"
+              }
+            }
+          }
+        },
+        "@types/node": {
+          "version": "12.20.24",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.24.tgz",
+          "integrity": "sha512-yxDeaQIAJlMav7fH5AQqPH1u8YIuhYJXYBzxaQ4PifsU0GDO38MSdmEDeRlIxrKbC6NbEaaEHDanWb+y30U8SQ=="
+        },
+        "@uifabric/foundation": {
+          "version": "7.10.8",
+          "resolved": "https://registry.npmjs.org/@uifabric/foundation/-/foundation-7.10.8.tgz",
+          "integrity": "sha512-u82qnYEkBx27oHk4VB5DDTGkUI7NYlchR30Cpt0UzPz2Dsep+oSlV3Z1vyS196BXNF8a4vtvOXrjN4vqzjVi7w==",
+          "requires": {
+            "@uifabric/merge-styles": "^7.19.2",
+            "@uifabric/set-version": "^7.0.24",
+            "@uifabric/styling": "^7.22.0",
+            "@uifabric/utilities": "^7.36.0",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "@uifabric/utilities": {
+              "version": "7.36.0",
+              "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.36.0.tgz",
+              "integrity": "sha512-Y+bu0Wc5nbS39Exy/WxhgwP7ZlNOJj2UTcgYd8Nk+hQiDkUZvt3pSCIbn10Cz/59WrCr0htctvF5Xkt+BkpICA==",
+              "requires": {
+                "@fluentui/dom-utilities": "^1.1.2",
+                "@uifabric/merge-styles": "^7.19.2",
+                "@uifabric/set-version": "^7.0.24",
+                "prop-types": "^15.7.2",
+                "tslib": "^1.10.0"
+              }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
           }
         },
         "@uifabric/icons": {
@@ -23349,6 +24025,75 @@
             "@uifabric/set-version": "^7.0.23",
             "@uifabric/styling": "^7.16.18",
             "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@uifabric/react-hooks": {
+          "version": "7.15.2",
+          "resolved": "https://registry.npmjs.org/@uifabric/react-hooks/-/react-hooks-7.15.2.tgz",
+          "integrity": "sha512-ngil4McS64HDCrMRyzOtXuyve4zOxBOX20DkYLa6rIBM3if+sUzNBodiwZ6RZz/6hBZW1nqpVmz7eEMnqEL4JA==",
+          "requires": {
+            "@fluentui/react-window-provider": "^1.0.3",
+            "@uifabric/set-version": "^7.0.24",
+            "@uifabric/utilities": "^7.36.0",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "@uifabric/utilities": {
+              "version": "7.36.0",
+              "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.36.0.tgz",
+              "integrity": "sha512-Y+bu0Wc5nbS39Exy/WxhgwP7ZlNOJj2UTcgYd8Nk+hQiDkUZvt3pSCIbn10Cz/59WrCr0htctvF5Xkt+BkpICA==",
+              "requires": {
+                "@fluentui/dom-utilities": "^1.1.2",
+                "@uifabric/merge-styles": "^7.19.2",
+                "@uifabric/set-version": "^7.0.24",
+                "prop-types": "^15.7.2",
+                "tslib": "^1.10.0"
+              }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
+          }
+        },
+        "@uifabric/styling": {
+          "version": "7.22.0",
+          "resolved": "https://registry.npmjs.org/@uifabric/styling/-/styling-7.22.0.tgz",
+          "integrity": "sha512-y2SntsWVKq7cabcwHDastfw9V4ahMdJr0idsrOlmU3vqWFTXwP99qIwYLcqrFVV4Kjb6F4T/JrnzNQW+bBlRGg==",
+          "requires": {
+            "@fluentui/theme": "^1.7.8",
+            "@microsoft/load-themed-styles": "^1.10.26",
+            "@uifabric/merge-styles": "^7.19.2",
+            "@uifabric/set-version": "^7.0.24",
+            "@uifabric/utilities": "^7.36.0",
+            "tslib": "^1.10.0"
+          },
+          "dependencies": {
+            "@uifabric/utilities": {
+              "version": "7.36.0",
+              "resolved": "https://registry.npmjs.org/@uifabric/utilities/-/utilities-7.36.0.tgz",
+              "integrity": "sha512-Y+bu0Wc5nbS39Exy/WxhgwP7ZlNOJj2UTcgYd8Nk+hQiDkUZvt3pSCIbn10Cz/59WrCr0htctvF5Xkt+BkpICA==",
+              "requires": {
+                "@fluentui/dom-utilities": "^1.1.2",
+                "@uifabric/merge-styles": "^7.19.2",
+                "@uifabric/set-version": "^7.0.24",
+                "prop-types": "^15.7.2",
+                "tslib": "^1.10.0"
+              }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
           }
         },
         "@uifabric/utilities": {
@@ -23378,13 +24123,13 @@
               "requires": {
                 "tslib": "^1.7.1"
               }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
             }
           }
-        },
-        "es6-promise": {
-          "version": "4.2.4",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
-          "integrity": "sha512-/NdNZVJg+uZgtm9eS3O6lrOLYmQag2DjdEXuPaHlZ6RuVqgqaVZfgYCepEIKsLqwdQArOPtC3XzRLqGGfT8KQQ=="
         },
         "get-value": {
           "version": "3.0.1",
@@ -23394,12 +24139,35 @@
             "isobject": "^3.0.1"
           }
         },
-        "msal": {
-          "version": "1.4.13",
-          "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.13.tgz",
-          "integrity": "sha512-uFEa4KGlpGqNMwa7/1OQc6WQUF8iwHbaiHMVn0Cl66Ec7o30ZTtX9s9OWrf0wAxp8Mwg0JEE886z/PHpsiZUxQ==",
+        "isomorphic-fetch": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz",
+          "integrity": "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==",
+          "requires": {
+            "node-fetch": "^2.6.1",
+            "whatwg-fetch": "^3.4.1"
+          },
+          "dependencies": {
+            "whatwg-fetch": {
+              "version": "3.6.2",
+              "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz",
+              "integrity": "sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA=="
+            }
+          }
+        },
+        "msalLegacy": {
+          "version": "npm:msal@1.4.12",
+          "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.12.tgz",
+          "integrity": "sha512-gjupwQ6nvNL6mZkl5NIXyUmZhTiEMRu5giNdgHMh8l5EPOnV2Xj6nukY1NIxFacSTkEYUSDB47Pej9GxDYf+1w==",
           "requires": {
             "tslib": "^1.9.3"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+            }
           }
         },
         "msgraph-helper": {
@@ -23421,12 +24189,43 @@
                 "tslib": "^1.9.3"
               }
             },
-            "es6-promise": {
-              "version": "4.2.8",
-              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-              "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
+            "isomorphic-fetch": {
+              "version": "2.2.1",
+              "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+              "integrity": "sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==",
+              "requires": {
+                "node-fetch": "^1.0.1",
+                "whatwg-fetch": ">=0.10.0"
+              }
+            },
+            "node-fetch": {
+              "version": "1.7.3",
+              "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
+              "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
+              "requires": {
+                "encoding": "^0.1.11",
+                "is-stream": "^1.0.1"
+              }
+            },
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
             }
           }
+        },
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "office-ui-fabric-core": {
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/office-ui-fabric-core/-/office-ui-fabric-core-11.0.1.tgz",
+          "integrity": "sha512-jcfycbVOm2aUoI+AGtHW24HvM7nUVFr44hR5NIE56EobK67bVwbNAQL15CJj3vNz5PBrnitsV9ROOB+KOEWn8g=="
         },
         "react": {
           "version": "16.8.5",
@@ -23483,6 +24282,14 @@
             }
           }
         },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "requires": {
+            "path-parse": "^1.0.6"
+          }
+        },
         "scheduler": {
           "version": "0.19.1",
           "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
@@ -23490,6 +24297,14 @@
           "requires": {
             "loose-envify": "^1.1.0",
             "object-assign": "^4.1.1"
+          }
+        },
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "requires": {
+            "lru-cache": "^6.0.0"
           }
         },
         "sp-hubsite-service": {
@@ -23504,21 +24319,31 @@
             "@pnp/sp": "^1.3.4"
           }
         },
+        "tslib": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
+          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
+        },
+        "validator": {
+          "version": "13.7.0",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+          "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
+        },
         "webpack": {
-          "version": "5.73.0",
-          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.73.0.tgz",
-          "integrity": "sha512-svjudQRPPa0YiOYa2lM/Gacw0r6PvxptHj4FuEKQ2kX05ZLkjbVc5MnPs6its5j7IZljnIqSVo/OsY2X0IpHGA==",
+          "version": "5.74.0",
+          "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
+          "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
           "requires": {
             "@types/eslint-scope": "^3.7.3",
             "@types/estree": "^0.0.51",
             "@webassemblyjs/ast": "1.11.1",
             "@webassemblyjs/wasm-edit": "1.11.1",
             "@webassemblyjs/wasm-parser": "1.11.1",
-            "acorn": "^8.4.1",
+            "acorn": "^8.7.1",
             "acorn-import-assertions": "^1.7.6",
             "browserslist": "^4.14.5",
             "chrome-trace-event": "^1.0.2",
-            "enhanced-resolve": "^5.9.3",
+            "enhanced-resolve": "^5.10.0",
             "es-module-lexer": "^0.9.0",
             "eslint-scope": "5.1.1",
             "events": "^3.2.0",
@@ -23531,7 +24356,7 @@
             "schema-utils": "^3.1.0",
             "tapable": "^2.1.1",
             "terser-webpack-plugin": "^5.1.3",
-            "watchpack": "^2.3.1",
+            "watchpack": "^2.4.0",
             "webpack-sources": "^3.2.3"
           }
         },
@@ -23539,6 +24364,26 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
           "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        },
+        "z-schema": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.4.tgz",
+          "integrity": "sha512-YvBeW5RGNeNzKOUJs3rTL4+9rpcvHXt5I051FJbOcitV8bl40pEfcG0Q+dWSwS0/BIYrMZ/9HHoqLllMkFhD0w==",
+          "requires": {
+            "commander": "^2.7.1",
+            "lodash.get": "^4.4.2",
+            "lodash.isequal": "^4.5.0",
+            "validator": "^13.6.0"
+          }
         }
       }
     },
@@ -26593,9 +27438,9 @@
       }
     },
     "terser": {
-      "version": "5.14.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.1.tgz",
-      "integrity": "sha512-+ahUAE+iheqBTDxXhTisdA8hgvbEG1hHOQ9xmNjeUJSoi6DU/gMrKNcfZjHkyY6Alnuyc+ikYJaxxfHkT3+WuQ==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.15.0.tgz",
+      "integrity": "sha512-L1BJiXVmheAQQy+as0oF3Pwtlo4s3Wi1X2zNZ2NxOB4wx9bdS9Vk67XQENLFdLYGCK/Z2di53mTj/hBafR+dTA==",
       "requires": {
         "@jridgewell/source-map": "^0.3.2",
         "acorn": "^8.5.0",
@@ -26604,15 +27449,26 @@
       }
     },
     "terser-webpack-plugin": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz",
-      "integrity": "sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==",
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.6.tgz",
+      "integrity": "sha512-kfLFk+PoLUQIbLmB1+PZDMRSZS99Mp+/MHqDNmMA6tOItzRt+Npe3E+fsMs5mfcM0wCtrrdU387UnV+vnSffXQ==",
       "requires": {
-        "@jridgewell/trace-mapping": "^0.3.7",
+        "@jridgewell/trace-mapping": "^0.3.14",
         "jest-worker": "^27.4.5",
         "schema-utils": "^3.1.1",
         "serialize-javascript": "^6.0.0",
-        "terser": "^5.7.2"
+        "terser": "^5.14.1"
+      },
+      "dependencies": {
+        "@jridgewell/trace-mapping": {
+          "version": "0.3.15",
+          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.15.tgz",
+          "integrity": "sha512-oWZNOULl+UbhsgB51uuZzglikfIKSUBO/M9W2OfEjn7cmqoAiCgmv9lyACTUacZwBz0ITnJ2NqjU8Tx0DHL88g==",
+          "requires": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        }
       }
     },
     "test-exclude": {
@@ -26703,8 +27559,7 @@
     "timsort": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
-      "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A==",
-      "dev": true
+      "integrity": "sha512-qsdtZH+vMoCARQtyod4imc2nIJwg9Cc7lPRrw9CzF8ZKR0khdr8+2nX80PBhET3tcyTtJDxAffGh2rXH4tyU8A=="
     },
     "tiny-lr": {
       "version": "0.2.1",
@@ -27555,8 +28410,7 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unpipe": {
       "version": "1.0.0",
@@ -29417,8 +30271,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "14.2.0",

--- a/SharePointFramework/ProjectExtensions/src/models/TemplateItem.ts
+++ b/SharePointFramework/ProjectExtensions/src/models/TemplateItem.ts
@@ -97,12 +97,12 @@ export class TemplateItem {
     try {
       const content = await this.web.getFileByServerRelativeUrl(this.serverRelativeUrl).getBlob()
       // eslint-disable-next-line @typescript-eslint/no-empty-function
-      const fileAddResult = await folder.files.addChunked(
+      const fileAddResult = await folder.files.addUsingPath(
         this.newName,
         content,
-        // eslint-disable-next-line @typescript-eslint/no-empty-function
-        () => {},
-        shouldOverwrite
+        {
+          Overwrite: shouldOverwrite
+        }
       )
       await (await fileAddResult.file.getItem()).update({ Title: this.newTitle })
       return fileAddResult

--- a/SharePointFramework/ProjectWebParts/package-lock.json
+++ b/SharePointFramework/ProjectWebParts/package-lock.json
@@ -7005,6 +7005,14 @@
             "tslib": "^1.9.3"
           }
         },
+        "msalLegacy": {
+          "version": "npm:msal@1.4.12",
+          "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.12.tgz",
+          "integrity": "sha512-gjupwQ6nvNL6mZkl5NIXyUmZhTiEMRu5giNdgHMh8l5EPOnV2Xj6nukY1NIxFacSTkEYUSDB47Pej9GxDYf+1w==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
         "office-ui-fabric-react": {
           "version": "7.174.1",
           "resolved": "https://registry.npmjs.org/office-ui-fabric-react/-/office-ui-fabric-react-7.174.1.tgz",
@@ -20101,14 +20109,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.0.tgz",
       "integrity": "sha512-NTxMFQh6t5g2QWMlvZTWTxL1bmcqiCv0cs2lxTHhUbWEuxWCfvaVRZfjxN8i+T0VltVVGaVIdML8QEoBnlbaSw==",
-      "requires": {
-        "tslib": "^1.9.3"
-      }
-    },
-    "msalLegacy": {
-      "version": "npm:msal@1.4.12",
-      "resolved": "https://registry.npmjs.org/msal/-/msal-1.4.12.tgz",
-      "integrity": "sha512-gjupwQ6nvNL6mZkl5NIXyUmZhTiEMRu5giNdgHMh8l5EPOnV2Xj6nukY1NIxFacSTkEYUSDB47Pej9GxDYf+1w==",
       "requires": {
         "tslib": "^1.9.3"
       }


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [X] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [X] Check the commit's or even all commits' message 
- [X] Check if your code additions will fail linting checks
- [X] Remember: Add issue description to [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the **ID of the issue** associated with this PR
- [X] Documentation: Have a look at the [PP365 User manual](https://puzzlepart.github.io/prosjektportalen-manual/) and consider the need for updates to be made. Updates can be done directly into the 'Kladd' branch or by providing information to test team for implementation.

### Description

When importing a document through the TemplateSelector library command, the values are set and seems to work as intended. When trying to edit a value through the list dialog and saving that change, the columns that had default values are wiped, this can also be seen in the version log. Default values set directly to SiteFields are not wiped. This has now been fixed by using `addUsingPath` instead of `addChunked`

### How to test

1. Go to a document library
2. Add default values to columns "Document library settings > Column default value settings"
3. Import document through the TemplateSelector library command
4. Edit values through list dialog
5. Witness fix

### Relevant issues (if applicable)

#761 
