### PR TITLE
Fiks for Planneroppgaver som ikke blir opprettet dersom de mangler plannavn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ og dette prosjektet følger [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Fixed an issue where webparts didn't load properly because user didn't have an e-mail account [#844](https://github.com/Puzzlepart/prosjektportalen365/issues/844)
 - Fixed bugs where users could not upgrade from pre 1.5.4 versions [#901](https://github.com/Puzzlepart/prosjektportalen365/issues/901)
 - Fixed a bug where parts of 'Fasevelger' webpart didn't show properly [#920](https://github.com/Puzzlepart/prosjektportalen365/issues/920)
+- Fixed a bug where planner plans without 'Plannername' in 'ListContent' failed under ProjectSetup [#976](https://github.com/Puzzlepart/prosjektportalen365/issues/976)
 
 ---
 

--- a/SharePointFramework/ProjectExtensions/src/models/ContentConfig.ts
+++ b/SharePointFramework/ProjectExtensions/src/models/ContentConfig.ts
@@ -44,7 +44,7 @@ export class ContentConfig extends UserSelectableObject {
     )
     this._sourceList = _spItem.GtLccSourceList
     this._destinationList = _spItem.GtLccDestinationList
-    this.plannerTitle = _spItem.GtPlannerName
+    this.plannerTitle = _spItem.GtPlannerName || _spItem.Title
   }
 
   /**

--- a/Templates/Portfolio/Objects/Lists/Listeinnhold.xml
+++ b/Templates/Portfolio/Objects/Lists/Listeinnhold.xml
@@ -96,6 +96,7 @@
             <pnp:DataValue FieldName="GtLccFields">-</pnp:DataValue>
             <pnp:DataValue FieldName="GtLccDefault">0</pnp:DataValue>
             <pnp:DataValue FieldName="GtLccHidden">0</pnp:DataValue>
+            <pnp:DataValue FieldName="GtPlannerName">Standardplan</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>
             <pnp:DataValue FieldName="ContentTypeId">0x0100B8B4EE61A547B247B49CFC21B67D5B7D01</pnp:DataValue>
@@ -105,6 +106,7 @@
             <pnp:DataValue FieldName="GtLccFields">-</pnp:DataValue>
             <pnp:DataValue FieldName="GtLccDefault">0</pnp:DataValue>
             <pnp:DataValue FieldName="GtLccHidden">0</pnp:DataValue>
+            <pnp:DataValue FieldName="GtPlannerName">Byggplan</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>
             <pnp:DataValue FieldName="ContentTypeId">0x0100B8B4EE61A547B247B49CFC21B67D5B7D01</pnp:DataValue>
@@ -114,6 +116,7 @@
             <pnp:DataValue FieldName="GtLccFields">-</pnp:DataValue>
             <pnp:DataValue FieldName="GtLccDefault">0</pnp:DataValue>
             <pnp:DataValue FieldName="GtLccHidden">0</pnp:DataValue>
+            <pnp:DataValue FieldName="GtPlannerName">Anleggsplan</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>
             <pnp:DataValue FieldName="Title">Standarddokumenter Bygg</pnp:DataValue>

--- a/Templates/Portfolio/Resources.no-NB.resx
+++ b/Templates/Portfolio/Resources.no-NB.resx
@@ -2183,10 +2183,10 @@
     <value>Velg hvilke tilganger denne rollen skal ha.</value>
   </data>
   <data name="SiteFields_GtPlannerName_DisplayName" xml:space="preserve">
-    <value>Plan-navn</value>
+    <value>Plannavn</value>
   </data>
   <data name="SiteFields_GtPlannerName_Description" xml:space="preserve">
-    <value>Velg et eget navn for planen. Brukes om du vil opprette flere planer for samme prosjekt. Det fullstendige plan-navnet vil også inneholde navnet på området/prosjektet.</value>
+    <value>Velg et eget navn for planen. Brukes om du vil opprette flere planer for samme prosjekt. Det fullstendige plannavnet vil også inneholde navnet på området/prosjektet.</value>
   </data>
   <data name="ProjectPhases_GoToChecklist2" xml:space="preserve">
     <value>Gå til &lt;a href="{0" target="_blank"&gt;fasesjekklisten&lt;/a&gt; (åpnes i ny fane)</value>


### PR DESCRIPTION
# Pull request (PR)

Sørg for at du ber om PR for din branch (høyre side). Sørg for at du gjør en PR mot dev-branchen (venstre side). Sjekk commits og alle commit-meldingene.

## Sjekklisten din

Alle sjekkpunktene under må være sjekket av og godkjent for at vi skal kunne merge branchen din mot dev.

- [X] Sjekk at din branch ikke feiler på `linting`.
- [X] Legg ved beskrivelse i [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md), markert med **ID av issue** knyttet til PR-en
- [X] Anig korrekt `Milestone` på PR-en og issuet
- [X] Tilegn deg selv PR-en og legg til `labels`

### Beskrivelse

Denne feilrettingen fikser problemet som omhandlet opprettelse av prosjekt med planner plan som manglet plannavn, det er nå lagt inn fallback mot tittel slik at dette vil fungere dersom plannavn ikke er angitt.

- Standard planneroppgaver har nå standardnavn som en del av løsningen
  - Planneroppgaver: Standardplan
  - Planneroppgaver Bygg: Byggplan
  - Planneropgaver Anlegg: Anleggsplan
- 'Plan-navn' kolonnen i `Listeinnhold` endres til 'Plannavn'

### Hvordan teste

| #   | Handling          | Forventet resultat     |
| --- | ----------------- | ---------------------- |
| 1   | Opprett prosjekt med en Planneroppgave som ikke har plannavn angitt og verifiser at planner plan er opprettet  | Dette vil nå fungere og tittelen på planen er det samme tom 'Tittel' i `Listeinnhold` listen.  |

### Relevante issues (hvis aktuelt)

- #976 

