### PR TITLE
feat: More dynamic handling of displaying project status sections with content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ Templates/*-report*.md
 Templates/*-report*.json
 Templates/Portfolio/Objects/ClientSidePages/*.json
 *.env
+.claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Sjekk ut [release notes](./releasenotes/1.12.0.md) for høydepunkter og mer deta
 - Knapp i `Footer` for `Områdeinnstillinger` gir også mulighet for å gå direkte til `Områdeinnhold`.
 - Støtte for å angi minimum og maksimum verdier for tall og valuta felt i redigeringspaneler for prosjektinformasjon [#1578](https://github.com/Puzzlepart/prosjektportalen365/issues/1578)
 - Støtte for at prosjekter kan lastes inn uten tilgang på hub, der prosjektinformasjon vises fra lokale data og feilmeldinger for prosjektstatus og prosjekttidslinje vises [#1707](https://github.com/Puzzlepart/prosjektportalen365/issues/1707)
+- Seksjoner i `Prosjektstatus` vises nå dersom noen av feltene i seksjonen har verdi, ikke bare statusfeltet. Seksjoner som kun er relevante for enkelte innholdstyper vises fortsatt ikke dersom de er helt tomme
 - Håndtering av 'overflow' i seksjonsmenyen på toppen av Prosjektstatus siden, slik at seksjonene som ikke får plass i bredden vises i en overflytmeny
 - Lagt til beskrivelse på sluttdato-feltet i redigeringspanelet for `Prosjekttidslinje` som indikerer at sluttdato er påkrevd for elementtyper som vises som punkt (diamant/trekant) på tidslinjen
 - Lagt til tegnbegrensning (255 tegn) for navn- og tittelfelt i `Hent dokumentmal`-dialogen

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/Sections/StatusSection/StatusSection.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/Sections/StatusSection/StatusSection.tsx
@@ -5,7 +5,7 @@ import { SectionContext } from '../context'
 
 export const StatusSection: FC = () => {
   const { headerProps } = useContext(SectionContext)
-  if (!headerProps.value) return null
+  if (!headerProps.value && !headerProps.comment) return null
   return (
     <BaseSection>
       <StatusElement />

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/Sections/useSections.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/Sections/useSections.tsx
@@ -1,44 +1,35 @@
 import { stringIsNullOrEmpty } from '@pnp/core'
-import { SectionModel, SectionType, StatusReport } from 'pp365-shared-library/lib/models'
-import { IProjectInformationData } from 'pp365-shared-library'
+import { SectionModel, SectionType } from 'pp365-shared-library/lib/models'
 import { useProjectStatusContext } from '../context'
 
 /**
- * Check if a section has any content worth displaying.
- *
- * @param section Section model
- * @param selectedReport Currently selected status report
- * @param properties Project properties data
- */
-function sectionHasContent(
-  section: SectionModel,
-  selectedReport: StatusReport,
-  properties: IProjectInformationData
-): boolean {
-  const { value, comment } = selectedReport?.getStatusValue(section.fieldName) ?? {}
-  if (!stringIsNullOrEmpty(value) || !stringIsNullOrEmpty(comment)) return true
-
-  if (section.type === SectionType.ProjectPropertiesSection && section.viewFields?.length > 0) {
-    const fieldValuesAsText = {
-      ...properties?.fieldValues?.['_fieldValuesAsText'],
-      ...selectedReport?.fieldValues?.['_fieldValuesAsText']
-    }
-    return section.viewFields.some(
-      (fieldName) => !stringIsNullOrEmpty(fieldValuesAsText?.[fieldName])
-    )
-  }
-
-  return false
-}
-
-/**
- * Component logic hook for `Sections`
+ * Component logic hook for `Sections`. Returns the sections that have
+ * displayable content and are configured to show, filtering against
+ * the currently selected status report and project properties.
  */
 export function useSections() {
   const context = useProjectStatusContext()
   const { data, isDataLoaded, selectedReport } = context.state
   if (!isDataLoaded) return data.sections
+
+  const sectionHasContent = (section: SectionModel): boolean => {
+    const { value, comment } = selectedReport?.getStatusValue(section.fieldName) ?? {}
+    if (!stringIsNullOrEmpty(value) || !stringIsNullOrEmpty(comment)) return true
+
+    if (section.type === SectionType.ProjectPropertiesSection && section.viewFields?.length > 0) {
+      const fieldValuesAsText = {
+        ...data.properties?.fieldValues?.['_fieldValuesAsText'],
+        ...selectedReport?.fieldValues?.['_fieldValuesAsText']
+      }
+      return section.viewFields.some(
+        (fieldName) => !stringIsNullOrEmpty(fieldValuesAsText?.[fieldName])
+      )
+    }
+
+    return false
+  }
+
   return data.sections
-    .filter((sec) => sectionHasContent(sec, selectedReport, data.properties))
+    .filter((sec) => sectionHasContent(sec))
     .filter((sec) => sec.showAsSection || sec.type === SectionType.SummarySection)
 }

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/Sections/useSections.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectStatus/Sections/useSections.tsx
@@ -1,6 +1,35 @@
 import { stringIsNullOrEmpty } from '@pnp/core'
-import { SectionType } from 'pp365-shared-library/lib/models'
+import { SectionModel, SectionType, StatusReport } from 'pp365-shared-library/lib/models'
+import { IProjectInformationData } from 'pp365-shared-library'
 import { useProjectStatusContext } from '../context'
+
+/**
+ * Check if a section has any content worth displaying.
+ *
+ * @param section Section model
+ * @param selectedReport Currently selected status report
+ * @param properties Project properties data
+ */
+function sectionHasContent(
+  section: SectionModel,
+  selectedReport: StatusReport,
+  properties: IProjectInformationData
+): boolean {
+  const { value, comment } = selectedReport?.getStatusValue(section.fieldName) ?? {}
+  if (!stringIsNullOrEmpty(value) || !stringIsNullOrEmpty(comment)) return true
+
+  if (section.type === SectionType.ProjectPropertiesSection && section.viewFields?.length > 0) {
+    const fieldValuesAsText = {
+      ...properties?.fieldValues?.['_fieldValuesAsText'],
+      ...selectedReport?.fieldValues?.['_fieldValuesAsText']
+    }
+    return section.viewFields.some(
+      (fieldName) => !stringIsNullOrEmpty(fieldValuesAsText?.[fieldName])
+    )
+  }
+
+  return false
+}
 
 /**
  * Component logic hook for `Sections`
@@ -10,6 +39,6 @@ export function useSections() {
   const { data, isDataLoaded, selectedReport } = context.state
   if (!isDataLoaded) return data.sections
   return data.sections
-    .filter((sec) => !stringIsNullOrEmpty(selectedReport?.getStatusValue(sec.fieldName)?.value))
+    .filter((sec) => sectionHasContent(sec, selectedReport, data.properties))
     .filter((sec) => sec.showAsSection || sec.type === SectionType.SummarySection)
 }


### PR DESCRIPTION
# Pull request (PR)

Sørg for at du ber om PR for din branch (høyre side). Sørg for at du gjør en PR mot riktig release-branch (venstre side). Sjekk commits og alle commit-meldingene.

## Sjekklisten din

Alle sjekkpunktene under må være sjekket av og godkjent for at vi skal kunne merge branchen din mot release-branch.

- [X] Legg ved beskrivelse i [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md), markert med **ID av issue** (dersom relevant) knyttet til PR-en
- [X] Angi korrekt `Milestone` på PR-en og issuet, samt tilegn deg selv PR-en og legg til `labels`

### Beskrivelse

I Prosjektstatus ble ikke statusseksjoner vist dersom "hovedfeltet" til seksjonen hadde tom verdi. Det fungerer dårlig for prosjektegenskaper-seksjoner der man på mange måter er "tvunget" til å velge et av feltene som hovedfelt.

Nå vises seksjonene dersom primærtfeltet, kommentarfeltet eller et av seksjonens refererte felter har verdi.

### Hvordan teste

Vennligst beskriv hvordan noen andre (en vanlig bruker uten kodeferdigheter) kan teste denne PR-en. Følg eksempelet under, punktene du legger ved vil bli brukt når vi tester neste versjon av Prosjektportalen

1. Lag en prosjektstatus-innholdstype med flere custom felter, og legg dette til i prosjektstatus listen og sett innholdstypen som standard for en mal
2. Konfigurer prosjektstatus-konfig listen, velg en ny seksjon. Velg et av custom feltene som primært felt og de andre som sekundære.
3. La et prosjekt basert på malen, fyll ut en prosjektstatus-rapport, sjekk at verdier vises i henhold til beskrivelsen over

### Relevante issues (hvis aktuelt)

-

## Sjekkliste for godkjenner

Alle sjekkpunktene under må være sjekket av og godkjent av reviewers for at vi skal kunne merge branchen din mot dev.

- [x] Sjekk at det er fylt ut testpunkter
- [x] Sjekk om det er nødvendig å nevne denne PR i release notes
- [x] Sjekk om det er nødvendig å oppdatere dokumentasjon for hjelpeinnhold
  - Ta en titt på [Brukermanual for Prosjektportalen 365](https://puzzlepart.github.io/prosjektportalen-manual/) og vurder behovet for oppdateringer.
