### PR TITLE
Fiks for tallet 0 vises som blankt i gevinstoversikten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Sjekk ut [release notes](./releasenotes/1.12.0.md) for høydepunkter og mer deta
 
 - Rettet et problem hvor tilpassede malbiblioteket ikke ble valgt når man klikket på "Hent dokumentmal" fra dokumentbiblioteket [#1628](https://github.com/Puzzlepart/prosjektportalen365/issues/1628)
 - Rettet et problem hvor Porteføljeoversiktens egenskapspanel ikke fungerte
+- Rettet et problem hvor tallet 0 vises som blankt i gevinstoversikten [#1649](https://github.com/Puzzlepart/prosjektportalen365/issues/1649)
 
 ---
 

--- a/SharePointFramework/PortfolioWebParts/src/components/List/ItemColumn/useOnRenderItemColumn.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/List/ItemColumn/useOnRenderItemColumn.tsx
@@ -24,8 +24,8 @@ function renderItemColumn(item: Record<string, any>, column: IColumn): ReactNode
   }
   const columnValue = item[column.fieldName]
   const dataTypeProperties: Record<string, any> = column.data?.dataTypeProperties ?? {}
-  if (!columnValue && column.fieldName !== '-') {
-    return dataTypeProperties.fallbackValue ?? null
+  if (!columnValue && column.fieldName !== '-' && dataTypeProperties?.fallbackValue) {
+    return dataTypeProperties.fallbackValue
   }
 
   if (column.fieldName === 'Title' && column['dataType'] === 'text') {


### PR DESCRIPTION
# Pull request (PR)

Sørg for at du ber om PR for din branch (høyre side). Sørg for at du gjør en PR mot riktig release-branch (venstre side). Sjekk commits og alle commit-meldingene.

## Sjekklisten din

Alle sjekkpunktene under må være sjekket av og godkjent for at vi skal kunne merge branchen din mot release-branch.

- [x] Legg ved beskrivelse i [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md), markert med **ID av issue** knyttet til PR-en
- [x] Angi korrekt `Milestone` på PR-en og issuet, samt tilegn deg selv PR-en og legg til `labels`

### Beskrivelse

Vennligst beskriv PR-en din i detalj.

Rettet et problem hvor tallet 0 vises som blankt i gevinstoversikten.

| Før      | Etter      |
| -------- | ---------- |
| ![image](https://github.com/user-attachments/assets/df562a2f-3ec9-4fcd-8236-33d5313ee5b5)| ![image](https://github.com/user-attachments/assets/ff6dc8aa-c34a-4448-8d5b-4b06246c192b)|

| Bilde beskrivelse |
| ----------------- |
| Bilde             |

| #   | Handling          | Forventet resultat     |
| --- | ----------------- | ---------------------- |
| 1   | Gå til Gevinstoversikt.aspx | Du skal tallet 0 vises for blankt i gevinstoversikten.  |

### Relevante issues (hvis aktuelt)

- #1649 

## Sjekkliste for godkjenner

Alle sjekkpunktene under må være sjekket av og godkjent av reviewers for at vi skal kunne merge branchen din mot dev.

- [x] Sjekk at det er fylt ut testpunkter
- [x] Sjekk om det er nødvendig å nevne denne PR i release notes
- [x] Sjekk om det er nødvendig å oppdatere dokumentasjon for hjelpeinnhold
  - Ta en titt på [Brukermanual for Prosjektportalen 365](https://puzzlepart.github.io/prosjektportalen-manual/) og vurder behovet for oppdateringer.
