### PR TITLE
Støtte for å "rendre" URL-kolonner i Porteføljeoversikten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ og dette prosjektet følger [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 Sjekk ut [release notes](./releasenotes/1.8.0.md) for høydepunkter og mer detaljert 'endringslogg' for siste hovedversjon.
 
+## 1.8.3 - TBA
+
+### Forbedringer
+
+- Porteføljeoversikten støtter nå visning av URL-kolonner
+
+
 ## 1.8.2 - TBA
 
 ### Ny funksjonalitet

--- a/SharePointFramework/PortfolioWebParts/package-lock.json
+++ b/SharePointFramework/PortfolioWebParts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pp365-portfoliowebparts",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "pp365-portfoliowebparts",
-      "version": "1.8.1",
+      "version": "1.8.2",
       "license": "MIT",
       "dependencies": {
         "@fluentui/react": "8.98.1",

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/RenderItemColumn/index.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/RenderItemColumn/index.tsx
@@ -9,11 +9,16 @@ import { TagsColumn } from './TagsColumn'
 import { UserColumn } from './UserColumn'
 import * as strings from 'PortfolioWebPartsStrings'
 import { IFetchDataForViewItemResult } from 'data/types'
+import { Link } from '@fluentui/react'
+import { stringIsNullOrEmpty } from '@pnp/common'
+
+type RenderDataType = 'user' | 'date' | 'currency' | 'tags' | 'boolean' | 'url'
+type RenderFunction = (props: IRenderItemColumnProps) => JSX.Element
 
 /**
- * Mapping for rendering of the different data types
+ * Mapping for rendering of the different data types. 
  */
-const renderDataTypeMap = {
+const renderDataTypeMap: Record<RenderDataType, RenderFunction> = {
   user: (props: IRenderItemColumnProps) => <UserColumn {...props} />,
   date: ({ columnValue: colValue }: IRenderItemColumnProps) => <span>{formatDate(colValue)}</span>,
   currency: ({ columnValue: colValue }: IRenderItemColumnProps) => (
@@ -22,15 +27,21 @@ const renderDataTypeMap = {
   tags: (props: IRenderItemColumnProps) => <TagsColumn {...props} />,
   boolean: ({ columnValue: colValue }: IRenderItemColumnProps) => (
     <span>{parseInt(colValue) === 1 ? strings.BooleanYes : strings.BooleanNo}</span>
-  )
+  ),
+  url: ({ columnValue: colValue }: IRenderItemColumnProps) => {
+    const [url, description] = colValue.split(', ')
+    return <Link href={url} target='_blank'>{description}</Link>
+  }
 }
 
 /**
- * On render item activeFilters
+ * On render item column function. First checks if the column has a custom render function, 
+ * if not it will use the default render function. Also the `Title` column has a custom render
+ * function by default and can not be overridden.
  *
- * @param item Item
- * @param column Column
- * @param props Props
+ * @param item Item to render the value for
+ * @param column Column to render the value for
+ * @param props Props for the component 
  */
 export function renderItemColumn(
   item: IFetchDataForViewItemResult,

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/RenderItemColumn/index.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/RenderItemColumn/index.tsx
@@ -1,22 +1,21 @@
+import { Link } from '@fluentui/react'
 import { Icon } from '@fluentui/react/lib/Icon'
+import * as strings from 'PortfolioWebPartsStrings'
+import { IFetchDataForViewItemResult } from 'data/types'
 import { formatDate, tryParseCurrency } from 'pp365-shared/lib/helpers'
 import { ProjectColumn } from 'pp365-shared/lib/models'
 import React from 'react'
 import { IPortfolioOverviewProps } from '../types'
-import { TitleColumn } from './TitleColumn'
 import { IRenderItemColumnProps } from './IRenderItemColumnProps'
 import { TagsColumn } from './TagsColumn'
+import { TitleColumn } from './TitleColumn'
 import { UserColumn } from './UserColumn'
-import * as strings from 'PortfolioWebPartsStrings'
-import { IFetchDataForViewItemResult } from 'data/types'
-import { Link } from '@fluentui/react'
-import { stringIsNullOrEmpty } from '@pnp/common'
 
 type RenderDataType = 'user' | 'date' | 'currency' | 'tags' | 'boolean' | 'url'
 type RenderFunction = (props: IRenderItemColumnProps) => JSX.Element
 
 /**
- * Mapping for rendering of the different data types. 
+ * Mapping for rendering of the different data types.
  */
 const renderDataTypeMap: Record<RenderDataType, RenderFunction> = {
   user: (props: IRenderItemColumnProps) => <UserColumn {...props} />,
@@ -30,18 +29,22 @@ const renderDataTypeMap: Record<RenderDataType, RenderFunction> = {
   ),
   url: ({ columnValue: colValue }: IRenderItemColumnProps) => {
     const [url, description] = colValue.split(', ')
-    return <Link href={url} target='_blank'>{description}</Link>
+    return (
+      <Link href={url} target='_blank'>
+        {description}
+      </Link>
+    )
   }
 }
 
 /**
- * On render item column function. First checks if the column has a custom render function, 
+ * On render item column function. First checks if the column has a custom render function,
  * if not it will use the default render function. Also the `Title` column has a custom render
  * function by default and can not be overridden.
  *
  * @param item Item to render the value for
  * @param column Column to render the value for
- * @param props Props for the component 
+ * @param props Props for the component
  */
 export function renderItemColumn(
   item: IFetchDataForViewItemResult,

--- a/SharePointFramework/ProjectWebParts/.hintrc
+++ b/SharePointFramework/ProjectWebParts/.hintrc
@@ -1,0 +1,8 @@
+{
+  "extends": [
+    "development"
+  ],
+  "hints": {
+    "no-inline-styles": "off"
+  }
+}

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/ProjectProperties/ProjectProperty/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/ProjectProperties/ProjectProperty/index.tsx
@@ -1,5 +1,5 @@
 import { DisplayMode } from '@microsoft/sp-core-library'
-import { Persona, PersonaSize } from '@fluentui/react'
+import { Link, Persona, PersonaSize } from '@fluentui/react'
 import { Toggle } from '@fluentui/react/lib/Toggle'
 import * as strings from 'ProjectWebPartsStrings'
 import React, { FC } from 'react'
@@ -15,7 +15,7 @@ export const ProjectProperty: FC<IProjectPropertyProps> = ({
 }) => {
   const renderValue = () => {
     switch (model.type) {
-      case 'User': {
+      case 'user': {
         return (
           <div>
             <Persona
@@ -26,7 +26,7 @@ export const ProjectProperty: FC<IProjectPropertyProps> = ({
           </div>
         )
       }
-      case 'UserMulti': {
+      case 'usermulti': {
         return (
           <div>
             {model.value.split(';').map((text, key) => (
@@ -40,7 +40,7 @@ export const ProjectProperty: FC<IProjectPropertyProps> = ({
           </div>
         )
       }
-      case 'TaxonomyFieldTypeMulti': {
+      case 'taxonomyfieldtypemulti': {
         return (
           <div className={styles.labels}>
             {model.value.split(';').map((text, key) => (
@@ -48,6 +48,14 @@ export const ProjectProperty: FC<IProjectPropertyProps> = ({
                 {text}
               </div>
             ))}
+          </div>
+        )
+      }
+      case 'url': {
+        const [url, description] = model.value.split(', ')
+        return (
+          <div>
+            <Link href={url} target='_blank'>{description}</Link>
           </div>
         )
       }

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/ProjectProperties/ProjectProperty/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/ProjectProperties/ProjectProperty/index.tsx
@@ -55,7 +55,9 @@ export const ProjectProperty: FC<IProjectPropertyProps> = ({
         const [url, description] = model.value.split(', ')
         return (
           <div>
-            <Link href={url} target='_blank'>{description}</Link>
+            <Link href={url} target='_blank'>
+              {description}
+            </Link>
           </div>
         )
       }

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/ProjectProperties/ProjectProperty/types.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/ProjectProperties/ProjectProperty/types.ts
@@ -3,6 +3,8 @@ import { TypedHash } from '@pnp/common'
 import { IEntityField } from 'sp-entityportal-service'
 import { stringIsNullOrEmpty } from '@pnp/common'
 
+type ProjectPropertyModelType = 'user' | 'usermulti' | 'taxonomyfieldtypemulti' | 'url'
+
 export class ProjectPropertyModel {
   /**
    * Internal name of the field
@@ -27,7 +29,7 @@ export class ProjectPropertyModel {
   /**
    * Type of the field
    */
-  public type?: string
+  public type?: ProjectPropertyModelType
 
   /**
    * Creates an instance of ProjectPropertyModel
@@ -40,7 +42,7 @@ export class ProjectPropertyModel {
     this.displayName = field.Title
     this.description = field.Description
     this.value = value
-    this.type = field.TypeAsString
+    this.type = field.TypeAsString.toLowerCase() as ProjectPropertyModelType
   }
 
   public get empty() {

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/Sections/SummarySection/index.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/Sections/SummarySection/index.tsx
@@ -21,7 +21,9 @@ export const SummarySection: FC<ISummarySectionProps> = (props) => {
   function renderStatusElements() {
     return context.state.data.sections.map((sec, idx) => {
       const ctxValue = createContextValue(sec)
-      const shouldRender = sec.showInStatusSection && (ctxValue.headerProps.value || sec.fieldName === 'GtOverallStatus')
+      const shouldRender =
+        sec.showInStatusSection &&
+        (ctxValue.headerProps.value || sec.fieldName === 'GtOverallStatus')
       return shouldRender ? (
         <SectionContext.Provider key={idx} value={ctxValue}>
           <div


### PR DESCRIPTION
# Pull request (PR)

Sørg for at du ber om PR for din branch (høyre side). Sørg for at du gjør en PR mot riktig release-branch (venstre side). Sjekk commits og alle commit-meldingene.

## Sjekklisten din

Alle sjekkpunktene under må være sjekket av og godkjent for at vi skal kunne merge branchen din mot dev.

- [x] Sjekk at din branch ikke feiler på `linting`.
- [x] Legg ved beskrivelse i [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md), markert med **ID av issue** knyttet til PR-en
- [x] Angi korrekt `Milestone` på PR-en og issuet, samt tilegn deg selv PR-en og legg til `labels`

### Beskrivelse

Støtte for å "rendre" URL-kolonner i Porteføljeoversikten. Det er tilgjengelig som et valg for `Datatype` i Prosjektkolonner, men har per nå (før denne PRen) ingen virkning.

**Før:**

![image](https://github.com/Puzzlepart/prosjektportalen365/assets/7606007/309bf1da-cd85-4395-9a4f-6726f309100e)


**Etter:**

![image](https://github.com/Puzzlepart/prosjektportalen365/assets/7606007/f3e345cf-7a6a-452b-ada3-ad9b71194ba2)


## Sjekkliste for godkjenner

Alle sjekkpunktene under må være sjekket av og godkjent av reviewers for at vi skal kunne merge branchen din mot dev.

- [ ] Sjekk at det er fylt ut testpunkter
- [ ] Sjekk om det er nødvendig å nevne denne PR i release notes
- [ ] Sjekk om det er nødvendig å oppdatere dokumentasjon for hjelpeinnhold
  - Ta en titt på [Brukermanual for Prosjektportalen 365](https://puzzlepart.github.io/prosjektportalen-manual/) og vurder behovet for oppdateringer.
