### PR TITLE
Fixed collapsing groups in aggregated webparts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Every change is marked with issue ID.
 - Fixed an issue where sometimes the role was shown as the owner of a resource allocation entry [#916](https://github.com/Puzzlepart/prosjektportalen365/issues/916)
 - Fixed an issue where '? Hjelp tilgjengelig' button didn't render propertly [#902](https://github.com/Puzzlepart/prosjektportalen365/issues/902)
 - Fixed an issue where visitors to a project didn't see the phase web part [#948](https://github.com/Puzzlepart/prosjektportalen365/issues/948)
+- Fixed an issue where it was not possible to collapse groups in aggregated webparts [#945](https://github.com/Puzzlepart/prosjektportalen365/issues/945)
 
 ## 1.7.2 - 26.10.2022
 

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/index.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/index.tsx
@@ -14,7 +14,7 @@ import { Commands } from './Commands'
 import { PortfolioAggregationContext } from './context'
 import { getDefaultColumns, renderItemColumn } from './itemColumn'
 import styles from './PortfolioAggregation.module.scss'
-import { COLUMN_HEADER_CONTEXT_MENU, ON_FILTER_CHANGE, TOGGLE_FILTER_PANEL } from './reducer'
+import { COLUMN_HEADER_CONTEXT_MENU, ON_FILTER_CHANGE, SET_ALL_COLLAPSED, SET_COLLAPSED, TOGGLE_FILTER_PANEL } from './reducer'
 import SearchBox from './SearchBox'
 import { ShowHideColumnPanel } from './ShowHideColumnPanel'
 import { IPortfolioAggregationProps } from './types'
@@ -57,6 +57,13 @@ export const PortfolioAggregation: FC<IPortfolioAggregationProps> = (props) => {
             ].filter((c) => c)}
             groups={state.groups}
             compact={state.isCompact}
+            groupProps={{
+              // TODO: Temporary fix for collapsing groups, the new state handling throws errors
+              onToggleCollapseAll: (isAllCollapsed) => dispatch(SET_ALL_COLLAPSED({ isAllCollapsed })),
+              headerProps: {
+                onToggleCollapse: (group) => dispatch(SET_COLLAPSED({ group }))
+              }
+            }}
           />
         </div>
         <ColumnContextMenu />


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [X] Make sure you are making a pull request against the **dev** branch (left side). Also you should start *your branch* off *dev*.
- [X] Check the commit's or even all commits' message 
- [X] Check if your code additions will fail linting checks
- [X] Remember: Add issue description to [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md) with the **ID of the issue** associated with this PR
- [X] Documentation: Have a look at the [PP365 User manual](https://puzzlepart.github.io/prosjektportalen-manual/) and consider the need for updates to be made. Updates can be done directly into the 'Kladd' branch or by providing information to test team for implementation.

### Description

Fixed an issue where it was not possible to collapse groups in aggregated webparts. This is a temporary fix as the rework of the whole state has made it impossible for the state.groups to change a property

### How to test

1. Gå til en av de aggregerte webdelene
2. Grupper etter Prosjekt
3. Sjekk at kollapsing per gruppe fungerer
4. Sjekk at kollapsing av alle grupperer fungerer (i header)

### Relevant issues (if applicable)

#945 
