### PR TITLE
SPDataAdapter._getFieldsToSync supports parameter forcedFields

### DIFF
--- a/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/useProjectInformation.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/useProjectInformation.ts
@@ -40,11 +40,7 @@ export const useProjectInformation = (props: IProjectInformationProps) => {
    * @param type Message bar type
    * @param durationSec Duration in seconds
    */
-  const addMessage = (
-    text: string,
-    type: MessageBarType,
-    durationSec: number = 5
-  ) => {
+  const addMessage = (text: string, type: MessageBarType, durationSec: number = 5) => {
     return new Promise<void>((resolve) => {
       setState({
         message: {
@@ -83,7 +79,7 @@ export const useProjectInformation = (props: IProjectInformationProps) => {
         props.webUrl,
         strings.ProjectPropertiesListName,
         state.data.templateParameters.ProjectContentTypeId ??
-        '0x0100805E9E4FEAAB4F0EABAB2600D30DB70C',
+          '0x0100805E9E4FEAAB4F0EABAB2600D30DB70C',
         { Title: props.webTitle }
       )
       if (!created) {

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectTimeline/data/fetchData.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectTimeline/data/fetchData.ts
@@ -17,7 +17,7 @@ export async function fetchData(
   props: IProjectTimelineProps
 ): Promise<Partial<IProjectTimelineState>> {
   try {
-    const timelineConfig = await fetchTimelineConfiguration(props)
+    const timelineConfig = await fetchTimelineConfiguration()
     const [timelineData, project] = await Promise.all([
       fetchTimelineData(props, timelineConfig),
       fetchProjectData(props, timelineConfig)

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectTimeline/data/fetchTimelineConfiguration.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectTimeline/data/fetchTimelineConfiguration.ts
@@ -4,14 +4,11 @@ import {
   TimelineConfigurationModel
 } from 'pp365-portfoliowebparts/lib/models'
 import strings from 'ProjectWebPartsStrings'
-import { IProjectTimelineProps } from '../types'
 
 /**
  * Fetch timeline configuration
- *
- * @param props Component properties for `ProjectTimeline`
  */
-export async function fetchTimelineConfiguration(props: IProjectTimelineProps) {
+export async function fetchTimelineConfiguration() {
   return (
     await SPDataAdapter.portal.web.lists
       .getByTitle(strings.TimelineConfigurationListName)


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [x] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [x] Check the commit's or even all commits' message 
- [x] Check if your code additions will fail linting checks
- [x] Remember: Add issue description to [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the **ID of the issue** associated with this PR
- [x] Documentation: Have a look at the [PP365 User manual](https://puzzlepart.github.io/prosjektportalen-manual/) and consider the need for updates to be made. Updates can be done directly into the 'Kladd' branch or by providing information to test team for implementation.

### Description

`SPDataAdapter._getFieldsToSync` supports parameter `forcedFields` enabling us to force sync of fields `GtIsParentProject` and `GtIsProgram` even though they have specified `ShowInEditForm="FALSE"` in the schema xml.

### Relevant issues (if applicable)

#912