### PR TITLE
Mulighet for søk på personer med mer på porteføljeforside

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ I denne versjonen er det gjort flere endringer på det visuelle uttrykket til Pr
 - Opprett og rediger eksisterende visninger direkte i Porteføljeaggregering [#1210](https://github.com/Puzzlepart/prosjektportalen365/issues/1210)
 - Rediger egenskaper for prosjektet i et panel som åpner seg på siden [#1227](https://github.com/Puzzlepart/prosjektportalen365/issues/1227)
 - Støtte for å håndtere tiltak for usikkerheter i Planner [#1273](https://github.com/Puzzlepart/prosjektportalen365/issues/1273)
+- Støtte for å søke etter prosjekteiere, prosjektledere, prosjekttype og tjenesteområder fra porteføljeforsiden [#1281](https://github.com/Puzzlepart/prosjektportalen365/issues/1281)
 
 ### Forbedringer
 

--- a/SharePointFramework/PortfolioWebParts/src/components/ProjectList/useProjectList.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/ProjectList/useProjectList.ts
@@ -84,11 +84,9 @@ export const useProjectList = (props: IProjectListProps) => {
           let value
           if (Array.isArray(project[key]) && project[key].length > 0) {
             value = project[key]?.join(', ')
-          }
-          else if (typeof project[key] === 'object' && project[key] !== null) {
+          } else if (typeof project[key] === 'object' && project[key] !== null) {
             value = Object.values(project[key])?.join(', ')
-          }
-          else {
+          } else {
             value = project[key]
           }
 

--- a/SharePointFramework/PortfolioWebParts/src/components/ProjectList/useProjectList.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/ProjectList/useProjectList.ts
@@ -81,7 +81,17 @@ export const useProjectList = (props: IProjectListProps) => {
       .filter((project) => state.selectedVertical.filter(project, state))
       .filter((project) =>
         _.any(Object.keys(project), (key) => {
-          const value = project[key]
+          let value
+          if (Array.isArray(project[key]) && project[key].length > 0) {
+            value = project[key]?.join(', ')
+          }
+          else if (typeof project[key] === 'object' && project[key] !== null) {
+            value = Object.values(project[key])?.join(', ')
+          }
+          else {
+            value = project[key]
+          }
+
           return (
             value &&
             typeof value === 'string' &&


### PR DESCRIPTION
# Pull request (PR)

Sørg for at du ber om PR for din branch (høyre side). Sørg for at du gjør en PR mot riktig release-branch (venstre side). Sjekk commits og alle commit-meldingene.

## Sjekklisten din

Alle sjekkpunktene under må være sjekket av og godkjent for at vi skal kunne merge branchen din mot dev.

- [x] Sjekk at din branch ikke feiler på `linting`.
- [x] Legg ved beskrivelse i [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md), markert med **ID av issue** knyttet til PR-en
- [x] Angi korrekt `Milestone` på PR-en og issuet, samt tilegn deg selv PR-en og legg til `labels`

### Beskrivelse

Det er lagt inn mulighet for å søke på mer enn bare "strings", det er mulig å søke på personer (array), prosjekttyper, tjenesteområde (objekt) og ellers alt det andre som finnes i "ProjectListModel"

### Hvordan teste

Vennligst beskriv hvordan noen andre (en vanlig bruker uten kodeferdigheter) kan teste denne PR-en. Følg eksempelet under, punktene du legger ved vil bli brukt når vi tester neste versjon av Prosjektportalen

| #   | Handling          | Forventet resultat     |
| --- | ----------------- | ---------------------- |
| 1   | Søk etter eier eller leder  | Resultater skal vise prosjekter hvor eier eller leder er angitt  |
| 2   | Søk etter prosjekttype eller tjenesteområder  | Resultater skal vise prosjekter hvor prosjekttype eller tjenesteområde er angitt  |
| 3   | Deretter utfør... | Her skal...            |

### Relevante issues (hvis aktuelt)

- #1281 

## Sjekkliste for godkjenner

Alle sjekkpunktene under må være sjekket av og godkjent av reviewers for at vi skal kunne merge branchen din mot dev.

- [x] Sjekk at det er fylt ut testpunkter
- [x] Sjekk om det er nødvendig å nevne denne PR i release notes
