### PR TITLE
Fiks for uthenting av prosjektinformasjon for brukere uten tilgang til hubområdet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Sjekk ut [release notes](./releasenotes/1.8.0.md) for høydepunkter og mer detal
 
 ### Feilrettinger
 
----
+- Fiks for uthenting av prosjektinformasjon for brukere uten tilgang til hubområdet [#1080](https://github.com/Puzzlepart/prosjektportalen365/issues/1080)
 
 ## 1.8.1 - 31.03.2023
 

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/types.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/types.ts
@@ -101,17 +101,17 @@ export interface IProjectInformationProps extends IBaseWebPartComponentProps {
 export interface IProjectInformationState
   extends IBaseWebPartComponentState<IProjectInformationData> {
   /**
-   * Properties
+   * Properties 
    */
   properties?: ProjectPropertyModel[]
 
   /**
-   * All Properties
+   * All properties (used for the properties panel)
    */
   allProperties?: ProjectPropertyModel[]
 
   /**
-   * Progress
+   * Progress dialog props
    */
   progress?: IProgressDialogProps
 
@@ -151,7 +151,7 @@ export interface IProjectInformationState
   userHasEditPermission?: boolean
 
   /**
-   * Is Project data synced
+   * Is project data synced
    */
   isProjectDataSynced?: boolean
 }

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/types.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/types.ts
@@ -101,7 +101,7 @@ export interface IProjectInformationProps extends IBaseWebPartComponentProps {
 export interface IProjectInformationState
   extends IBaseWebPartComponentState<IProjectInformationData> {
   /**
-   * Properties 
+   * Properties
    */
   properties?: ProjectPropertyModel[]
 

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/useProjectInformationDataFetch.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/useProjectInformationDataFetch.ts
@@ -83,10 +83,13 @@ const checkProjectDataSynced: DataFetchFunction<IProjectInformationProps, boolea
  * Fetch project status reports, sections and column config  if `props.hideStatusReport` is false.
  * Catches errors and returns empty arrays to support e.g. the case where the user does not have
  * access to the hub site.
- * 
+ *
  * @param props Component properties for `ProjectInformation`
  */
-const fetchProjectStatusReports: DataFetchFunction<IProjectInformationProps, [StatusReport[], SectionModel[], ProjectColumnConfig[]]> = async (props) => {
+const fetchProjectStatusReports: DataFetchFunction<
+  IProjectInformationProps,
+  [StatusReport[], SectionModel[], ProjectColumnConfig[]]
+> = async (props) => {
   if (props.hideStatusReport) {
     return [[], [], []]
   }
@@ -99,11 +102,7 @@ const fetchProjectStatusReports: DataFetchFunction<IProjectInformationProps, [St
       SPDataAdapter.portal.getProjectStatusSections(),
       SPDataAdapter.portal.getProjectColumnConfig()
     ])
-    return [
-      reports,
-      sections,
-      columnConfig
-    ] 
+    return [reports, sections, columnConfig]
   } catch (error) {
     return [[], [], []]
   }
@@ -140,11 +139,11 @@ const fetchData: DataFetchFunction<
       SPDataAdapter.project.getPropertiesData(),
       props.page === 'Frontpage'
         ? SPDataAdapter.portal.getParentProjects(
-          props.webPartContext?.pageContext?.web?.absoluteUrl,
-          ProjectInformationParentProject
-        )
+            props.webPartContext?.pageContext?.web?.absoluteUrl,
+            ProjectInformationParentProject
+          )
         : Promise.resolve([]),
-      fetchProjectStatusReports(props),
+      fetchProjectStatusReports(props)
     ])
     const data: IProjectInformationData = {
       columns,


### PR DESCRIPTION
# Pull request (PR)

Sørg for at du ber om PR for din branch (høyre side). Sørg for at du gjør en PR mot riktig release-branch (venstre side). Sjekk commits og alle commit-meldingene.

## Sjekklisten din

Alle sjekkpunktene under må være sjekket av og godkjent for at vi skal kunne merge branchen din mot dev.

- [x] Sjekk at din branch ikke feiler på `linting`.
- [x] Legg ved beskrivelse i [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md), markert med **ID av issue** knyttet til PR-en
- [x] Angi korrekt `Milestone` på PR-en og issuet, samt tilegn deg selv PR-en og legg til `labels`

### Beskrivelse

Fiks for uthenting av prosjektinformasjon for brukere uten tilgang til hubområdet.

Siden brukere ikke har tilgang til området, bestemmes hvilke kolonner som skal vises for disse brukerne ved å redigere webdelen og gå til fanen "Konfigurasjon".

![image](https://user-images.githubusercontent.com/7606007/232766232-1093f73f-ded4-4a21-b889-8c082ca2d4fa.png)


### Hvordan teste
Test om Prosjektinformasjon-webdelen laster og viser spesifiserte egenskaper for en bruker uten tilgang til hubområdet.

### Relevante issues (hvis aktuelt)
#1080 

## Sjekkliste for godkjenner

Alle sjekkpunktene under må være sjekket av og godkjent av reviewers for at vi skal kunne merge branchen din mot dev.

- [ ] Sjekk at det er fylt ut testpunkter
- [x] Sjekk om det er nødvendig å nevne denne PR i release notes
- [x] Sjekk om det er nødvendig å oppdatere dokumentasjon for hjelpeinnhold
  - Ta en titt på [Brukermanual for Prosjektportalen 365](https://puzzlepart.github.io/prosjektportalen-manual/) og vurder behovet for oppdateringer.
