### PR TITLE
Add setting to Project Information statusReportShowOnlyIcons for Project Status

### DIFF
--- a/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/ProjectStatusReport/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/ProjectStatusReport/index.tsx
@@ -16,6 +16,7 @@ export const ProjectStatusReport: FC = () => {
           transparent
           noPadding
           noMargin
+          iconsOnly={context.props.statusReportShowOnlyIcons}
           iconSize={18}
           truncateComment={context.props.statusReportTruncateComments}
         />

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/index.tsx
@@ -13,7 +13,7 @@ import styles from './ProjectInformation.module.scss'
 import { ProjectProperties } from './ProjectProperties'
 import { ProjectStatusReport } from './ProjectStatusReport'
 import { SyncProjectDialog } from './SyncProjectDialog'
-import { IProjectInformationProps } from './types'
+import { IProjectInformationProps, ProjectInformationDefaultProps } from './types'
 import { useProjectInformation } from './useProjectInformation'
 
 export const ProjectInformation: FC<IProjectInformationProps> = (props) => {
@@ -49,15 +49,7 @@ export const ProjectInformation: FC<IProjectInformationProps> = (props) => {
   )
 }
 
-ProjectInformation.defaultProps = {
-  page: 'Frontpage',
-  customActions: [],
-  hideActions: [],
-  hideAllActions: false,
-  useFramelessButtons: false,
-  hideStatusReport: true,
-  hideParentProjects: true
-}
+ProjectInformation.defaultProps = ProjectInformationDefaultProps
 
 export * from '../ProjectInformationPanel'
 export * from './types'

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/types.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/types.ts
@@ -91,6 +91,22 @@ export interface IProjectInformationProps extends IBaseWebPartComponentProps {
    * Truncate status report comments to the specified length and add ellipsis (...)
    */
   statusReportTruncateComments?: number
+
+  /**
+   * Show only icons for latest status report
+   */
+  statusReportShowOnlyIcons?: boolean
+}
+
+export const ProjectInformationDefaultProps: IProjectInformationProps = {
+  page: 'Frontpage',
+  customActions: [],
+  hideActions: [],
+  hideAllActions: false,
+  useFramelessButtons: false,
+  hideStatusReport: true,
+  hideParentProjects: true,
+  statusReportShowOnlyIcons: true
 }
 
 export interface IProjectInformationState

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/Sections/SummarySection/SummarySection.module.scss
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/Sections/SummarySection/SummarySection.module.scss
@@ -6,16 +6,35 @@
     @include ms-sm12;
     @include ms-xl6;
   }
-  .sections {
+
+  .statusElements {
     @include ms-Grid-col;
     @include ms-sm12;
     @include ms-xl6;
+
+    .container {
+      @include ms-Grid;
+      .row {
+        @include ms-Grid-row;
+        .statusElement {
+          @include ms-Grid-col;
+
+          &.halfWidth {
+            @include ms-sm6;
+          }
+
+          &.iconsOnly {
+            margin: 10px 0 0 0;
+          }
+        }
+      }
+    }
   }
 
   .fullWidth {
     @include ms-sm12;
     @include ms-xl12;
-    padding: 0; 
+    padding: 0;
     margin: 0;
   }
 }

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/Sections/SummarySection/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/Sections/SummarySection/index.tsx
@@ -8,7 +8,7 @@ import { SectionContext } from '../context'
 import { useCreateContextValue } from '../useCreateContextValue'
 import { ISummarySectionProps } from './types'
 import styles from './SummarySection.module.scss'
-import { conditionalClassName } from 'pp365-shared/lib/util'
+import { conditionalClassName as className } from 'pp365-shared/lib/util'
 import { pick } from 'underscore'
 
 export const SummarySection: FC<ISummarySectionProps> = (props) => {
@@ -16,17 +16,22 @@ export const SummarySection: FC<ISummarySectionProps> = (props) => {
   const createContextValue = useCreateContextValue({})
 
   /**
-   * Render sections where `ctxValue.headerProps.value` is set, or the `fieldName` is
-   * **GtOverallStatus**.
+   * Render status elements where `ctxValue.headerProps.value` is set,
+   * or the `fieldName` is **GtOverallStatus**.
    */
-  function renderSections() {
+  function renderStatusElements() {
     return context.state.data.sections.map((sec, idx) => {
       const ctxValue = createContextValue(sec)
       const shouldRender = ctxValue.headerProps.value || sec.fieldName === 'GtOverallStatus'
       return shouldRender ? (
         <SectionContext.Provider key={idx} value={ctxValue}>
-          <div key={idx} className='ms-Grid-col ms-sm6'>
-            <StatusElement {...pick(props, 'iconSize', 'truncateComment')} />
+          <div
+            key={idx}
+            className={className([
+              styles.statusElement,
+              props.iconsOnly ? styles.iconsOnly : styles.halfWidth
+            ])}>
+            <StatusElement {...pick(props, 'iconSize', 'truncateComment', 'iconsOnly')} />
           </div>
         </SectionContext.Provider>
       ) : null
@@ -51,12 +56,12 @@ export const SummarySection: FC<ISummarySectionProps> = (props) => {
           </div>
         )}
         <div
-          className={conditionalClassName([
-            styles.sections,
+          className={className([
+            styles.statusElements,
             !props.showProjectInformation && styles.fullWidth
           ])}>
-          <div className='ms-Grid' dir='ltr'>
-            <div className='ms-Grid-row'>{renderSections()}</div>
+          <div className={styles.container} dir='ltr'>
+            <div className={styles.row}>{renderStatusElements()}</div>
           </div>
         </div>
       </div>

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/StatusElement/StatusElement.module.scss
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/StatusElement/StatusElement.module.scss
@@ -6,12 +6,7 @@
   
   .container {
     @include ms-Grid-row;
-
-    .icon {
-      @include ms-Grid-col;
-      @include ms-sm12;      
-      @include ms-md2;
-    }
+    
     .content {
       @include ms-Grid-col;
       @include ms-sm12;

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/StatusElement/StatusElementIcon/StatusElementIcon.module.scss
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/StatusElement/StatusElementIcon/StatusElementIcon.module.scss
@@ -1,0 +1,7 @@
+@import "~@microsoft/sp-office-ui-fabric-core/dist/sass/SPFabricCore.scss";
+
+.root {
+  @include ms-Grid-col;
+  @include ms-sm12;
+  @include ms-md2;
+}

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/StatusElement/StatusElementIcon/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/StatusElement/StatusElementIcon/index.tsx
@@ -1,0 +1,19 @@
+import { Icon } from '@fluentui/react/lib/Icon'
+import { SectionContext } from 'components/ProjectStatus/Sections/context'
+import React, { FC, useContext } from 'react'
+import { IStatusElementIconProps } from './types'
+import styles from './StatusElementIcon.module.scss'
+
+export const StatusElementIcon: FC<IStatusElementIconProps> = (props) => {
+  const { headerProps } = useContext(SectionContext)
+  return (
+    <div
+      className={styles.root}
+      style={{
+        fontSize: props.iconSize,
+        color: headerProps.iconColor
+      }}>
+      <Icon iconName={headerProps.iconName} />
+    </div>
+  )
+}

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/StatusElement/StatusElementIcon/types.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/StatusElement/StatusElementIcon/types.ts
@@ -1,0 +1,3 @@
+export interface IStatusElementIconProps {
+  iconSize: number | string
+}

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/StatusElement/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/StatusElement/index.tsx
@@ -1,9 +1,9 @@
 import { TooltipHost } from '@fluentui/react'
-import { Icon } from '@fluentui/react/lib/Icon'
 import { ConditionalWrapper } from 'pp365-shared/lib/components'
 import React, { FC, ReactNode, useContext } from 'react'
 import { SectionContext } from '../Sections/context'
 import styles from './StatusElement.module.scss'
+import { StatusElementIcon } from './StatusElementIcon'
 import { IStatusElementProps } from './types'
 import { useStatusElement } from './useStatusElement'
 
@@ -12,9 +12,10 @@ export const StatusElement: FC<IStatusElementProps> = (props) => {
   const { commentProps, iconSize } = useStatusElement(props)
   return (
     <ConditionalWrapper
-      condition={!!props.truncateComment}
+      condition={!!props.truncateComment || props.iconsOnly}
       wrapper={(children: ReactNode) => (
         <TooltipHost
+          styles={{ root: { cursor: 'pointer' } }}
           content={
             <div className={styles.tooltip}>
               <StatusElement />
@@ -23,23 +24,20 @@ export const StatusElement: FC<IStatusElementProps> = (props) => {
           {children}
         </TooltipHost>
       )}>
-      <div className={styles.root}>
-        <div className={styles.container}>
-          <div
-            className={styles.icon}
-            style={{
-              fontSize: iconSize,
-              color: headerProps.iconColor
-            }}>
-            <Icon iconName={headerProps.iconName} />
-          </div>
-          <div className={styles.content}>
-            <div className={styles.label}>{headerProps.label}</div>
-            <div className={styles.value}>{headerProps.value}</div>
-            <div {...commentProps}></div>
+      {props.iconsOnly ? (
+        <StatusElementIcon iconSize={iconSize} />
+      ) : (
+        <div className={styles.root}>
+          <div className={styles.container}>
+            <StatusElementIcon iconSize={iconSize} />
+            <div className={styles.content}>
+              <div className={styles.label}>{headerProps.label}</div>
+              <div className={styles.value}>{headerProps.value}</div>
+              <div {...commentProps}></div>
+            </div>
           </div>
         </div>
-      </div>
+      )}
     </ConditionalWrapper>
   )
 }

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/StatusElement/types.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/StatusElement/types.ts
@@ -9,5 +9,13 @@ export interface IStatusElement {
 }
 
 export interface IStatusElementProps extends Pick<IStatusElement, 'iconSize'> {
+  /**
+   * Truncate comment to the specified length and add ellipsis (...)
+   */
   truncateComment?: number
+
+  /**
+   * Show only icons
+   */
+  iconsOnly?: boolean
 }

--- a/SharePointFramework/ProjectWebParts/src/loc/mystrings.d.ts
+++ b/SharePointFramework/ProjectWebParts/src/loc/mystrings.d.ts
@@ -1,4 +1,6 @@
 declare interface IProjectWebPartsStrings {
+  ParentProjectsGroupName: string
+  StatusReportShowOnlyIconsLabel: string | ReactElement<any, string | JSXElementConstructor<any>>
   StatusReportTruncateCommentsLabel: string
   ProjectInformationStatusReportHeaderText: string
   HideStatusReportLabel: string
@@ -23,7 +25,6 @@ declare interface IProjectWebPartsStrings {
   NavigateToSourceUrlText: string
   ProjectStatusGroupName: string
   StatusReportsHeaderLabel: string
-  StatusReportsCountLabel: string
   ChangePhaseText: string
   ChangingPhaseDescription: string
   PleaseWaitText: string

--- a/SharePointFramework/ProjectWebParts/src/loc/nb-no.js
+++ b/SharePointFramework/ProjectWebParts/src/loc/nb-no.js
@@ -1,5 +1,7 @@
 define([], function () {
   return {
+    ParentProjectsGroupName:'Overordnede prosjekter',
+    StatusReportShowOnlyIconsLabel: 'Vis kun ikoner',
     StatusReportTruncateCommentsLabel: 'Avkort kommentarer',
     DefaultGroupByLabel: 'Standard gruppering',
     DefaultTimeframeStartLabel: 'Standard starttdato',
@@ -76,7 +78,6 @@ define([], function () {
     WebPartNotConfiguredMessage: 'Webdelen er ikke konfigurert riktig. Du må angi webpartegenskaper riktig.',
     Yes: 'Ja',
     StatusReportsHeaderLabel: 'Overskrift',
-    StatusReportsCountLabel: 'Antal rapporter å vise',
     ProjectStatusGroupName: 'Prosjektstatus',
     NavigateToSourceUrlText: 'Gå tilbake',
     SyncProjectPropertiesText: 'Hent prosjektdata',

--- a/SharePointFramework/ProjectWebParts/src/webparts/projectInformation/index.ts
+++ b/SharePointFramework/ProjectWebParts/src/webparts/projectInformation/index.ts
@@ -7,7 +7,11 @@ import {
 import { CalloutTriggers } from '@pnp/spfx-property-controls/lib/PropertyFieldHeader'
 import { PropertyFieldMultiSelect } from '@pnp/spfx-property-controls/lib/PropertyFieldMultiSelect'
 import { PropertyFieldToggleWithCallout } from '@pnp/spfx-property-controls/lib/PropertyFieldToggleWithCallout'
-import { IProjectInformationProps, ProjectInformation } from 'components/ProjectInformation'
+import {
+  IProjectInformationProps,
+  ProjectInformation,
+  ProjectInformationDefaultProps
+} from 'components/ProjectInformation'
 import * as strings from 'ProjectWebPartsStrings'
 import React from 'react'
 import { BaseProjectWebPart } from '../@baseProjectWebPart'
@@ -33,6 +37,7 @@ export default class ProjectInformationWebPart extends BaseProjectWebPart<
   }
 
   public getPropertyPaneConfiguration(): IPropertyPaneConfiguration {
+    const propertiesWithDefaults = { ...ProjectInformationDefaultProps, ...this.properties }
     return {
       pages: [
         {
@@ -82,42 +87,44 @@ export default class ProjectInformationWebPart extends BaseProjectWebPart<
                   ],
                   selectedKeys: this.properties.hideActions ?? []
                 }),
+                !this.properties.hideAllActions &&
+                  PropertyPaneToggle('useFramelessButtons', {
+                    label: strings.UseFramelessButtonsLabel
+                  }),
                 PropertyPaneTextField('adminPageLink', {
                   label: strings.AdminPageLinkLabel
-                }),
-                PropertyPaneToggle('hideParentProjects', {
-                  label: strings.HideParentProjectsLabel,
-                  checked:
-                    this.properties.hideParentProjects === undefined
-                      ? true
-                      : this.properties.hideParentProjects
-                }),
-                PropertyPaneToggle('useFramelessButtons', {
-                  label: strings.UseFramelessButtonsLabel
                 })
               ].filter(Boolean)
+            },
+            {
+              groupName: strings.ParentProjectsGroupName,
+              groupFields: [
+                PropertyPaneToggle('hideParentProjects', {
+                  label: strings.HideParentProjectsLabel,
+                  checked: propertiesWithDefaults.hideParentProjects
+                })
+              ]
             },
             {
               groupName: strings.ProjectStatusGroupName,
               groupFields: [
                 PropertyPaneToggle('hideStatusReport', {
                   label: strings.HideStatusReportLabel,
-                  checked:
-                    this.properties.hideStatusReport === undefined
-                      ? true
-                      : this.properties.hideStatusReport
+                  checked: propertiesWithDefaults.hideStatusReport
                 }),
-                this.properties.hideStatusReport === false &&
-                PropertyPaneSlider('statusReportTruncateComments', {
-                  label: strings.StatusReportTruncateCommentsLabel,
-                  min: 25,
-                  max: 150,
-                  step: 5,
-                }),
-                this.properties.hideStatusReport === false &&
-                PropertyPaneToggle('statusReportShowOnlyIcons', {
-                  label: strings.StatusReportTruncateCommentsLabel
-                })
+                !propertiesWithDefaults.hideStatusReport &&
+                  PropertyPaneToggle('statusReportShowOnlyIcons', {
+                    label: strings.StatusReportShowOnlyIconsLabel,
+                    checked: propertiesWithDefaults.statusReportShowOnlyIcons
+                  }),
+                !propertiesWithDefaults.hideStatusReport &&
+                  !propertiesWithDefaults.statusReportShowOnlyIcons &&
+                  PropertyPaneSlider('statusReportTruncateComments', {
+                    label: strings.StatusReportTruncateCommentsLabel,
+                    min: 25,
+                    max: 150,
+                    step: 5
+                  })
               ].filter(Boolean)
             },
             {

--- a/SharePointFramework/ProjectWebParts/src/webparts/projectInformation/index.ts
+++ b/SharePointFramework/ProjectWebParts/src/webparts/projectInformation/index.ts
@@ -113,6 +113,10 @@ export default class ProjectInformationWebPart extends BaseProjectWebPart<
                   min: 25,
                   max: 150,
                   step: 5,
+                }),
+                this.properties.hideStatusReport === false &&
+                PropertyPaneToggle('statusReportShowOnlyIcons', {
+                  label: strings.StatusReportTruncateCommentsLabel
                 })
               ].filter(Boolean)
             },


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [x] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [x] Check the commit's or even all commits' message 
- [x] Check if your code additions will fail linting checks
- [x] Remember: Add issue description to [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the **ID of the issue** associated with this PR
- [x] Documentation: Have a look at the [PP365 User manual](https://puzzlepart.github.io/prosjektportalen-manual/) and consider the need for updates to be made. Updates can be done directly into the 'Kladd' branch or by providing information to test team for implementation.

### Description

Add setting to Project Information `statusReportShowOnlyIcons` for Project Status.

### Relevant issues (if applicable)

#869