### PR TITLE
Vise statusrapport ikoner  standard i prosjektinformasjon webdel

### DIFF
--- a/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/index.tsx
@@ -66,8 +66,8 @@ ProjectInformation.defaultProps = {
   hideActions: [],
   hideAllActions: false,
   useFramelessButtons: false,
-  hideStatusReport: true,
-  hideParentProjects: true,
+  hideStatusReport: false,
+  hideParentProjects: false,
   statusReportShowOnlyIcons: true
 }
 


### PR DESCRIPTION
# Pull request (PR)

Sørg for at du ber om PR for din branch (høyre side). Sørg for at du gjør en PR mot dev-branchen (venstre side). Sjekk commits og alle commit-meldingene.

## Sjekklisten din

Alle sjekkpunktene under må være sjekket av og godkjent for at vi skal kunne merge branchen din mot dev.

- [X] Sjekk at din branch ikke feiler på `linting`.
- [X] Legg ved beskrivelse i [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md), markert med **ID av issue** knyttet til PR-en
- [X] Anig korrekt `Milestone` på PR-en og issuet
- [X] Tilegn deg selv PR-en og legg til `labels`

### Beskrivelse

Som standard skal siste statusrapport ikoner vises i bunnen av prosjektinformasjon webdel

| Før      | Etter      |
| -------- | ---------- |
| ![image](https://user-images.githubusercontent.com/28678468/218083584-1f7d90c2-9a41-4d73-8e89-1382fd050546.png) | ![image](https://user-images.githubusercontent.com/28678468/218083622-d8637cad-70cd-4f94-a160-1373770373d9.png) |

### Hvordan teste

Vennligst beskriv hvordan noen andre (en vanlig bruker uten kodeferdigheter) kan teste denne PR-en. Følg eksempelet under, punktene du legger ved vil bli brukt når vi tester neste versjon av Prosjektportalen

| #   | Handling          | Forventet resultat     |
| --- | ----------------- | ---------------------- |
| 1   | Gå inn på et prosjekt som har statusrapport og se at ikoner vises i bunnen av prosjektinformasjon webdel (Vis som ikoner skal være standard visning)  | Som standard skal siste statusrapport ikoner vises i bunnen av prosjektinformasjon webdel  |

### Relevante issues (hvis aktuelt)

- #978 

