### PR TITLE
"Vis i statusseksjonen" ble ikke overholdt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,10 @@ Sjekk ut [release notes](./releasenotes/1.8.0.md) for høydepunkter og mer detal
 - Fiks for Gevinstoversikt på prosjektnivå [#1095](https://github.com/Puzzlepart/prosjektportalen365/issues/1095)
 - Aggregerte oversikter henter nå ut alle elementer - tidligere ble det kun hentet maksimalt 500 [#1099](https://github.com/Puzzlepart/prosjektportalen365/issues/1099)
 - Fikset problem dersom det ble oppgitt for mange vedlegg eller sjekkpunkter i planneroppgaver og innhold manglet [#1039](https://github.com/Puzzlepart/prosjektportalen365/issues/1039)
-  - Det loggføres i `Logg` listen dersom begrensninger er nådd.
+- Det loggføres i `Logg` listen dersom begrensninger er nådd.
 - Fiks for #1049 (feil ved publisering av statusrapporter) [#1049](https://github.com/Puzzlepart/prosjektportalen365/issues/1049)
 - Oppgraderingsoperasjonene som kjører før oppgradering varsler nå om feil, og det ble rettet feil som gjorde at oppgradering i 1.8.0 og 1.8.1 ikke fungerte fullstendig [#1094](https://github.com/Puzzlepart/prosjektportalen365/issues/1094)
+- Fikset et problem hvor "Vis i statusseksjonen" verdien ikke ble overholdt i visning av statusseksjoner
 
 ## 1.8.1 - 31.03.2023
 

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/Sections/SummarySection/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/Sections/SummarySection/index.tsx
@@ -21,7 +21,7 @@ export const SummarySection: FC<ISummarySectionProps> = (props) => {
   function renderStatusElements() {
     return context.state.data.sections.map((sec, idx) => {
       const ctxValue = createContextValue(sec)
-      const shouldRender = ctxValue.headerProps.value || sec.fieldName === 'GtOverallStatus'
+      const shouldRender = sec.showInStatusSection && (ctxValue.headerProps.value || sec.fieldName === 'GtOverallStatus')
       return shouldRender ? (
         <SectionContext.Provider key={idx} value={ctxValue}>
           <div


### PR DESCRIPTION
# Pull request (PR)

Sørg for at du ber om PR for din branch (høyre side). Sørg for at du gjør en PR mot riktig release-branch (venstre side). Sjekk commits og alle commit-meldingene.

## Sjekklisten din

Alle sjekkpunktene under må være sjekket av og godkjent for at vi skal kunne merge branchen din mot dev.

- [X] Sjekk at din branch ikke feiler på `linting`.
- [X] Legg ved beskrivelse i [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md), markert med **ID av issue** knyttet til PR-en
- [X] Angi korrekt `Milestone` på PR-en og issuet, samt tilegn deg selv PR-en og legg til `labels`

### Beskrivelse

Feltet i konfigurasjon av statusseksjoner "Vis i statusseksjonen" hadde ingen effekt, og var ikke implementert. Feltet fungerer nå til å styre om seksjonsdata skal vises i den øverste statusseksjonen.

### Hvordan teste

Test ja/nei i feltverdien til "Vis i statusseksjonen" og se om en seksjon vises i den øverste statusseksjonen.

## Sjekkliste for godkjenner

Alle sjekkpunktene under må være sjekket av og godkjent av reviewers for at vi skal kunne merge branchen din mot dev.

- [ ] Sjekk at det er fylt ut testpunkter
- [ ] Sjekk om det er nødvendig å nevne denne PR i release notes
- [ ] Sjekk om det er nødvendig å oppdatere dokumentasjon for hjelpeinnhold
  - Ta en titt på [Brukermanual for Prosjektportalen 365](https://puzzlepart.github.io/prosjektportalen-manual/) og vurder behovet for oppdateringer.
