### PR TITLE
Rettet et problem hvor det ikke var mulig å lagre tom verdi i valuta/tall felt fra redigeringspanel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Sjekk ut [release notes](./releasenotes/1.9.0.md) for høydepunkter og mer detal
 - Rettet et problem hvor `Standardmal` ble satt som standard selvom andre maler var angitt som standard [#1471](https://github.com/Puzzlepart/prosjektportalen365/issues/1471)
 - Rettet et problem hvor taksonomifelt i redigeringspanel ikke støttet nivåer av termer [#1504](https://github.com/Puzzlepart/prosjektportalen365/issues/1504)
 - Rettet et problem hvor "Ansvarlig"-feltet i administrering av tiltak ikke viste personen som er valgt i feltet [#1506](https://github.com/Puzzlepart/prosjektportalen365/issues/1506)
+- Rettet et problem hvor det ikke var mulig å lagre tom verdi i valuta/tall felt fra redigeringspanel [#1510](https://github.com/Puzzlepart/prosjektportalen365/issues/1510)
 
 ### Forbedringer
 

--- a/SharePointFramework/shared-library/src/components/CustomEditPanel/CustomEditPanelBody/FieldElements/Currency.tsx
+++ b/SharePointFramework/shared-library/src/components/CustomEditPanel/CustomEditPanelBody/FieldElements/Currency.tsx
@@ -17,7 +17,7 @@ export const Currency: FieldElementComponent = ({ field }) => {
       <Input
         type='number'
         defaultValue={context.model.get<string>(field)}
-        onChange={(_, data) => context.model.set(field, data.value)}
+        onChange={(_, data) => context.model.set(field, data.value || null)}
         placeholder={strings.Placeholder.TextField}
       />
     </FieldContainer>

--- a/SharePointFramework/shared-library/src/components/CustomEditPanel/CustomEditPanelBody/FieldElements/Number.tsx
+++ b/SharePointFramework/shared-library/src/components/CustomEditPanel/CustomEditPanelBody/FieldElements/Number.tsx
@@ -17,7 +17,7 @@ export const Number: FieldElementComponent = ({ field }) => {
       <Input
         type='number'
         defaultValue={context.model.get<string>(field)}
-        onChange={(_, data) => context.model.set(field, data.value)}
+        onChange={(_, data) => context.model.set(field, data.value || null)}
         placeholder={strings.Placeholder.NumberField}
       />
     </FieldContainer>


### PR DESCRIPTION
# Pull request (PR)

Sørg for at du ber om PR for din branch (høyre side). Sørg for at du gjør en PR mot riktig release-branch (venstre side). Sjekk commits og alle commit-meldingene.

## Sjekklisten din

Alle sjekkpunktene under må være sjekket av og godkjent for at vi skal kunne merge branchen din mot dev.

- [x] Legg ved beskrivelse i [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md), markert med **ID av issue** knyttet til PR-en
- [x] Angi korrekt `Milestone` på PR-en og issuet, samt tilegn deg selv PR-en og legg til `labels`

### Beskrivelse

Verdi fra valuta/tall felt er av type ```string```. Hvis feltet tømmes av bruker forsøker den å lagre en tom streng - som feiler. Denne endringen setter ```null``` dersom verdien fra feltet er en tom streng som lar deg lagre den tomme verdien.

### Hvordan teste

1. Gå til Statusrapport for et prosjekt
2. Opprett statusrapport dersom den ikke finnes fra før
3. Legg inn verdi i et valuta/tall felt hvis ingen har verdier og lagre
4. Fjern verdier i valuta/tall feltene og forsøk å lagre
5. Kontroller at feltet ble lagret med tom verdi (forsvinner fra rapporten)

### Relevante issues (hvis aktuelt)

- #1510 

## Sjekkliste for godkjenner

Alle sjekkpunktene under må være sjekket av og godkjent av reviewers for at vi skal kunne merge branchen din mot dev.

- [x] Sjekk at det er fylt ut testpunkter
- [x] Sjekk om det er nødvendig å nevne denne PR i release notes
- [x] Sjekk om det er nødvendig å oppdatere dokumentasjon for hjelpeinnhold
  - Ta en titt på [Brukermanual for Prosjektportalen 365](https://puzzlepart.github.io/prosjektportalen-manual/) og vurder behovet for oppdateringer.
