### PR TITLE
Added UpdateChildren=true for GtChildProjects in Prosjekt CT

### DIFF
--- a/Templates/Portfolio/Objects/ContentTypes/Prosjekt.xml
+++ b/Templates/Portfolio/Objects/ContentTypes/Prosjekt.xml
@@ -32,7 +32,7 @@
         <pnp:FieldRef ID="664ddf9a-a415-4b0b-a34f-0653547f03f0" Name="GtProjectAdminRoles" UpdateChildren="true" />
         <pnp:FieldRef ID="4cc4a931-3861-45ad-85de-6db88afe9fa0" Name="GtProjectTemplate" UpdateChildren="true" />
         <pnp:FieldRef ID="98e55335-a95a-4755-83a3-6f8b64af2420" Name="GtParentProjects" UpdateChildren="true" />
-        <pnp:FieldRef ID="e007ef7e-9c47-4bc2-8171-5c32688f3e0c" Name="GtChildProjects"  />
+        <pnp:FieldRef ID="e007ef7e-9c47-4bc2-8171-5c32688f3e0c" Name="GtChildProjects" UpdateChildren="true"  />
         <pnp:FieldRef ID="8f1f38cb-7eb2-4122-a866-4c9e99b2ebed" Name="GtIsParentProject" UpdateChildren="true" />
         <pnp:FieldRef ID="77baede1-38df-454c-a53a-dd7904ba0046" Name="GtIsProgram" UpdateChildren="true" />
     </pnp:FieldRefs>


### PR DESCRIPTION
Prosjekt content type had an issue.

UpdateChildren was not set to true on field GtProjectChildren, leading to the installation script failing as Prosjekter was missing the field. 

Added UpdateChildren=true for the field