### PR TITLE
Rettet et problem hvor lenke til prosjektets tidslinje ikke lenket riktig for program

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Sjekk ut [release notes](./releasenotes/1.9.0.md) for høydepunkter og mer detal
 - Rettet et problem hvor taksonomifelt i redigeringspanel ikke støttet nivåer av termer [#1504](https://github.com/Puzzlepart/prosjektportalen365/issues/1504)
 - Rettet et problem hvor "Ansvarlig"-feltet i administrering av tiltak ikke viste personen som er valgt i feltet [#1506](https://github.com/Puzzlepart/prosjektportalen365/issues/1506)
 - Rettet et problem hvor det ikke var mulig å lagre tom verdi i valuta/tall felt fra redigeringspanel [#1510](https://github.com/Puzzlepart/prosjektportalen365/issues/1510)
+- Rettet et problem hvor lenke til prosjektets tidslinje ikke lenket riktig for program [#1511](https://github.com/Puzzlepart/prosjektportalen365/issues/1511)
 
 ### Forbedringer
 

--- a/SharePointFramework/shared-library/src/components/ProjectTimeline/Timeline/useGroupRenderer.tsx
+++ b/SharePointFramework/shared-library/src/components/ProjectTimeline/Timeline/useGroupRenderer.tsx
@@ -10,13 +10,14 @@ import strings from 'SharedLibraryStrings'
 export function useGroupRenderer() {
   return ({ group }: ReactCalendarGroupRendererProps<ITimelineGroup>) => {
     const style: React.CSSProperties = { display: 'block', width: '100%' }
+    const page = group.isProgram ? 'Programtidslinje' : 'Prosjekttidslinje'
 
     return (
       <div style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
         {group.type === TimelineGroupType.Project ? (
           <Tooltip content={strings.TimelineGroupDescription} relationship='description' withArrow>
             <Link
-              href={`${group.path}/SitePages/Prosjekttidslinje.aspx`}
+              href={`${group.path}/SitePages/${page}.aspx`}
               target='_blank'
               title={group.title}
             >

--- a/SharePointFramework/shared-library/src/components/ProjectTimeline/useProjectTimelineDataFetch.ts
+++ b/SharePointFramework/shared-library/src/components/ProjectTimeline/useProjectTimelineDataFetch.ts
@@ -26,7 +26,8 @@ const createProjectGroups = (projects: ProjectListModel[]): ITimelineGroup[] => 
     return {
       title: project.title,
       siteId: project.siteId,
-      path: project.url
+      path: project.url,
+      isProgram: project.isProgram
     }
   })
 
@@ -36,7 +37,8 @@ const createProjectGroups = (projects: ProjectListModel[]): ITimelineGroup[] => 
       title: project.title,
       type: TimelineGroupType.Project,
       siteId: project.siteId,
-      path: project.path
+      path: project.path,
+      isProgram: project.isProgram
     }
   })
 

--- a/SharePointFramework/shared-library/src/interfaces/ITimelineGroup.ts
+++ b/SharePointFramework/shared-library/src/interfaces/ITimelineGroup.ts
@@ -12,6 +12,7 @@ export interface ITimelineGroup {
   type?: TimelineGroupType
   siteId?: string
   path?: string
+  isProgram?: boolean
 }
 
 export interface ITimelineGroups {


### PR DESCRIPTION
# Pull request (PR)

Sørg for at du ber om PR for din branch (høyre side). Sørg for at du gjør en PR mot riktig release-branch (venstre side). Sjekk commits og alle commit-meldingene.

## Sjekklisten din

Alle sjekkpunktene under må være sjekket av og godkjent for at vi skal kunne merge branchen din mot dev.

- [ ] Legg ved beskrivelse i [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md), markert med **ID av issue** knyttet til PR-en
- [ ] Angi korrekt `Milestone` på PR-en og issuet, samt tilegn deg selv PR-en og legg til `labels`

### Beskrivelse

Lenker i tidslinjen lenker alltid til "Prosjekttidslinje.aspx". Denne endringen skiller mellom program/prosjekt og legger inn lenke til rett tidslinje.

### Hvordan teste

1. Gå til prosjekttidslinjen på portejøljenivå
2. Klikk på lenken til et prosjekt og et program og kontroller at lenkene fører til rett tidslinje (ingen døde lenker)
3. Gå til tidslinjen i et program
4. Klikk på lenken for programmet og et underprosjekt og kontroller at disse også virker

### Relevante issues (hvis aktuelt)

- #1511 

## Sjekkliste for godkjenner

Alle sjekkpunktene under må være sjekket av og godkjent av reviewers for at vi skal kunne merge branchen din mot dev.

- [ ] Sjekk at det er fylt ut testpunkter
- [ ] Sjekk om det er nødvendig å nevne denne PR i release notes
- [ ] Sjekk om det er nødvendig å oppdatere dokumentasjon for hjelpeinnhold
  - Ta en titt på [Brukermanual for Prosjektportalen 365](https://puzzlepart.github.io/prosjektportalen-manual/) og vurder behovet for oppdateringer.
