### PR TITLE
Issue/916 Resource allocation name matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Every change is marked with issue ID.
 - Persist selection when doing a search in Program Admin [#849](https://github.com/Puzzlepart/prosjektportalen365/issues/849)
 - Bugfix for ResourceAllocation where web part is not loaded due to elements not having User or Role assigned [#904](https://github.com/Puzzlepart/prosjektportalen365/issues/904)
 - Fixed an issue where hubsite was not resolved, leading to inconsistensies and errors [#640](https://github.com/Puzzlepart/prosjektportalen365/issues/849)
+- Fixed an issue where sometimes the role was shown as the owner of a resource allocation entry [#916](https://github.com/Puzzlepart/prosjektportalen365/issues/916)
 
 ## 1.7.2 - 26.10.2022
 

--- a/SharePointFramework/PortfolioWebParts/src/components/ResourceAllocation/useResourceAllocationDataFetch.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/ResourceAllocation/useResourceAllocationDataFetch.ts
@@ -56,8 +56,12 @@ function transformItems(
     .map<ITimelineItem>((res, id) => {
       const group = _.find(
         groups,
-        (grp) => [res.RefinableString71, res.RefinableString72].indexOf(grp.title) !== -1
-      )
+        (grp) => res.RefinableString71 && res.RefinableString71.indexOf(grp.title) !== -1
+      ) ?? _.find(
+        groups,
+        (grp) => res.RefinableString72 && res.RefinableString72.indexOf(grp.title) !== -1
+      );
+
       const isAbsence = res.ContentTypeId.indexOf('0x010029F45E75BA9CE340A83EFFB2927E11F4') !== -1
       if (!group || (isAbsence && !res.GtResourceAbsenceOWSCHCS)) return null
       const allocation = tryParsePercentage(res.GtResourceLoadOWSNMBR, false, 0) as number

--- a/SharePointFramework/PortfolioWebParts/src/components/ResourceAllocation/useResourceAllocationDataFetch.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/ResourceAllocation/useResourceAllocationDataFetch.ts
@@ -60,7 +60,7 @@ function transformItems(
       ) ?? _.find(
         groups,
         (grp) => res.RefinableString72 && res.RefinableString72.indexOf(grp.title) !== -1
-      );
+      )
 
       const isAbsence = res.ContentTypeId.indexOf('0x010029F45E75BA9CE340A83EFFB2927E11F4') !== -1
       if (!group || (isAbsence && !res.GtResourceAbsenceOWSCHCS)) return null


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [X] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [X] Check the commit's or even all commits' message 
- [X] Check if your code additions will fail linting checks
- [X] Remember: Add issue description to [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the **ID of the issue** associated with this PR
- [X] Documentation: Have a look at the [PP365 User manual](https://puzzlepart.github.io/prosjektportalen-manual/) and consider the need for updates to be made. Updates can be done directly into the 'Kladd' branch or by providing information to test team for implementation.

### Description

Fixed #916 by searching for groups in order - first by name and then by role.

### How to test

1. Create an entry with name and role
2. Create an entry with just the role
3. Verify they have two different entries in the resource allocation overview

### Relevant issues (if applicable)

#916 
