### PR TITLE
Endra standardsortering av dokumentbibliotek i prosjekter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Sjekk ut [release notes](./releasenotes/1.8.0.md) for høydepunkter og mer detal
 - Lagt inn mulighet for å angi sortering på Planner oppgaver som provisjoneres [#1056](https://github.com/Puzzlepart/prosjektportalen365/issues/1056)
 - Porteføljeoversikt: vis personlige visninger som egen "seksjon" [#1045](https://github.com/Puzzlepart/prosjektportalen365/issues/1045)
 - Endret feltet GtSearchQuery til Note for å støtte lange spørringer. NB: Vil ikke endres gjennom oppgradering. Endre manuelt felttype til "Flere linjer med tekst" ved behov. [#970](https://github.com/Puzzlepart/prosjektportalen365/issues/970)
+- Endra standardsortering av dokumentbiblioteker til å sortere på filnavn (var "Ingen" før)
 
 ### Feilrettinger
 

--- a/Templates/JsonTemplates/_JsonTemplateProject.json
+++ b/Templates/JsonTemplates/_JsonTemplateProject.json
@@ -1243,7 +1243,7 @@
                     "AdditionalSettings": {
                         "RowLimit": 30,
                         "Paged": true,
-                        "ViewQuery": ""
+                        "ViewQuery": "<OrderBy><FieldRef Name='LinkFilename' /></OrderBy>"
                     }
                 },
                 {
@@ -1257,7 +1257,7 @@
                     "AdditionalSettings": {
                         "RowLimit": 30,
                         "Paged": true,
-                        "ViewQuery": "",
+                        "ViewQuery": "<OrderBy><FieldRef Name='LinkFilename' /></OrderBy>",
                         "Scope": 1
                     }
                 }


### PR DESCRIPTION
# Pull request (PR)

Sørg for at du ber om PR for din branch (høyre side). Sørg for at du gjør en PR mot riktig release-branch (venstre side). Sjekk commits og alle commit-meldingene.

## Sjekklisten din

Alle sjekkpunktene under må være sjekket av og godkjent for at vi skal kunne merge branchen din mot dev.

- [X] Sjekk at din branch ikke feiler på `linting`.
- [X] Legg ved beskrivelse i [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md), markert med **ID av issue** knyttet til PR-en
- [X] Angi korrekt `Milestone` på PR-en og issuet, samt tilegn deg selv PR-en og legg til `labels`

### Beskrivelse

Standardsortering er nå etter filnavn, før var det "Ingen" som gjorde at dokument sorterte seg hulter til bulter.

### Hvordan teste

Vennligst beskriv hvordan noen andre (en vanlig bruker uten kodeferdigheter) kan teste denne PR-en. Følg eksempelet under, punktene du legger ved vil bli brukt når vi tester neste versjon av Prosjektportalen

| #   | Handling          | Forventet resultat     |
| --- | ----------------- | ---------------------- |
| 1   | Opprett prosjekt  | Prosjektet opprettes  |
| 2   | Sjekk at visningen "Alle dokumenter" sorteres etter filnavn | Visningen sorteres etter filnavn |
| 3   | Sjekk at visningen "Gjeldende fase" sorteres etter filnavn | Visningen sorteres etter filnavn |

## Sjekkliste for godkjenner

Alle sjekkpunktene under må være sjekket av og godkjent av reviewers for at vi skal kunne merge branchen din mot dev.

- [ ] Sjekk at det er fylt ut testpunkter
- [ ] Sjekk om det er nødvendig å nevne denne PR i release notes
- [ ] Sjekk om det er nødvendig å oppdatere dokumentasjon for hjelpeinnhold
  - Ta en titt på [Brukermanual for Prosjektportalen 365](https://puzzlepart.github.io/prosjektportalen-manual/) og vurder behovet for oppdateringer.
