### PR TITLE
Rettet et problem hvor "Ansvarlig"-feltet i administrering av tiltak ikke viste personen som er valgt i feltet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Sjekk ut [release notes](./releasenotes/1.9.0.md) for høydepunkter og mer detal
 - Rettet et problem hvor visnings-id ikke la seg i URL feltet ved opprettelse av nye visninger, samt oppdatering av visningen (Porteføljeoversikter og andre aggregerte oversikter) [#1441](https://github.com/Puzzlepart/prosjektportalen365/issues/1441)
 - Rettet et problem hvor `Standardmal` ble satt som standard selvom andre maler var angitt som standard [#1471](https://github.com/Puzzlepart/prosjektportalen365/issues/1471)
 - Rettet et problem hvor taksonomifelt i redigeringspanel ikke støttet nivåer av termer [#1504](https://github.com/Puzzlepart/prosjektportalen365/issues/1504)
+- Rettet et problem hvor "Ansvarlig"-feltet i administrering av tiltak ikke viste personen som er valgt i feltet [#1506](https://github.com/Puzzlepart/prosjektportalen365/issues/1506)
 
 ### Forbedringer
 

--- a/SharePointFramework/ProjectExtensions/src/components/RiskAction/RiskActionPopover/NewRiskActionPanel/ResponsibleField/ResponsibleField.tsx
+++ b/SharePointFramework/ProjectExtensions/src/components/RiskAction/RiskActionPopover/NewRiskActionPanel/ResponsibleField/ResponsibleField.tsx
@@ -24,6 +24,7 @@ export const ResponsibleField: FC<IResponsibleFieldProps> = (props) => {
         freeform
         value={value}
         onOptionSelect={(_e, data) => {
+          setValue(data.optionText)
           props.onChange(data.optionValue)
         }}
         onChange={(e) => {


### PR DESCRIPTION
# Pull request (PR)

Sørg for at du ber om PR for din branch (høyre side). Sørg for at du gjør en PR mot riktig release-branch (venstre side). Sjekk commits og alle commit-meldingene.

## Sjekklisten din

Alle sjekkpunktene under må være sjekket av og godkjent for at vi skal kunne merge branchen din mot dev.

- [x] Legg ved beskrivelse i [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md), markert med **ID av issue** knyttet til PR-en
- [x] Angi korrekt `Milestone` på PR-en og issuet, samt tilegn deg selv PR-en og legg til `labels`

### Beskrivelse

Comboboxen holder styr på hva du skriver inn i feltet i onChange, men onOptionSelect oppdaterer ikke ```value``` variablen i state. Den setter kun epost til brukeren som skal lagres. Denne PR legger til en state-oppdatering av ```value``` når en option er valgt, slik at det reflekteres i input-feltet.

### Hvordan teste

1. Gå til et prosjekt
2. Gå til Usikkerhetslisten
3. Opprett et element dersom det ikke finnes
4. Prøv å legge til tiltak ved å holde klikke på melding eller verdi under Tiltak kolonnen
5. Trykk på "Legg til nytt tiltak"
6. Søk etter en bruker i feltet: "Ansvarlig" og velg et forslag
7. Se at navnet til bruker lagres som verdi i feltet

### Relevante issues (hvis aktuelt)

- #1506 

## Sjekkliste for godkjenner

Alle sjekkpunktene under må være sjekket av og godkjent av reviewers for at vi skal kunne merge branchen din mot dev.

- [x] Sjekk at det er fylt ut testpunkter
- [x] Sjekk om det er nødvendig å nevne denne PR i release notes
- [x] Sjekk om det er nødvendig å oppdatere dokumentasjon for hjelpeinnhold
  - Ta en titt på [Brukermanual for Prosjektportalen 365](https://puzzlepart.github.io/prosjektportalen-manual/) og vurder behovet for oppdateringer.
