### PR TITLE
Fikse bug hvor "Alle prosjekter" standard-vertikal ikke fungerte

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Sjekk ut [release notes](./releasenotes/1.8.0.md) for høydepunkter og mer detal
 
 ### Feilrettinger
 
+- Fikset et problem hvor 'Alle prosjekter' ikke kunne settes som standard vertikal [#1163](https://github.com/Puzzlepart/prosjektportalen365/issues/1163)
+
 ---
 
 ## 1.8.3 - TBA

--- a/SharePointFramework/.tasks/modifySolutionFiles.js
+++ b/SharePointFramework/.tasks/modifySolutionFiles.js
@@ -121,7 +121,6 @@ function generateComponentManifestFiles(solutionConfig, componentManifestFiles) 
         return
     }
     const componentManifestFiles = glob(path.join(process.cwd(), `src/**/manifest.json`));
-    console.log(process.env.SERVE_CHANNEL)
     if (revert || process.env.npm_lifecycle_event === 'postwatch') {
         revertPackageSolutionFile();
         revertComponentManifestFiles(componentManifestFiles);

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/ColumnFormPanel/index.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/ColumnFormPanel/index.tsx
@@ -33,7 +33,8 @@ export const ColumnFormPanel: FC = () => {
       headerText={state.editColumn ? strings.EditColumnHeaderText : strings.NewColumnHeaderText}
       onDismiss={onDismiss}
       isLightDismiss={true}
-      className={styles.root}>
+      className={styles.root}
+    >
       <div className={styles.field}>
         <TextField
           label={strings.SortOrderLabel}

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/ItemModal/index.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/ItemModal/index.tsx
@@ -29,7 +29,8 @@ export default class ItemModal extends PureComponent<IItemModalProps, IItemModal
           isDarkOverlay={true}
           containerClassName={styles.itemModal}
           onDismiss={this._onCloseModal.bind(this)}
-          isBlocking={false}>
+          isBlocking={false}
+        >
           <div className={styles.header}>
             <div className={styles.title}>{this.props.title}</div>
           </div>

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/ShowHideColumnPanel/index.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/ShowHideColumnPanel/index.tsx
@@ -62,7 +62,8 @@ export const ShowHideColumnPanel: FC = () => {
       headerText={strings.ShowHideColumnsLabel}
       onDismiss={onDismiss}
       isLightDismiss={true}
-      className={styles.root}>
+      className={styles.root}
+    >
       <p>{strings.ShowHideColumnsDescription}</p>
       {selectedColumns.map((col, idx) => {
         return (

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/itemColumn.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/itemColumn.tsx
@@ -92,7 +92,8 @@ export const renderItemColumn = (item: any, index: number, column: IColumn) => {
             href={item.ServerRedirectedURL}
             rel='noopener noreferrer'
             target='_blank'
-            style={{ marginLeft: 8 }}>
+            style={{ marginLeft: 8 }}
+          >
             {columnValue}
           </Link>
         </span>
@@ -154,7 +155,8 @@ export const getDefaultColumns = (props: IPortfolioAggregationProps) => {
                 }}
                 onClick={onToggle}
               />
-            )}>
+            )}
+          >
             <Link href={item.SPWebURL} rel='noopener noreferrer' target='_blank'>
               {item.SiteTitle}
             </Link>

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/reducer.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioAggregation/reducer.ts
@@ -415,7 +415,8 @@ const createPortfolioAggregationReducer = (props: IPortfolioAggregationProps) =>
       } else if (props.dataSource || props.defaultViewId) {
         currentView = _.find(
           views,
-          (v: DataSource) => v.title === props.dataSource || v.id.toString() === props.defaultViewId?.toString()
+          (v: DataSource) =>
+            v.title === props.dataSource || v.id.toString() === props.defaultViewId?.toString()
         )
       } else {
         currentView = _.find(views, (v) => v.isDefault)

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/ListHeader/index.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/ListHeader/index.tsx
@@ -29,7 +29,8 @@ export const ListHeader: FC<IListHeaderProps> = (props) => {
     <Sticky
       stickyClassName={styles.sticky}
       stickyPosition={StickyPositionType.Header}
-      isScrollSynced={true}>
+      isScrollSynced={true}
+    >
       <div className={styles.root}>
         <div className={styles.header}>
           <div className={styles.title}>{context.props.title}</div>

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/RenderItemColumn/TitleColumn/index.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/RenderItemColumn/TitleColumn/index.tsx
@@ -54,7 +54,8 @@ export const TitleColumn: FC<ITitleColumnProps> = ({ item, props }) => {
               }}
               onClick={onToggle}
             />
-          )}>
+          )}
+        >
           <Link href={item.Path} rel='noopener noreferrer' target='_blank'>
             {item.Title}
           </Link>

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/index.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/index.tsx
@@ -27,13 +27,8 @@ import { usePortfolioOverview } from './usePortfolioOverview'
  * Component for displaying a portfolio overview - an overview of all projects in a portfolio.
  */
 export const PortfolioOverview: FC<IPortfolioOverviewProps> = (props) => {
-  const {
-    state,
-    contextValue,
-    selection,
-    onColumnHeaderClick,
-    onColumnHeaderContextMenu
-  } = usePortfolioOverview(props)
+  const { state, contextValue, selection, onColumnHeaderClick, onColumnHeaderContextMenu } =
+    usePortfolioOverview(props)
   const { items, columns, groups } = useFilteredData(props, state)
 
   return (
@@ -57,7 +52,8 @@ export const PortfolioOverview: FC<IPortfolioOverviewProps> = (props) => {
           ) : (
             <ScrollablePane
               scrollbarVisibility={ScrollbarVisibility.auto}
-              styles={{ root: { top: 75 } }}>
+              styles={{ root: { top: 75 } }}
+            >
               <MarqueeSelection selection={selection} className={styles.listContainer}>
                 <ShimmeredDetailsList
                   enableShimmer={state.loading || !!state.isChangingView}

--- a/SharePointFramework/PortfolioWebParts/src/components/ProjectList/ProjectCard/index.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/ProjectList/ProjectCard/index.tsx
@@ -28,7 +28,8 @@ export const ProjectCard: FC = () => {
             />
           </div>
         </div>
-      }>
+      }
+    >
       <DocumentCard {...documentCardProps}>
         <Link href={documentCardProps.onClickHref} target='_blank'>
           <ProjectCardHeader onImageLoad={() => setIsImageLoaded(true)} />

--- a/SharePointFramework/PortfolioWebParts/src/components/ProjectList/ProjectListViews.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/ProjectList/ProjectListViews.ts
@@ -32,7 +32,8 @@ export const ProjectListViews: IProjectListView[] = [
     itemIcon: 'AllApps',
     searchBoxPlaceholder: strings.AllProjectsSearchBoxPlaceholderText,
     filter: (_, state) =>
-      (state.isUserInPortfolioManagerGroup)
+      (state.isUserInPortfolioManagerGroup),
+    isHidden: (state) => !state.isUserInPortfolioManagerGroup
   },
   {
     itemKey: 'parent_projects',

--- a/SharePointFramework/PortfolioWebParts/src/components/ProjectList/ProjectListViews.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/ProjectList/ProjectListViews.ts
@@ -31,8 +31,7 @@ export const ProjectListViews: IProjectListView[] = [
     headerText: strings.AllProjectsHeaderText,
     itemIcon: 'AllApps',
     searchBoxPlaceholder: strings.AllProjectsSearchBoxPlaceholderText,
-    filter: (_, state) =>
-      (state.isUserInPortfolioManagerGroup),
+    filter: (_, state) => state.isUserInPortfolioManagerGroup,
     isHidden: (state) => !state.isUserInPortfolioManagerGroup
   },
   {

--- a/SharePointFramework/PortfolioWebParts/src/components/ProjectList/ProjectListViews.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/ProjectList/ProjectListViews.ts
@@ -31,8 +31,8 @@ export const ProjectListViews: IProjectListView[] = [
     headerText: strings.AllProjectsHeaderText,
     itemIcon: 'AllApps',
     searchBoxPlaceholder: strings.AllProjectsSearchBoxPlaceholderText,
-    filter: () => true,
-    isHidden: (state) => !state.isUserInPortfolioManagerGroup
+    filter: (_, state) =>
+      (state.isUserInPortfolioManagerGroup)
   },
   {
     itemKey: 'parent_projects',

--- a/SharePointFramework/PortfolioWebParts/src/components/ProjectList/index.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/ProjectList/index.tsx
@@ -119,7 +119,7 @@ export const ProjectList: FC<IProjectListProps> = (props) => {
               setState({ selectedView: find(views, (v) => v.itemKey === props.itemKey) })
             }
             selectedKey={state.selectedView.itemKey}>
-            {views.map((view) => (
+            {state.isDataLoaded && views.map((view) => (
               <PivotItem
                 key={view.itemKey}
                 itemKey={view.itemKey}

--- a/SharePointFramework/PortfolioWebParts/src/components/ProjectList/index.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/ProjectList/index.tsx
@@ -51,7 +51,8 @@ export const ProjectList: FC<IProjectListProps> = (props) => {
               project,
               actions: getCardActions(project),
               isDataLoaded: state.isDataLoaded
-            }}>
+            }}
+          >
             <ProjectCard />
           </ProjectCardContext.Provider>
         ))
@@ -118,35 +119,42 @@ export const ProjectList: FC<IProjectListProps> = (props) => {
             onLinkClick={({ props }) =>
               setState({ selectedView: find(views, (v) => v.itemKey === props.itemKey) })
             }
-            selectedKey={state.selectedView.itemKey}>
-            {state.isDataLoaded && views.map((view) => (
-              <PivotItem
-                key={view.itemKey}
-                itemKey={view.itemKey}
-                headerText={view.headerText}
-                itemIcon={view.itemIcon}
-                headerButtonProps={view.getHeaderButtonProps && view.getHeaderButtonProps(state)}>
-                <div className={styles.searchBox} hidden={!props.showSearchBox}>
-                  <SearchBox
-                    disabled={!state.isDataLoaded || isEmpty(state.projects)}
-                    value={state.searchTerm}
-                    placeholder={searchBoxPlaceholder}
-                    onChange={onSearch}
-                  />
-                </div>
-                <RenderModeDropdown
-                  hidden={!props.showViewSelector}
-                  renderAs={state.renderMode}
-                  onChange={(renderAs) => setState({ renderMode: renderAs })}
-                />
-                {state.isDataLoaded && isEmpty(projects) && (
-                  <div className={styles.emptyMessage}>
-                    <MessageBar>{strings.ProjectListEmptyText}</MessageBar>
-                  </div>
-                )}
-                <div className={styles.projects}>{renderProjects(projects)}</div>
-              </PivotItem>
-            ))}
+            selectedKey={state.selectedView.itemKey}
+          >
+            {state.isDataLoaded &&
+              views
+                .filter((view) => !view.isHidden || !view.isHidden(state))
+                .map((view) => (
+                  <PivotItem
+                    key={view.itemKey}
+                    itemKey={view.itemKey}
+                    headerText={view.headerText}
+                    itemIcon={view.itemIcon}
+                    headerButtonProps={
+                      view.getHeaderButtonProps && view.getHeaderButtonProps(state)
+                    }
+                  >
+                    <div className={styles.searchBox} hidden={!props.showSearchBox}>
+                      <SearchBox
+                        disabled={!state.isDataLoaded || isEmpty(state.projects)}
+                        value={state.searchTerm}
+                        placeholder={searchBoxPlaceholder}
+                        onChange={onSearch}
+                      />
+                    </div>
+                    <RenderModeDropdown
+                      hidden={!props.showViewSelector}
+                      renderAs={state.renderMode}
+                      onChange={(renderAs) => setState({ renderMode: renderAs })}
+                    />
+                    {state.isDataLoaded && isEmpty(projects) && (
+                      <div className={styles.emptyMessage}>
+                        <MessageBar>{strings.ProjectListEmptyText}</MessageBar>
+                      </div>
+                    )}
+                    <div className={styles.projects}>{renderProjects(projects)}</div>
+                  </PivotItem>
+                ))}
           </Pivot>
         </div>
       </div>

--- a/SharePointFramework/PortfolioWebParts/src/components/ProjectList/types.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/ProjectList/types.ts
@@ -22,9 +22,7 @@ export interface IProjectListView extends IPivotItemProps {
    *
    * @param state State of the component
    */
-  getHeaderButtonProps?: (
-    state: IProjectListState
-  ) =>
+  getHeaderButtonProps?: (state: IProjectListState) =>
     | IButtonProps
     | {
         [key: string]: string | number | boolean

--- a/SharePointFramework/PortfolioWebParts/src/components/ProjectList/useProjectList.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/ProjectList/useProjectList.ts
@@ -102,9 +102,7 @@ export const useProjectList = (props: IProjectListProps) => {
   }
 
   const projects = state.isDataLoaded ? filterProjets(state.projects) : state.projects
-  const views = props.views.filter(
-    (view) => !props.hideViews.includes(view.itemKey) && (!view.isHidden || !view?.isHidden(state))
-  )
+  const views = props.views.filter((view) => !props.hideViews.includes(view.itemKey))
 
   useProjectListDataFetch(props, views, setState)
 

--- a/SharePointFramework/PortfolioWebParts/src/components/ProjectList/useProjectListDataFetch.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/ProjectList/useProjectListDataFetch.ts
@@ -25,16 +25,6 @@ export function useProjectListDataFetch(
       props.dataAdapter.fetchEnrichedProjects(),
       props.dataAdapter.isUserInGroup(strings.PortfolioManagerGroupName)
     ]).then(([projects, isUserInPortfolioManagerGroup]) => {
-      if (props.defaultView === 'all_projects' && !isUserInPortfolioManagerGroup) {
-        props.defaultView = _.first(views).itemKey
-
-        views.forEach((view) => {
-          if (view.itemKey === 'all_projects') {
-            view.isHidden = (state) => !state.isUserInPortfolioManagerGroup
-          }
-        })
-      }
-
       const selectedView =
         _.find(views, (view) => view.itemKey === props.defaultView) ?? _.first(views)
 

--- a/SharePointFramework/PortfolioWebParts/src/components/ProjectList/useProjectListDataFetch.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/ProjectList/useProjectListDataFetch.ts
@@ -20,32 +20,24 @@ export function useProjectListDataFetch(
   views: IProjectListView[],
   setState: (newState: Partial<IProjectListState>) => void
 ) {
-  console.log(views)
-
   useEffect(() => {
     Promise.all([
       props.dataAdapter.fetchEnrichedProjects(),
       props.dataAdapter.isUserInGroup(strings.PortfolioManagerGroupName)
     ]).then(([projects, isUserInPortfolioManagerGroup]) => {
-
       if (props.defaultView === 'all_projects' && !isUserInPortfolioManagerGroup) {
-        props.defaultView = 'projects_access'
+        props.defaultView = _.first(views).itemKey
 
-        // iterate through views and set view 'all_projects' to isHidden = true
         views.forEach((view) => {
           if (view.itemKey === 'all_projects') {
             view.isHidden = (state) => !state.isUserInPortfolioManagerGroup
           }
-        }
-        )
-
+        })
       }
-
 
       const selectedView =
         _.find(views, (view) => view.itemKey === props.defaultView) ?? _.first(views)
 
-      console.log(selectedView)
       setState({
         projects,
         isDataLoaded: true,

--- a/SharePointFramework/PortfolioWebParts/src/components/ProjectList/useProjectListDataFetch.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/ProjectList/useProjectListDataFetch.ts
@@ -20,13 +20,32 @@ export function useProjectListDataFetch(
   views: IProjectListView[],
   setState: (newState: Partial<IProjectListState>) => void
 ) {
+  console.log(views)
+
   useEffect(() => {
     Promise.all([
       props.dataAdapter.fetchEnrichedProjects(),
       props.dataAdapter.isUserInGroup(strings.PortfolioManagerGroupName)
     ]).then(([projects, isUserInPortfolioManagerGroup]) => {
+
+      if (props.defaultView === 'all_projects' && !isUserInPortfolioManagerGroup) {
+        props.defaultView = 'projects_access'
+
+        // iterate through views and set view 'all_projects' to isHidden = true
+        views.forEach((view) => {
+          if (view.itemKey === 'all_projects') {
+            view.isHidden = (state) => !state.isUserInPortfolioManagerGroup
+          }
+        }
+        )
+
+      }
+
+
       const selectedView =
         _.find(views, (view) => view.itemKey === props.defaultView) ?? _.first(views)
+
+      console.log(selectedView)
       setState({
         projects,
         isDataLoaded: true,

--- a/SharePointFramework/PortfolioWebParts/src/components/ProjectList/useProjectListState.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/ProjectList/useProjectListState.ts
@@ -19,7 +19,7 @@ export function useProjectListState(props: IProjectListProps) {
     renderMode: props.defaultRenderMode ?? 'tiles',
     selectedView: defaultSelectedView,
     projects: mockProjects,
-    isUserInPortfolioManagerGroup: false,
+    isUserInPortfolioManagerGroup: true,
     sort: defaultSort
   })
 

--- a/SharePointFramework/PortfolioWebParts/src/components/ProjectList/useProjectListState.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/ProjectList/useProjectListState.ts
@@ -19,7 +19,6 @@ export function useProjectListState(props: IProjectListProps) {
     renderMode: props.defaultRenderMode ?? 'tiles',
     selectedView: defaultSelectedView,
     projects: mockProjects,
-    isUserInPortfolioManagerGroup: true,
     sort: defaultSort
   })
 

--- a/SharePointFramework/PortfolioWebParts/src/components/ResourceAllocation/DetailsCallout/index.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/ResourceAllocation/DetailsCallout/index.tsx
@@ -13,7 +13,8 @@ export const DetailsCallout: FC<IDetailsCalloutProps> = (props) => {
       gapSpace={10}
       target={props.viewItem.element}
       onDismiss={props.onDismiss}
-      setInitialFocus={true}>
+      setInitialFocus={true}
+    >
       <p>
         <b>{strings.ProjectLabel}:</b>{' '}
         <a href={item.data.projectUrl}>

--- a/SharePointFramework/PortfolioWebParts/src/components/ResourceAllocation/index.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/ResourceAllocation/index.tsx
@@ -15,15 +15,8 @@ import { useResourceAllocation } from './useResourceAllocation'
 import { FilterPanel } from 'pp365-shared-library/lib/components'
 
 export const ResourceAllocation: FC<IResourceAllocationProps> = (props) => {
-  const {
-    state,
-    setState,
-    commandBar,
-    filters,
-    onFilterChange,
-    items,
-    groups
-  } = useResourceAllocation(props)
+  const { state, setState, commandBar, filters, onFilterChange, items, groups } =
+    useResourceAllocation(props)
 
   if (!state.isDataLoaded) return null
 
@@ -54,7 +47,8 @@ export const ResourceAllocation: FC<IResourceAllocationProps> = (props) => {
                   strings.ResourceAllocationInfoText,
                   encodeURIComponent(window.location.href)
                 )
-              }}></div>
+              }}
+            ></div>
           </MessageBar>
         </div>
         <div className={styles.timeline}>
@@ -70,7 +64,8 @@ export const ResourceAllocation: FC<IResourceAllocationProps> = (props) => {
             }
             groupRenderer={groupRenderer}
             defaultTimeStart={moment().add(...props.defaultTimeStart)}
-            defaultTimeEnd={moment().add(...props.defaultTimeEnd)}>
+            defaultTimeEnd={moment().add(...props.defaultTimeEnd)}
+          >
             <TimelineMarkers>
               <TodayMarker date={moment().toDate()} />
             </TimelineMarkers>

--- a/SharePointFramework/PortfolioWebParts/src/components/ResourceAllocation/itemRenderer.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/ResourceAllocation/itemRenderer.tsx
@@ -15,10 +15,12 @@ export function itemRenderer(
     <div
       {...htmlProps}
       className={`${styles.timelineItem} rc-item`}
-      onClick={(event) => onItemClick({ element: event.currentTarget, item: props.item })}>
+      onClick={(event) => onItemClick({ element: event.currentTarget, item: props.item })}
+    >
       <div
         className={`${styles.itemContent} rc-item-content`}
-        style={{ maxHeight: `${props.itemContext.dimensions.height}` }}>
+        style={{ maxHeight: `${props.itemContext.dimensions.height}` }}
+      >
         {props.item.title}
       </div>
     </div>

--- a/SharePointFramework/PortfolioWebParts/src/components/ResourceAllocation/useResourceAllocationDataFetch.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/ResourceAllocation/useResourceAllocationDataFetch.ts
@@ -9,7 +9,12 @@ import { tryParsePercentage } from 'pp365-shared-library/lib/helpers'
 import { DataSourceService } from 'pp365-shared-library/lib/services'
 import { useEffect } from 'react'
 import { IResourceAllocationProps } from './types'
-import { ITimelineData, ITimelineGroup, ITimelineItem, TimelineResourceType } from 'pp365-shared-library/lib/interfaces'
+import {
+  ITimelineData,
+  ITimelineGroup,
+  ITimelineItem,
+  TimelineResourceType
+} from 'pp365-shared-library/lib/interfaces'
 
 /**
  * Creating groups based on user property (`RefinableString71`) on the search result,

--- a/SharePointFramework/PortfolioWebParts/src/data/index.ts
+++ b/SharePointFramework/PortfolioWebParts/src/data/index.ts
@@ -17,7 +17,15 @@ import { capitalize } from 'lodash'
 import msGraph from 'msgraph-helper'
 import * as strings from 'PortfolioWebPartsStrings'
 import { getUserPhoto } from 'pp365-shared-library/lib/helpers/getUserPhoto'
-import { DataSource, PortfolioOverviewView, ProjectColumn, ProjectListModel, SPTimelineConfigurationItem, TimelineConfigurationModel, TimelineContentModel } from 'pp365-shared-library/lib/models'
+import {
+  DataSource,
+  PortfolioOverviewView,
+  ProjectColumn,
+  ProjectListModel,
+  SPTimelineConfigurationItem,
+  TimelineConfigurationModel,
+  TimelineContentModel
+} from 'pp365-shared-library/lib/models'
 import { DataSourceService } from 'pp365-shared-library/lib/services/DataSourceService'
 import { PortalDataService } from 'pp365-shared-library/lib/services/PortalDataService'
 import _ from 'underscore'
@@ -31,7 +39,7 @@ import {
   DataField,
   ProgramItem,
   SPChartConfigurationItem,
-  SPContentType,
+  SPContentType
 } from '../models'
 import {
   CONTENT_TYPE_ID_BENEFITS,
@@ -136,23 +144,16 @@ export class DataAdapter implements IDataAdapter {
    */
   public async getPortfolioConfig(): Promise<IPortfolioConfiguration> {
     // eslint-disable-next-line prefer-const
-    const [
-      columnConfig,
-      columns,
-      views,
-      programs,
-      viewsUrls,
-      columnUrls,
-      userCanAddViews
-    ] = await Promise.all([
-      this._portal.getProjectColumnConfig(),
-      this._portal.getProjectColumns(),
-      this._portal.getPortfolioOverviewViews(),
-      this._portal.getPrograms(ProgramItem),
-      this._portal.getListFormUrls('PORTFOLIO_VIEWS'),
-      this._portal.getListFormUrls('PROJECT_COLUMNS'),
-      this._portal.currentUserHasPermissionsToList('PORTFOLIO_VIEWS', PermissionKind.AddListItems)
-    ])
+    const [columnConfig, columns, views, programs, viewsUrls, columnUrls, userCanAddViews] =
+      await Promise.all([
+        this._portal.getProjectColumnConfig(),
+        this._portal.getProjectColumns(),
+        this._portal.getPortfolioOverviewViews(),
+        this._portal.getPrograms(ProgramItem),
+        this._portal.getListFormUrls('PORTFOLIO_VIEWS'),
+        this._portal.getListFormUrls('PROJECT_COLUMNS'),
+        this._portal.currentUserHasPermissionsToList('PORTFOLIO_VIEWS', PermissionKind.AddListItems)
+      ])
     const configuredColumns = columns.map((col) => col.configure(columnConfig))
     const refiners = columns.filter((col) => col.isRefinable)
     const configuredViews = views.map((view) => view.configure(columns))
@@ -356,27 +357,24 @@ export class DataAdapter implements IDataAdapter {
     siteId: string,
     siteIdProperty: string = 'GtSiteIdOWSTEXT'
   ) {
-    let [
-      projects,
-      { PrimarySearchResults: sites },
-      { PrimarySearchResults: statusReports }
-    ] = await Promise.all([
-      this._fetchItemsForView(view, [
-        ...configuration.columns.map((f) => f.fieldName),
-        siteIdProperty
-      ]),
-      sp.search({
-        ...DEFAULT_SEARCH_SETTINGS,
-        QueryTemplate: `DepartmentId:{${siteId}} contentclass:STS_Site`,
-        SelectProperties: ['Path', 'Title', 'SiteId']
-      }),
-      sp.search({
-        ...DEFAULT_SEARCH_SETTINGS,
-        QueryTemplate: `DepartmentId:{${siteId}} ContentTypeId:0x010022252E35737A413FB56A1BA53862F6D5* GtModerationStatusOWSCHCS:Publisert`,
-        SelectProperties: [...configuration.columns.map((f) => f.fieldName), siteIdProperty],
-        Refiners: configuration.refiners.map((ref) => ref.fieldName).join(',')
-      })
-    ])
+    let [projects, { PrimarySearchResults: sites }, { PrimarySearchResults: statusReports }] =
+      await Promise.all([
+        this._fetchItemsForView(view, [
+          ...configuration.columns.map((f) => f.fieldName),
+          siteIdProperty
+        ]),
+        sp.search({
+          ...DEFAULT_SEARCH_SETTINGS,
+          QueryTemplate: `DepartmentId:{${siteId}} contentclass:STS_Site`,
+          SelectProperties: ['Path', 'Title', 'SiteId']
+        }),
+        sp.search({
+          ...DEFAULT_SEARCH_SETTINGS,
+          QueryTemplate: `DepartmentId:{${siteId}} ContentTypeId:0x010022252E35737A413FB56A1BA53862F6D5* GtModerationStatusOWSCHCS:Publisert`,
+          SelectProperties: [...configuration.columns.map((f) => f.fieldName), siteIdProperty],
+          Refiners: configuration.refiners.map((ref) => ref.fieldName).join(',')
+        })
+      ])
     projects = projects.map((item) => cleanDeep({ ...item }))
     sites = sites.map((item) => cleanDeep({ ...item }))
     statusReports = statusReports.map((item) => cleanDeep({ ...item }))

--- a/SharePointFramework/PortfolioWebParts/src/data/types.ts
+++ b/SharePointFramework/PortfolioWebParts/src/data/types.ts
@@ -8,7 +8,13 @@ import {
 } from '@pnp/sp'
 import { IAggregatedListConfiguration, IPortfolioConfiguration } from 'interfaces'
 import { IProjectContentColumn } from 'interfaces/IProjectContentColumn'
-import { DataSource, PortfolioOverviewView, ProjectListModel, TimelineConfigurationModel, TimelineContentModel } from 'pp365-shared-library/lib/models'
+import {
+  DataSource,
+  PortfolioOverviewView,
+  ProjectListModel,
+  TimelineConfigurationModel,
+  TimelineContentModel
+} from 'pp365-shared-library/lib/models'
 import { DataSourceService } from 'pp365-shared-library/lib/services'
 
 export interface IFetchDataForViewItemResult extends SearchResult {

--- a/SharePointFramework/PortfolioWebParts/src/webparts/portfolioAggregation/index.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/webparts/portfolioAggregation/index.tsx
@@ -14,9 +14,7 @@ import _ from 'lodash'
 import React from 'react'
 import { BasePortfolioWebPart } from 'webparts/@basePortfolioWebPart'
 
-export default class PortfolioAggregationWebPart extends BasePortfolioWebPart<
-  IPortfolioAggregationProps
-> {
+export default class PortfolioAggregationWebPart extends BasePortfolioWebPart<IPortfolioAggregationProps> {
   private _configuration: IAggregatedListConfiguration
 
   public render(): void {

--- a/SharePointFramework/PortfolioWebParts/src/webparts/portfolioInsights/index.ts
+++ b/SharePointFramework/PortfolioWebParts/src/webparts/portfolioInsights/index.ts
@@ -4,9 +4,7 @@ import '@fluentui/react/dist/css/fabric.min.css'
 import * as strings from 'PortfolioWebPartsStrings'
 import { BasePortfolioWebPart } from 'webparts/@basePortfolioWebPart'
 
-export default class PortfolioInsightsWebPart extends BasePortfolioWebPart<
-  IPortfolioInsightsProps
-> {
+export default class PortfolioInsightsWebPart extends BasePortfolioWebPart<IPortfolioInsightsProps> {
   public render(): void {
     this.renderComponent<IPortfolioInsightsProps>(PortfolioInsights)
   }

--- a/SharePointFramework/PortfolioWebParts/src/webparts/portfolioOverview/index.ts
+++ b/SharePointFramework/PortfolioWebParts/src/webparts/portfolioOverview/index.ts
@@ -22,9 +22,7 @@ export const PROPERTYPANE_CONFIGURATION_PROPS = {
   SHOW_VIEWSELECTOR: 'showViewSelector'
 }
 
-export default class PortfolioOverviewWebPart extends BasePortfolioWebPart<
-  IPortfolioOverviewProps
-> {
+export default class PortfolioOverviewWebPart extends BasePortfolioWebPart<IPortfolioOverviewProps> {
   private _configuration: IPortfolioConfiguration
 
   public render(): void {

--- a/SharePointFramework/PortfolioWebParts/src/webparts/resourceAllocation/index.ts
+++ b/SharePointFramework/PortfolioWebParts/src/webparts/resourceAllocation/index.ts
@@ -2,9 +2,7 @@ import { IPropertyPaneConfiguration } from '@microsoft/sp-property-pane'
 import { IResourceAllocationProps, ResourceAllocation } from 'components/ResourceAllocation'
 import { BasePortfolioWebPart } from 'webparts/@basePortfolioWebPart'
 
-export default class ResourceAllocationWebPart extends BasePortfolioWebPart<
-  IResourceAllocationProps
-> {
+export default class ResourceAllocationWebPart extends BasePortfolioWebPart<IResourceAllocationProps> {
   public render(): void {
     this.renderComponent<IResourceAllocationProps>(ResourceAllocation)
   }


### PR DESCRIPTION
# Pull request (PR)

Sørg for at du ber om PR for din branch (høyre side). Sørg for at du gjør en PR mot riktig release-branch (venstre side). Sjekk commits og alle commit-meldingene.

## Sjekklisten din

Alle sjekkpunktene under må være sjekket av og godkjent for at vi skal kunne merge branchen din mot dev.

- [x] Sjekk at din branch ikke feiler på `linting`.
- [x] Legg ved beskrivelse i [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md), markert med **ID av issue** knyttet til PR-en
- [x] Angi korrekt `Milestone` på PR-en og issuet, samt tilegn deg selv PR-en og legg til `labels`

### Beskrivelse

Dersom man er eier eller ligger i gruppen "Porteføljeinnsyn" og ser vertikalen "Alle prosjekter" på forsiden og setter denne som standard vertikal hopper den til "Tilgang til" vertikalen.

Det er nå mulig å sette vertikalen "Alle prosjekter" som standard. For eiere/"Porteføljeinnsyn" fungerer dette nå som normalt.

For medlemmer, vil webdelen defaulte til "Tilgang til" (den første vertikalen), den viser heller aldri vertikalen "Alle prosjekter" før webdelen har verifisert hva brukeren har tilgang til.

### Hvordan teste

Vennligst beskriv hvordan noen andre (en vanlig bruker uten kodeferdigheter) kan teste denne PR-en. Følg eksempelet under, punktene du legger ved vil bli brukt når vi tester neste versjon av Prosjektportalen

| #   | Handling          | Forventet resultat     |
| --- | ----------------- | ---------------------- |
| 1   | Gå til Porteføljeforsiden, rediger Prosjektutlistingswebdel, angi "Alle prosjekter" vertikalen som standard  | Vertikalen "Alle prosjekter" vil bli angitt som standard  |
| 2	| Logg inn med en bruker som er Eier eller medlem i "Porteføljeinnsyn"  og verifiser at "Alle prosjekter" er standard vertikal | Eier eller medlem i "Porteføljeinnsyn" skal se vertikalen "Alle prosjekter" på forsiden og den skal være satt som standard vertikal |
| 3	| Logg inn med en bruker som er medlem og ikke ligger i "Porteføljeinnsyn", verifiser at "Alle prosjekter" vertikalen ikke vises og at standard vertikal vist er den første | Brukeren skal ikke se vertikalen "Alle prosjekter" på forsiden |
| 4	| Medlem skal ikke se vertikalen "Alle prosjekter" før tilgang er verifisert (rendret) | "Alle prosjekter" vertikalen vises ikke før tilgang er verifisert. |

### Relevante issues (hvis aktuelt)

- #1163 

## Sjekkliste for godkjenner

Alle sjekkpunktene under må være sjekket av og godkjent av reviewers for at vi skal kunne merge branchen din mot dev.

- [x] Sjekk at det er fylt ut testpunkter
- [x] Sjekk om det er nødvendig å nevne denne PR i release notes
- [x] Sjekk om det er nødvendig å oppdatere dokumentasjon for hjelpeinnhold
  - Ta en titt på [Brukermanual for Prosjektportalen 365](https://puzzlepart.github.io/prosjektportalen-manual/) og vurder behovet for oppdateringer.
