### PR TITLE
Fikset problem med 'Usikkerhetsoversikt' kategori mangel

### DIFF
--- a/Templates/Portfolio/Objects/Lists/Hjelpeinnhold.xml
+++ b/Templates/Portfolio/Objects/Lists/Hjelpeinnhold.xml
@@ -82,9 +82,9 @@
         </pnp:DataRow>
         <pnp:DataRow>
             <pnp:DataValue FieldName="GtSortOrder">70</pnp:DataValue>
-            <pnp:DataValue FieldName="Title">Risikooversikt Brukermanual</pnp:DataValue>
+            <pnp:DataValue FieldName="Title">Usikkerhetsoversikt Brukermanual</pnp:DataValue>
             <pnp:DataValue FieldName="GtIconName" />
-            <pnp:DataValue FieldName="GtURL">SitePages/Risikooversikt.aspx</pnp:DataValue>
+            <pnp:DataValue FieldName="GtURL">SitePages/Usikkerhetsoversikt.aspx</pnp:DataValue>
             <pnp:DataValue FieldName="GtTextContent" />
             <pnp:DataValue FieldName="GtResourceLink" />
             <pnp:DataValue FieldName="GtExternalURL">https://github.com/Puzzlepart/prosjektportalen-manual/blob/master/Brukermanual/3%20Portefolje/3.7%20Risikooversikt.md</pnp:DataValue>

--- a/Templates/Portfolio/Objects/Lists/Prosjektinnholdskolonner.xml
+++ b/Templates/Portfolio/Objects/Lists/Prosjektinnholdskolonner.xml
@@ -75,7 +75,7 @@
             <pnp:DataValue FieldName="GtInternalName">GtRiskProbability</pnp:DataValue>
             <pnp:DataValue FieldName="GtManagedProperty">GtRiskProbabilityOWSNMBR</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Number</pnp:DataValue>
-            <pnp:DataValue FieldName="GtDataSourceCategory">Risikooversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtDataSourceCategory">Usikkerhetsoversikt</pnp:DataValue>
             <pnp:DataValue FieldName="GtColMinWidth">100</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 7 -->
@@ -84,7 +84,7 @@
             <pnp:DataValue FieldName="GtInternalName">GtRiskConsequence</pnp:DataValue>
             <pnp:DataValue FieldName="GtManagedProperty">GtRiskConsequenceOWSNMBR</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Number</pnp:DataValue>
-            <pnp:DataValue FieldName="GtDataSourceCategory">Risikooversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtDataSourceCategory">Usikkerhetsoversikt</pnp:DataValue>
             <pnp:DataValue FieldName="GtColMinWidth">100</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 8 -->
@@ -93,7 +93,7 @@
             <pnp:DataValue FieldName="GtInternalName">GtRiskProbabilityPostAction</pnp:DataValue>
             <pnp:DataValue FieldName="GtManagedProperty">GtRiskProbabilityPostActionOWSNMBR</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Number</pnp:DataValue>
-            <pnp:DataValue FieldName="GtDataSourceCategory">Risikooversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtDataSourceCategory">Usikkerhetsoversikt</pnp:DataValue>
             <pnp:DataValue FieldName="GtColMinWidth">100</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 9 -->
@@ -102,7 +102,7 @@
             <pnp:DataValue FieldName="GtInternalName">GtRiskConsequencePostAction</pnp:DataValue>
             <pnp:DataValue FieldName="GtManagedProperty">GtRiskConsequencePostActionOWSNMBR</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Number</pnp:DataValue>
-            <pnp:DataValue FieldName="GtDataSourceCategory">Risikooversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtDataSourceCategory">Usikkerhetsoversikt</pnp:DataValue>
             <pnp:DataValue FieldName="GtColMinWidth">100</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 10 -->
@@ -111,7 +111,7 @@
             <pnp:DataValue FieldName="GtInternalName">GtRiskActionOWSMTXT</pnp:DataValue>
             <pnp:DataValue FieldName="GtManagedProperty">GtRiskActionOWSMTXT</pnp:DataValue>
             <pnp:DataValue FieldName="GtFieldDataType">Note</pnp:DataValue>
-            <pnp:DataValue FieldName="GtDataSourceCategory">Risikooversikt</pnp:DataValue>
+            <pnp:DataValue FieldName="GtDataSourceCategory">Usikkerhetsoversikt</pnp:DataValue>
             <pnp:DataValue FieldName="GtColMinWidth">300</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>            <!-- ID: 11 -->


### PR DESCRIPTION
# Pull request (PR)

Sørg for at du ber om PR for din branch (høyre side). Sørg for at du gjør en PR mot dev-branchen (venstre side). Sjekk commits og alle commit-meldingene.

## Sjekklisten din

Alle sjekkpunktene under må være sjekket av og godkjent for at vi skal kunne merge branchen din mot dev.

- [X] Sjekk at din branch ikke feiler på `linting`.
- [X] Legg ved beskrivelse i [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md), markert med **ID av issue** knyttet til PR-en `Ikke nødvendig for denne PR-en`
- [X] Anig korrekt `Milestone` på PR-en og issuet
- [X] Tilegn deg selv PR-en og legg til `labels`

### Beskrivelse

Da Usikkerhetsoversikten ble endret fra å være Risikooversikt, ble elementer i Prosjektinnholdskolonner listen gjenværende i gammel kategori. Dermed dukket ikke riktige kolonner opp i listen og Filterpanel sluttet å fungere.

Dette er nå blitt fikset. Ved oppgradering vil den oppdatere elementer som sto i 'Risikooversikt' kategori så lenge InternalName er lik som standard.

### Hvordan teste

| #   | Handling          | Forventet resultat     |
| --- | ----------------- | ---------------------- |
| 1   | Gå til Usikkerhetsoversikten, se at visninger og filterpanel fungerer som normalt  | Visninger og filterpanel skal fungere som normalt  |

### Relevante issues (hvis aktuelt)

- #980 
