### PR TITLE
fix: resolve filename validation issues in document templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ Sjekk ut [release notes](./releasenotes/1.12.0.md) for høydepunkter og mer deta
 - Rettet en feil hvor gruppeoppretting definert i `Tillatelseskonfigurasjon` kunne feile for alle resterende grupper dersom én gruppe feilet under tilrettelegging av tillatelser [#1716](https://github.com/Puzzlepart/prosjektportalen365/issues/1716)
 - Rettet en visuell feil hvor `Prosjektinformasjon mangler.`-melding overlappet seksjoner på Prosjektstatus-seksjonen `Overordnet status`
 - Rettet en feil hvor sortering ikke fungerte i prosjektoversikten på forsiden av porteføljen
+- Rettet en feil i hent dokumentmal hvor validering av navn på filer og mapper ikke intraff på forskjell i små og store bokstaver [#1727](https://github.com/Puzzlepart/prosjektportalen365/issues/1727)
+- Rettet en feil i hent dokumentmal hvor punktum i filnavn før fil-endingen behandlet filnavnet og endingen feil [#1727](https://github.com/Puzzlepart/prosjektportalen365/issues/1727)
 
 ---
 

--- a/SharePointFramework/ProjectExtensions/src/data/SPDataAdapter/index.ts
+++ b/SharePointFramework/ProjectExtensions/src/data/SPDataAdapter/index.ts
@@ -47,17 +47,19 @@ class SPDataAdapter extends SPDataAdapterBase<ISPDataAdapterConfiguration> {
       return isFolder ? strings.FolderNameInValidErrorText : strings.FilenameInValidErrorText
 
     if (isFolder) {
-      const [folder] = await this.sp.web
+      const folders = await this.sp.web
         .getFolderByServerRelativePath(folderServerRelativeUrl)
-        .folders.filter(`Name eq '${name}'`)()
-      if (folder) {
+        .folders()
+      const existingFolder = folders.find(f => f.Name.toLowerCase() === name.toLowerCase())
+      if (existingFolder) {
         return strings.FolderNameAlreadyInUseErrorText
       }
     } else {
-      const [file] = await this.sp.web
+      const files = await this.sp.web
         .getFolderByServerRelativePath(folderServerRelativeUrl)
-        .files.filter(`Name eq '${name}'`)()
-      if (file) {
+        .files()
+      const existingFile = files.find(f => f.Name.toLowerCase() === name.toLowerCase())
+      if (existingFile) {
         return strings.FilenameAlreadyInUseErrorText
       }
     }
@@ -108,8 +110,7 @@ class SPDataAdapter extends SPDataAdapterBase<ISPDataAdapterConfiguration> {
           // eslint-disable-next-line quotes
           "ListItemEntityTypeFullName ne 'SP.Data.FormServerTemplatesItem'"
         ].join(' and ')
-      )
-      .using(DefaultCaching)()
+      )()
     return libraries.map((lib) => new SPFolder(lib))
   }
 }

--- a/SharePointFramework/ProjectExtensions/src/models/TemplateItem.ts
+++ b/SharePointFramework/ProjectExtensions/src/models/TemplateItem.ts
@@ -243,14 +243,14 @@ export class TemplateItem {
    * Name without extension
    */
   public get nameWithoutExtension() {
-    return this.name.split('.')[0]
+    return this.name.substring(0, this.name.lastIndexOf('.'))
   }
 
   /**
    * File extension
    */
   public get fileExtension() {
-    return this.name.split('.')[1]
+    return this.name.substring(this.name.lastIndexOf('.') + 1)
   }
 
   /**


### PR DESCRIPTION
# Pull request (PR)

Sørg for at du ber om PR for din branch (høyre side). Sørg for at du gjør en PR mot riktig release-branch (venstre side). Sjekk commits og alle commit-meldingene.

## Sjekklisten din

Alle sjekkpunktene under må være sjekket av og godkjent for at vi skal kunne merge branchen din mot release-branch.

- [x] Legg ved beskrivelse i [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md), markert med **ID av issue** (dersom relevant) knyttet til PR-en
- [x] Angi korrekt `Milestone` på PR-en og issuet, samt tilegn deg selv PR-en og legg til `labels`

### Beskrivelse

Fikser feil i validering av filnavn og mappenavn i hent dokumentmal og retter feilhåndtering av filer som har punktum i filnavnet.
Fjerner caching fra fetch. Denne gjorde at man må vente en time før nye mapper du har opprettet dukker opp i hent dokumentmal dialogen. Dette sparer ekstremt lite ytelse mot dårlig brukeropplevelse.

### Hvordan teste

1. **Hent en dokumentmal med filnavn som finnes fra før i mappen du kopierer til** - Skal få feilmelding og må inputte nytt navn.
2. **Hent en dokumentmal med punktum i filnavnet. For eksempel filene med versjonsnummer v4.0 etc** - Fil-extension skal behandles riktig istedenfor å bli ".0"
3. **Hent en hel mappe hvor du har mappe med samme navn i små bokstaver** - Skal få beskjed at mappen finnes fra før på tross av forskjell i casing

### Relevante issues (hvis aktuelt)

- #1727 

## Sjekkliste for godkjenner

Alle sjekkpunktene under må være sjekket av og godkjent av reviewers for at vi skal kunne merge branchen din mot dev.

- [x] Sjekk at det er fylt ut testpunkter
- [x] Sjekk om det er nødvendig å nevne denne PR i release notes
- [x] Sjekk om det er nødvendig å oppdatere dokumentasjon for hjelpeinnhold
  - Ta en titt på [Brukermanual for Prosjektportalen 365](https://puzzlepart.github.io/prosjektportalen-manual/) og vurder behovet for oppdateringer.
