### PR TITLE
Install and Template changes related to B&A

### DIFF
--- a/Install/Build-Release.ps1
+++ b/Install/Build-Release.ps1
@@ -24,7 +24,7 @@ function StartAction($Action) {
 
 function EndAction() {
     $global:sw_action.Stop()
-    $ElapsedSeconds = [math]::Round(($global:sw_action.ElapsedMilliseconds)/1000, 2)
+    $ElapsedSeconds = [math]::Round(($global:sw_action.ElapsedMilliseconds) / 1000, 2)
     Write-Host "Completed in $($ElapsedSeconds)s" -ForegroundColor Green
 }
 

--- a/Install/Scripts/PP365Functions.ps1
+++ b/Install/Scripts/PP365Functions.ps1
@@ -4,18 +4,19 @@
         $Identity    
     )
 
-    if( -not (Get-PnPWeb | Select-Object Url) -like ("*admin.sharepoint.com*") ){
+    if ( -not (Get-PnPWeb | Select-Object Url) -like ("*admin.sharepoint.com*") ) {
         Write-Host "Not connected to an admin site, cannot get hubsite children"
         throw
     }
 
-    if($Identity.GetType().Name -eq "HubSiteProperties"){
+    if ($Identity.GetType().Name -eq "HubSiteProperties") {
         $FilterSiteId = $Identity.SiteId.ToString()
-    } else {
+    }
+    else {
         $FilterSiteId = $Identity
     }
 
     $Items = Get-PnPListItem -List "DO_NOT_DELETE_SPLIST_TENANTADMIN_AGGREGATED_SITECOLLECTIONS" -PageSize 500
-    $FilteredItems = $Items | Where-Object {$_["HubSiteId"] -eq $FilterSiteId -and $_["SiteId"] -ne $FilterSiteId}
+    $FilteredItems = $Items | Where-Object { $_["HubSiteId"] -eq $FilterSiteId -and $_["SiteId"] -ne $FilterSiteId }
     return $FilteredItems.FieldValues.SiteUrl
 }

--- a/Install/Scripts/PostInstall.ps1
+++ b/Install/Scripts/PostInstall.ps1
@@ -13,8 +13,8 @@ $TemplateSetups = Get-PnPListItem -List "Maloppsett"
 $TemplateFiles = Get-PnPListItem -List "Prosjektmaler"
 
 $TemplatesMap = @{
-    "Standardmal" = "Standardmal.txt";
-    "Programmal" = "Programmal.txt";
+    "Standardmal"    = "Standardmal.txt";
+    "Programmal"     = "Programmal.txt";
     "Overordnet mal" = "Overordnet.txt";
 }
 

--- a/Install/Scripts/PostInstallUpgrade.ps1
+++ b/Install/Scripts/PostInstallUpgrade.ps1
@@ -54,9 +54,7 @@ if ($null -ne $LastInstall) {
     }
 
     if ($PreviousVersion -lt "1.8.0" -or $PreviousVersion -like "*BA*") {
-
         Write-Host "[INFO] In version v1.8.0 we have integrated the 'Bygg & Anlegg' addon with standard installation. Checking to see if addon has been previously installed..." 
-
 
         #If Either Bygg or Anlegg changes title in the list, rename these.
         $TemplateMap = @{
@@ -79,7 +77,6 @@ if ($null -ne $LastInstall) {
 
         $Bygg = $MalOppsett | Where-Object { $_["Title"] -eq $TemplateMap["Bygg"] }
         $Anlegg = $MalOppsett | Where-Object { $_["Title"] -eq $TemplateMap["Anlegg"] }
-
         $ByggPlanner = $ListContent | Where-Object { $_["Title"] -eq $ListContentMap["PlannerBygg"] }
         $ByggFasesjekk = $ListContent | Where-Object { $_["Title"] -eq $ListContentMap["FasesjekkBygg"] }
         $ByggDokument = $ListContent | Where-Object { $_["Title"] -eq $ListContentMap["DokumentBygg"] }
@@ -102,9 +99,5 @@ if ($null -ne $LastInstall) {
         $Anlegg["ListContentConfigLookup"] = $AnleggItems
         $Anlegg.SystemUpdate()
         $Anlegg.Context.ExecuteQuery()
-
-
-
-
     }
 }

--- a/Install/Scripts/PostInstallUpgrade.ps1
+++ b/Install/Scripts/PostInstallUpgrade.ps1
@@ -54,8 +54,57 @@ if ($null -ne $LastInstall) {
     }
 
     if ($PreviousVersion -lt "1.8.0" -or $PreviousVersion -like "*BA*") {
+
         Write-Host "[INFO] In version v1.8.0 we have integrated the 'Bygg & Anlegg' addon with standard installation. Checking to see if addon has been previously installed..." 
 
-        # Set correct listeinnhold to B&A maloppsett
+
+        #If Either Bygg or Anlegg changes title in the list, rename these.
+        $TemplateMap = @{
+            "Bygg"="Byggprosjekt";
+            "Anlegg"="Anleggsprosjekt"
+        }
+
+        #If any of the titles are changed, change here.
+        $ListContentMap = @{
+            "FasesjekkBygg" = "Fasesjekkliste Bygg";
+            "PlannerBygg" = "Planneroppgaver Bygg";
+            "DokumentBygg" = "Standarddokumenter Bygg";
+            "FasesjekkAnlegg" = "Fasesjekkliste Anlegg";
+            "PlannerAnlegg" = "Planneroppgaver Anlegg";
+            "DokumentAnlegg" = "Standarddokumenter Anlegg";
+        }
+
+        $ListContent = Get-PnPListItem -List Listeinnhold
+        $MalOppsett = Get-PnPListItem -List Maloppsett
+
+        $Bygg = $MalOppsett | Where-Object { $_["Title"] -eq $TemplateMap["Bygg"] }
+        $Anlegg = $MalOppsett | Where-Object { $_["Title"] -eq $TemplateMap["Anlegg"] }
+
+        $ByggPlanner = $ListContent | Where-Object { $_["Title"] -eq $ListContentMap["PlannerBygg"] }
+        $ByggFasesjekk = $ListContent | Where-Object { $_["Title"] -eq $ListContentMap["FasesjekkBygg"] }
+        $ByggDokument = $ListContent | Where-Object { $_["Title"] -eq $ListContentMap["DokumentBygg"] }
+        $AnleggPlanner = $ListContent | Where-Object { $_["Title"] -eq $ListContentMap["PlannerAnlegg"] }
+        $AnleggFasesjekk = $ListContent | Where-Object { $_["Title"] -eq $ListContentMap["FasesjekkAnlegg"] }
+        $AnleggDokument = $ListContent | Where-Object { $_["Title"] -eq $ListContentMap["DokumentAnlegg"] }     
+
+        #Adds Standard List Content to B&A template setup
+        $ByggItems = @()
+        $ByggItems+=[Microsoft.SharePoint.Client.FieldLookupValue]@{"LookupId"=$ByggPlanner.Id}
+        $ByggItems+=[Microsoft.SharePoint.Client.FieldLookupValue]@{"LookupId"=$ByggFasesjekk.Id}
+        $ByggItems+=[Microsoft.SharePoint.Client.FieldLookupValue]@{"LookupId"=$ByggDokument.Id}
+        $Bygg["ListContentConfigLookup"] = $ByggItems
+        $Bygg.SystemUpdate()
+        $Bygg.Context.ExecuteQuery()
+        $AnleggItems = @()
+        $AnleggItems += [Microsoft.SharePoint.Client.FieldLookupValue]@{"LookupId"=$AnleggPlanner.Id}
+        $AnleggItems += [Microsoft.SharePoint.Client.FieldLookupValue]@{"LookupId"=$AnleggFasesjekk.Id}
+        $AnleggItems += [Microsoft.SharePoint.Client.FieldLookupValue]@{"LookupId"=$AnleggDokument.Id}
+        $Anlegg["ListContentConfigLookup"] = $AnleggItems
+        $Anlegg.SystemUpdate()
+        $Anlegg.Context.ExecuteQuery()
+
+
+
+
     }
 }

--- a/Install/Scripts/PostInstallUpgrade.ps1
+++ b/Install/Scripts/PostInstallUpgrade.ps1
@@ -52,4 +52,10 @@ if ($null -ne $LastInstall) {
         Add-PnPNavigationNode -Location TopNavigationBar -Title "Usikkerhetsoversikt" -Url "$($Uri.LocalPath)/SitePages/Usikkerhetsoversikt.aspx"
         Write-Host "[SUCCESS] Please adjust navigation order manually"
     }
+
+    if ($PreviousVersion -lt "1.8.0" -or $PreviousVersion -like "*BA*") {
+        Write-Host "[INFO] In version v1.8.0 we have integrated the 'Bygg & Anlegg' addon with standard installation. Checking to see if addon has been previously installed..." 
+
+        # Set correct listeinnhold to B&A maloppsett
+    }
 }

--- a/Install/Scripts/PreInstallUpgrade.ps1
+++ b/Install/Scripts/PreInstallUpgrade.ps1
@@ -35,4 +35,30 @@ if ($null -ne $LastInstall) {
             }
         }
     }
+
+    if ($PreviousVersion -lt "1.8.0") {
+        Write-Host "[INFO] In version v1.8.0 we have integrated the 'Bygg & Anlegg' addon with standard installation. Checking to see if addon has been previously installed..." 
+
+        $TermSetA = Get-PnPTermSet -Identity "cc6cdd18-c7d5-42e1-8d19-a336dd78f3f2" -TermGroup "Prosjektportalen" -ErrorAction SilentlyContinue
+            $TermSetB = Get-PnPTermSet -Identity "ec5ceb95-7259-4282-811f-7c57304be71e" -TermGroup "Prosjektportalen" -ErrorAction SilentlyContinue
+        if ($TermSetA -or $TermSetB) {
+            Write-Host "[INFO] 'Bygg & Anlegg' addon detected. Renaming old contenttypes to avoid conflicts..." 
+            $ProjectStatusBACT = Get-PnPContentType -Identity "Prosjektstatus (Bygg og anlegg)" -ErrorAction SilentlyContinue
+            $ProjectBACT = Get-PnPContentType -Identity "Prosjektstatus (Bygg og anlegg)" -ErrorAction SilentlyContinue
+
+            if ($ProjectStatusBACT) {
+                $ProjectStatusBACT.Name = "Prosjektstatus (Bygg og anlegg) - UTDATERT"
+                $ProjectStatusBACT.SystemUpdate()
+                $ProjectStatusBACT.Context.ExecuteQuery()
+            }
+
+            if ($ProjectBACT) {
+                $ProjectBACT.Name = "Prosjekt (Bygg og anlegg) - UTDATERT"
+                $ProjectBACT.SystemUpdate()
+                $ProjectBACT.Context.ExecuteQuery()
+            }
+            Write-Host "[SUCCESS] 'Bygg & Anlegg' contenttypes renamed" 
+
+        }
+    }
 }

--- a/Install/Scripts/PreInstallUpgrade.ps1
+++ b/Install/Scripts/PreInstallUpgrade.ps1
@@ -36,11 +36,11 @@ if ($null -ne $LastInstall) {
         }
     }
 
-    if ($PreviousVersion -lt "1.8.0") {
+    if ($PreviousVersion -lt "1.8.0" -or $PreviousVersion -like "*BA*") {
         Write-Host "[INFO] In version v1.8.0 we have integrated the 'Bygg & Anlegg' addon with standard installation. Checking to see if addon has been previously installed..." 
 
         $TermSetA = Get-PnPTermSet -Identity "cc6cdd18-c7d5-42e1-8d19-a336dd78f3f2" -TermGroup "Prosjektportalen" -ErrorAction SilentlyContinue
-            $TermSetB = Get-PnPTermSet -Identity "ec5ceb95-7259-4282-811f-7c57304be71e" -TermGroup "Prosjektportalen" -ErrorAction SilentlyContinue
+        $TermSetB = Get-PnPTermSet -Identity "ec5ceb95-7259-4282-811f-7c57304be71e" -TermGroup "Prosjektportalen" -ErrorAction SilentlyContinue
         if ($TermSetA -or $TermSetB) {
             Write-Host "[INFO] 'Bygg & Anlegg' addon detected. Renaming old contenttypes to avoid conflicts..." 
             $ProjectStatusBACT = Get-PnPContentType -Identity "Prosjektstatus (Bygg og anlegg)" -ErrorAction SilentlyContinue

--- a/Install/Scripts/PreInstallUpgrade.ps1
+++ b/Install/Scripts/PreInstallUpgrade.ps1
@@ -57,8 +57,7 @@ if ($null -ne $LastInstall) {
                 $ProjectBACT.SystemUpdate()
                 $ProjectBACT.Context.ExecuteQuery()
             }
-            Write-Host "[SUCCESS] 'Bygg & Anlegg' contenttypes renamed" 
-
+            Write-Host "[SUCCESS] 'Bygg & Anlegg' contenttypes re-named" 
         }
     }
 }

--- a/Install/Scripts/PreInstallUpgrade.ps1
+++ b/Install/Scripts/PreInstallUpgrade.ps1
@@ -44,7 +44,7 @@ if ($null -ne $LastInstall) {
         if ($TermSetA -or $TermSetB) {
             Write-Host "[INFO] 'Bygg & Anlegg' addon detected. Renaming old contenttypes to avoid conflicts..." 
             $ProjectStatusBACT = Get-PnPContentType -Identity "Prosjektstatus (Bygg og anlegg)" -ErrorAction SilentlyContinue
-            $ProjectBACT = Get-PnPContentType -Identity "Prosjektstatus (Bygg og anlegg)" -ErrorAction SilentlyContinue
+            $ProjectBACT = Get-PnPContentType -Identity "Prosjekt (Bygg og anlegg)" -ErrorAction SilentlyContinue
 
             if ($ProjectStatusBACT) {
                 $ProjectStatusBACT.Name = "Prosjektstatus (Bygg og anlegg) - UTDATERT"

--- a/Install/Scripts/UpgradeAllSitesToLatest.ps1
+++ b/Install/Scripts/UpgradeAllSitesToLatest.ps1
@@ -72,7 +72,7 @@ function EnsureProjectTimelinePage() {
 }
 
 function EnsureResourceLoadIsSiteColumn() {
-    if($global:__InstalledVersion -lt "1.7.2") {
+    if ($global:__InstalledVersion -lt "1.7.2") {
         $ResourceAllocation = Get-PnPList -Identity "Ressursallokering" -ErrorAction SilentlyContinue
         if ($null -ne $ResourceAllocation) {
             $ResourceLoadSiteColumn = Get-PnPField -Identity "GtResourceLoad"

--- a/Templates/Portfolio/Resources.en-US.resx
+++ b/Templates/Portfolio/Resources.en-US.resx
@@ -416,13 +416,13 @@
     <value></value>
   </data>
   <data name="ContentTypes_ProjectBA_Name" xml:space="preserve">
-    <value>Prosjekt (Bygg og anlegg)</value>
+    <value>Prosjekt (BA)</value>
   </data>
   <data name="ContentTypes_ProjectBA_Description" xml:space="preserve">
     <value>Prosjekt innholdstype for bygg- og anleggsprosjekter</value>
   </data>
   <data name="ContentTypes_ProjectStatusBA_Name" xml:space="preserve">
-    <value>Prosjektstatus (Bygg og anlegg)</value>
+    <value>Prosjektstatus (BA)</value>
   </data>
   <data name="ContentTypes_ProjectStatusBA_Description" xml:space="preserve">
     <value>Prosjektstatus innholdstype for bygg- og anleggsprosjekter</value>

--- a/Templates/Portfolio/Resources.no-NB.resx
+++ b/Templates/Portfolio/Resources.no-NB.resx
@@ -464,13 +464,13 @@
     <value></value>
   </data>
   <data name="ContentTypes_ProjectBA_Name" xml:space="preserve">
-    <value>Prosjekt (Bygg og anlegg)</value>
+    <value>Prosjekt (BA)</value>
   </data>
   <data name="ContentTypes_ProjectBA_Description" xml:space="preserve">
     <value>Prosjekt innholdstype for bygg- og anleggsprosjekter</value>
   </data>
   <data name="ContentTypes_ProjectStatusBA_Name" xml:space="preserve">
-    <value>Prosjektstatus (Bygg og anlegg)</value>
+    <value>Prosjektstatus (BA)</value>
   </data>
   <data name="ContentTypes_ProjectStatusBA_Description" xml:space="preserve">
     <value>Prosjektstatus innholdstype for bygg- og anleggsprosjekter</value>


### PR DESCRIPTION
## Sjekklisten din

Alle sjekkpunktene under må være sjekket av og godkjent for at vi skal kunne merge branchen din mot dev.

- [x] Sjekk at din branch ikke feiler på `linting`.
- [x] Anig korrekt `Milestone` på PR-en og issuet
- [x] Tilegn deg selv PR-en og legg til `labels`

### Beskrivelse

Det har vært utfordringer knyttet til installasjon as BA innhold ved oppgraderinger fra eksisterende BA installasjoner.
PRen inneholder følgende:
* Bytte av BA Content Type navn til et unikt navn. Dette ble forsøkt unngått ved å fjerne eksisterende CT, men dette gikk ikke. 
  * `A duplicate content type "Prosjektstatus (Bygg og anlegg)" was found.` oppsto selv ved fjerning av eksisterende CT før oppgradering ble forsøkt kjørt, men feilet. Samme feil for Prosjekt (Bygg og anlegg)
  * Endrer nå navn på eksisterende CT, og legger til ny CT
* Listeinnhold manglet for Bygg og Anlegg malene. Vi legger nå inn disse

