### PR TITLE
Fiks for kommandolinje og standard egenskaper på prosjekttidslinje

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Sjekk ut [release notes](./releasenotes/1.8.0.md) for høydepunkter og mer detal
 ### Feilrettinger
 
 - Fikset et problem i oppgraderingsskript der noen tenants ikke kunne hente alle hub children
+- Fikset et problem hvor kommandolinje ikke ble vist som standard [#1042](https://github.com/Puzzlepart/prosjektportalen365/issues/1042)
 
 ## 1.8.0 - 28.02.2023
 

--- a/Install/Scripts/UpgradeAllSitesToLatest.ps1
+++ b/Install/Scripts/UpgradeAllSitesToLatest.ps1
@@ -57,7 +57,7 @@ function EnsureProjectTimelinePage() {
             Write-Host "`t`t`tAdding project timeline page"
             Add-PnPPage -Name "Prosjekttidslinje.aspx" -PromoteAs None -LayoutType SingleWebPartAppPage -CommentsEnabled:$false -Publish >$null 2>&1
             Write-Host "`t`t`tAdding project timeline app"
-            Add-PnPPageWebPart -Page "Prosjekttidslinje" -Component "Prosjekttidslinje" -WebPartProperties '{"listName":"Tidslinjeinnhold","showFilterButton":true,"showTimeline":true,"showInfoMessage":true,"showCmdTimelineList":true,"showTimelineList":true,"title":"Prosjekttidslinje"}' >$null 2>&1
+            Add-PnPPageWebPart -Page "Prosjekttidslinje" -Component "Prosjekttidslinje" -WebPartProperties '{"listName":"Tidslinjeinnhold","showTimeline":true,"showTimelineListCommands":true,"showTimelineList":true,"showProjectDeliveries":false,"projectDeliveriesListName":"Prosjektleveranser","configItemTitle":"Prosjektleveranse"}' >$null 2>&1
             Set-PnPClientSidePage -Identity "Prosjekttidslinje" -LayoutType SingleWebPartAppPage -HeaderType None -Publish >$null 2>&1
             Write-Host "`t`t`tAdding project timeline navigation item"
             Add-PnPNavigationNode -Location QuickLaunch -Title "Prosjekttidslinje" -Url "SitePages/Prosjekttidslinje.aspx" >$null 2>&1
@@ -224,7 +224,7 @@ $UserName = $Context.Web.CurrentUser.LoginName
 
 Write-Host "Retrieving all sites of the Project Portal hub..."
 $ProjectsHub = Get-PnPTenantSite -Identity $Url
-$ProjectsInHub = Get-PnPTenantSite | Where-Object {$_.HubSiteId -eq $ProjectsHub.HubSiteId -and $_.Url -ne $ProjectsHub.Url } | ForEach-Object { return $_.Url }
+$ProjectsInHub = Get-PnPTenantSite | Where-Object { $_.HubSiteId -eq $ProjectsHub.HubSiteId -and $_.Url -ne $ProjectsHub.Url } | ForEach-Object { return $_.Url }
 
 Write-Host "The following sites were found to be part of the Project Portal hub:"
 $ProjectsInHub | ForEach-Object { Write-Host "`t$_" }

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectTimeline/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectTimeline/index.tsx
@@ -52,9 +52,13 @@ export const ProjectTimeline: FC<IProjectTimelineProps> = (props) => {
 }
 
 ProjectTimeline.defaultProps = {
+  showTimeline: true,
+  showTimelineList: true,
+  showTimelineListCommands: true,
   defaultTimeframeStart: '4,months',
   defaultTimeframeEnd: '4,months',
   defaultGroupBy: strings.TypeLabel,
+  showProjectDeliveries: false,
   projectDeliveriesListName: 'Prosjektleveranser',
   configItemTitle: 'Prosjektleveranse',
   defaultCategory: 'Styring'

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectTimeline/types.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectTimeline/types.ts
@@ -12,7 +12,6 @@ import {
 
 export interface IProjectTimelineProps extends IBaseWebPartComponentProps {
   listName?: string
-  showFilterButton?: boolean
   showTimeline?: boolean
   showTimelineList?: boolean
   showTimelineListCommands?: boolean

--- a/Templates/JsonTemplates/_JsonTemplateProgram.json
+++ b/Templates/JsonTemplates/_JsonTemplateProgram.json
@@ -826,13 +826,14 @@
                                 {
                                     "Id": "d156652b-9121-47af-89ae-1fe8427c53da",
                                     "Properties": {
-                                        "title": "Programtidslinje",
-                                        "showFilterButton": true,
+                                        "listName": "Tidslinjeinnhold",
                                         "showTimeline": true,
-                                        "showInfoMessage": true,
-                                        "showCmdTimelineList": true,
+                                        "showTimelineListCommands": true,
                                         "showTimelineList": true,
-                                        "infoText": "Her listes listeelementene for programmet. Her kan du redigere og legge til nye elementer. Dette vil synkroniseres til listen på hubområdet. For å zoome inn/ut i tidslinje: ALT+Musehjul"
+                                        "infoText": "Her listes listeelementene for programmet. Her kan du redigere og legge til nye elementer. Dette vil synkroniseres til listen på hubområdet. For å zoome inn/ut i tidslinje: ALT+Musehjul",
+                                        "showProjectDeliveries": false,
+                                        "projectDeliveriesListName": "Prosjektleveranser",
+                                        "configItemTitle": "Prosjektleveranse"
                                     }
                                 }
                             ]

--- a/Templates/JsonTemplates/_JsonTemplateProject.json
+++ b/Templates/JsonTemplates/_JsonTemplateProject.json
@@ -796,12 +796,13 @@
                                 {
                                     "Id": "d156652b-9121-47af-89ae-1fe8427c53da",
                                     "Properties": {
-                                        "title": "Prosjekttidslinje",
-                                        "showFilterButton": true,
+                                        "listName": "Tidslinjeinnhold",
                                         "showTimeline": true,
-                                        "showInfoMessage": true,
-                                        "showCmdTimelineList": true,
-                                        "showTimelineList": true
+                                        "showTimelineListCommands": true,
+                                        "showTimelineList": true,
+                                        "showProjectDeliveries": false,
+                                        "projectDeliveriesListName": "Prosjektleveranser",
+                                        "configItemTitle": "Prosjektleveranse"
                                     }
                                 }
                             ]


### PR DESCRIPTION
# Pull request (PR)

Sørg for at du ber om PR for din branch (høyre side). Sørg for at du gjør en PR mot dev-branchen (venstre side). Sjekk commits og alle commit-meldingene.

## Sjekklisten din

Alle sjekkpunktene under må være sjekket av og godkjent for at vi skal kunne merge branchen din mot dev.

- [X] Sjekk at din branch ikke feiler på `linting`.
- [X] Legg ved beskrivelse i [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md), markert med **ID av issue** knyttet til PR-en
- [X] Angi korrekt `Milestone` på PR-en og issuet
- [X] Tilegn deg selv PR-en og legg til `labels`

### Beskrivelse

Egenskaper på prosjekttidslinje ble endret fra 1.7.2 til 1.8.0, disse var satt i maler for prosjekt og program. Dette førte til at kommandolinje ikke ble vist vist som standard (for eksisterende prosjekter blandt annet)

`showCmdTimelineList` blir satt til true, men siden denne ikke finnes (som nå heter `showTimelineListCommands`) blir den false.

Dette er blitt fikset, riktig properties er angitt i maler og upgrade script. Har også fjerna `showFilterButton` property som ikke var i bruk.

### Hvordan teste

Vennligst beskriv hvordan noen andre (en vanlig bruker uten kodeferdigheter) kan teste denne PR-en. Følg eksempelet under, punktene du legger ved vil bli brukt når vi tester neste versjon av Prosjektportalen

| #   | Handling          | Forventet resultat     |
| --- | ----------------- | ---------------------- |
| 1   | Gå til en Prosjektidslinje og verifiser at kommandolinje dukker opp  | Kommandolinje skal dukke opp på Prosjekttidslinje  |

### Relevante issues (hvis aktuelt)

- #1042 
