### PR TITLE
Fikset problem hvor prosjekttidslinje ikke returnerte tilhørende elementer for prosjekt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ Sjekk ut [release notes](./releasenotes/1.8.0.md) for høydepunkter og mer detal
 ### Feilrettinger
 
 - Rettet et problem hvor låst mal hindret mulighet for å gjøre et prosjekt om til overordnet område [#1134](https://github.com/Puzzlepart/prosjektportalen365/issues/1134)
-- Fikset et problem hvor 'Hooks' ikke ble kjørt på slutten av provisjoneringen av et prosjekt. [#1127](https://github.com/Puzzlepart/prosjektportalen365/issues/1127)
+- Fikset et problem hvor 'Hooks' ikke ble kjørt på slutten av provisjoneringen av et prosjekt [#1127](https://github.com/Puzzlepart/prosjektportalen365/issues/1127)
+- Fikset et problem hvor prosjekttidslinje på prosjektnivå ikke returnerte tidslinje-elementer for prosjektet [#1172](https://github.com/Puzzlepart/prosjektportalen365/pull/1172)
 
 ---
 

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectTimeline/data/fetchTimelineData.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectTimeline/data/fetchTimelineData.ts
@@ -65,6 +65,7 @@ export async function fetchTimelineData(
           'GtSiteIdLookup/GtSiteId'
         )
         .expand('GtSiteIdLookup', 'GtTimelineTypeLookup')
+        .filter(`GtSiteIdLookup/GtSiteId eq '${props.siteId}'`)
         .getAll(),
       timelineContentList.fields
         .filter(filterString)
@@ -73,9 +74,7 @@ export async function fetchTimelineData(
         .get()
     ])
 
-    let timelineListItems = timelineContentItems.filter(
-      (item) => item.GtSiteIdLookup.Title === props.webTitle
-    )
+    let timelineListItems = timelineContentItems.filter((item) => item.GtSiteIdLookup !== null)
 
     const columns = timelineColumns
       .filter((column) => column.InternalName !== 'GtSiteIdLookup')
@@ -125,6 +124,6 @@ export async function fetchTimelineData(
 
     return { timelineContentItems, timelineListItems, columns, timelineConfig } as const
   } catch (error) {
-    return null
+    return error
   }
 }


### PR DESCRIPTION
# Pull request (PR)

Sørg for at du ber om PR for din branch (høyre side). Sørg for at du gjør en PR mot riktig release-branch (venstre side). Sjekk commits og alle commit-meldingene.

## Sjekklisten din

Alle sjekkpunktene under må være sjekket av og godkjent for at vi skal kunne merge branchen din mot dev.

- [x] Sjekk at din branch ikke feiler på `linting`.
- [x] Legg ved beskrivelse i [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md), markert med **ID av issue** knyttet til PR-en
- [x] Angi korrekt `Milestone` på PR-en og issuet, samt tilegn deg selv PR-en og legg til `labels`

### Beskrivelse

Fikset et problem hvor prosjekttidslinje på Prosjektnivå ikke returnerte tilhørende elementer for prosjekt.

Error håndtering var tidligere ignorert, kallet for å hente ut tidslinjeelementer er nå forhåndsfiltrert for å unngå store datakall som er unødvendig.

### Hvordan teste

Vennligst beskriv hvordan noen andre (en vanlig bruker uten kodeferdigheter) kan teste denne PR-en. Følg eksempelet under, punktene du legger ved vil bli brukt når vi tester neste versjon av Prosjektportalen

| #   | Handling          | Forventet resultat     |
| --- | ----------------- | ---------------------- |
| 1   | Gå inn på tidslinjen til et Prosjekt  | Se at prosjektet og tilhørende tidslinjeelementer blir returnert riktig  |


## Sjekkliste for godkjenner

Alle sjekkpunktene under må være sjekket av og godkjent av reviewers for at vi skal kunne merge branchen din mot dev.

- [x] Sjekk at det er fylt ut testpunkter
- [x] Sjekk om det er nødvendig å nevne denne PR i release notes
- [x] Sjekk om det er nødvendig å oppdatere dokumentasjon for hjelpeinnhold
  - Ta en titt på [Brukermanual for Prosjektportalen 365](https://puzzlepart.github.io/prosjektportalen-manual/) og vurder behovet for oppdateringer.
