### PR TITLE
Fix: blank property pane issue for portfolio webpart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Sjekk ut [release notes](./releasenotes/1.12.0.md) for høydepunkter og mer deta
 
 - Rettet et problem hvor tilpassede malbiblioteket ikke ble valgt når man klikket på "Hent dokumentmal" fra dokumentbiblioteket [#1628](https://github.com/Puzzlepart/prosjektportalen365/issues/1628)
 
+- Rettet et problem hvor Porteføljeoversiktens egenskapspanel ikke fungerte
+
 ---
 
 ## 1.11.1 - 18.08.2025

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ Sjekk ut [release notes](./releasenotes/1.12.0.md) for høydepunkter og mer deta
 ### Feilrettinger
 
 - Rettet et problem hvor tilpassede malbiblioteket ikke ble valgt når man klikket på "Hent dokumentmal" fra dokumentbiblioteket [#1628](https://github.com/Puzzlepart/prosjektportalen365/issues/1628)
-
 - Rettet et problem hvor Porteføljeoversiktens egenskapspanel ikke fungerte
 
 ---

--- a/SharePointFramework/PortfolioWebParts/src/webparts/portfolioOverview/index.ts
+++ b/SharePointFramework/PortfolioWebParts/src/webparts/portfolioOverview/index.ts
@@ -95,7 +95,7 @@ export default class PortfolioOverviewWebPart extends BasePortfolioWebPart<IPort
   ): IPropertyPaneDropdownOption[] {
     switch (targetProperty) {
       case 'portfolios': {
-        return this.properties.portfolios.map((portfolio) => ({
+        return this.properties.portfolios?.map((portfolio) => ({
           key: portfolio.uniqueId,
           text: portfolio.title
         }))


### PR DESCRIPTION
# Pull request (PR)

Sørg for at du ber om PR for din branch (høyre side). Sørg for at du gjør en PR mot riktig release-branch (venstre side). Sjekk commits og alle commit-meldingene.

## Sjekklisten din

Alle sjekkpunktene under må være sjekket av og godkjent for at vi skal kunne merge branchen din mot release-branch.

- [x] Legg ved beskrivelse i [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md), markert med **ID av issue** knyttet til PR-en
- [x] Angi korrekt `Milestone` på PR-en og issuet, samt tilegn deg selv PR-en og legg til `labels`

### Beskrivelse

Vennligst beskriv PR-en din i detalj.

Rettet et problem hvor Porteføljeoversiktens egenskapspanel ikke fungerte.

| Før      | Etter      |
| -------- | ---------- |
| ![image](https://github.com/user-attachments/assets/fc0f741e-c08a-452a-b884-f8710738c9dc)| ![image](https://github.com/user-attachments/assets/ddc4e3fa-859e-4c82-8977-761e6129f679)|

| Bilde beskrivelse |
| ----------------- |
| Bilde             |

### Hvordan teste

| #   | Handling          | Forventet resultat     |
| --- | ----------------- | ---------------------- |
| 1   | Gå til Porteføljeoversikt.aspx og klikk på knappen «Rediger» | Du skal se egenskapspanel nå.  |


### Relevante issues (hvis aktuelt)

-

## Sjekkliste for godkjenner

Alle sjekkpunktene under må være sjekket av og godkjent av reviewers for at vi skal kunne merge branchen din mot dev.

- [x] Sjekk at det er fylt ut testpunkter
- [x] Sjekk om det er nødvendig å nevne denne PR i release notes
- [x] Sjekk om det er nødvendig å oppdatere dokumentasjon for hjelpeinnhold
  - Ta en titt på [Brukermanual for Prosjektportalen 365](https://puzzlepart.github.io/prosjektportalen-manual/) og vurder behovet for oppdateringer.
