### PR TITLE
Skjul tom '? Hjelp tilgjengelig' linje dersom hjelpeinnhold ikke er definert for siden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ og dette prosjektet følger [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue where webparts didn't load properly because user didn't have an e-mail account [#844](https://github.com/Puzzlepart/prosjektportalen365/issues/844)
 - Fixed bugs where users could not upgrade from pre 1.5.4 versions [#901](https://github.com/Puzzlepart/prosjektportalen365/issues/901)
 - Fixed a bug where parts of 'Fasevelger' webpart didn't show properly [#920](https://github.com/Puzzlepart/prosjektportalen365/issues/920)
+- Fixed a bug where '? Hjelp tilgjengelig' div rendered as empty line if a page didn't have help content [#974](https://github.com/Puzzlepart/prosjektportalen365/issues/974)
 
 ---
 

--- a/SharePointFramework/ProjectExtensions/src/helpContent/index.tsx
+++ b/SharePointFramework/ProjectExtensions/src/helpContent/index.tsx
@@ -37,6 +37,7 @@ export default class HelpContentApplicationCustomizer extends BaseApplicationCus
    */
   private async _render(): Promise<void> {
     const helpContent = await this._getHelpContent(this.properties.listName)
+    if (helpContent.length === 0) return
     const helpContentId = 'pp-help-content'
     let helpContentPlaceholder = document.getElementById(helpContentId)
     if (helpContentPlaceholder === null) {


### PR DESCRIPTION
# Pull request (PR)

Sørg for at du ber om PR for din branch (høyre side). Sørg for at du gjør en PR mot dev-branchen (venstre side). Sjekk commits og alle commit-meldingene.

## Sjekklisten din

Alle sjekkpunktene under må være sjekket av og godkjent for at vi skal kunne merge branchen din mot dev.

- [x] Sjekk at din branch ikke feiler på `linting`.
- [x] Legg ved beskrivelse i [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md), markert med **ID av issue** knyttet til PR-en
- [x] Anig korrekt `Milestone` på PR-en og issuet
- [x] Tilegn deg selv PR-en og legg til `labels`

### Beskrivelse

Denne feilrettingen vil skjule tom '? Hjelp tilgjengelig' linje dersom hjelpeinnhold ikke er definert for siden.

| Før      | Etter      |
| -------- | ---------- |
| ![image](https://user-images.githubusercontent.com/28678468/218066574-b18a1b7d-b75b-4cce-abe6-009974b6f5b5.png) | ![image](https://user-images.githubusercontent.com/28678468/218066628-902dffdc-e25b-4c9c-89fd-e32bf6db4959.png) |

### Hvordan teste


| #   | Handling          | Forventet resultat     |
| --- | ----------------- | ---------------------- |
| 1   | Gå til en side som ikke har hjelp innhold definert  | Tom linje skal ikke vises (se før/etter bilder i PR)  |

### Relevante issues (hvis aktuelt)

- #974 

