### PR TITLE
Add role-based assistant access control for project sites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ Sjekk ut [release notes](./releasenotes/1.12.0.md) for høydepunkter og mer deta
 - Lagt til to nye kolonner i `Prosjekter`-listen: `Prosjekttillegg` og `Listeinnhold`, som lagrer navnene på valgte tillegg og listeinnhold (kommaseparert) ved opprettelse av prosjektet. [#1542](https://github.com/Puzzlepart/prosjektportalen365/issues/1542)
 - Dynamisk feltrendering i `Bestillingsportalen` som støtter konfigurerbar feltrekkefølge og nivåplassering via `order` og `level` egenskaper
 - Lagt til «Se mine bestillinger»-knapp i verktøylinjen i `Bestillingsportalen`-skuffen for rask tilgang til bestillingsstatus
-- Ny tilgangsstyring for PP Assistenten basert på prosjektadministrasjonsroller. Ny global innstilling `AssistantAccessMode` med tre moduser: `group` (standard, eksisterende oppførsel), `role` (rollebasert per prosjekt) og `both` (bruker må tilfredsstille både gruppe- og rollesjekk). Ny tilgang `AssistantAccess` som kan tilordnes roller i `Prosjektadministrasjonsroller`-listen.
+- Ny tilgangsstyring for Prosjektportalen Assistenten basert på prosjektadministrasjonsroller. Ny global innstilling `AssistantAccessMode` med tre moduser: `group` (standard, eksisterende oppførsel), `role` (rollebasert per prosjekt) og `both` (bruker må tilfredsstille både gruppe- og rollesjekk). Ny tilgang `AssistantAccess` som kan tilordnes roller i `Prosjektadministrasjonsroller`-listen.
 
 ### Forbedringer
 
@@ -122,7 +122,7 @@ Sjekk ut [release notes](./releasenotes/1.12.0.md) for høydepunkter og mer deta
 
 ### Feilrettinger
 
-- Rettet et problem hvor Prosjektstatus-feltene for PP-Assistentens vurdering ikke ble installert (Førte til feil i bruk av PP-assistenten mot prosjektstatus)
+- Rettet et problem hvor Prosjektstatus-feltene for Prosjektportalen Assistentens vurdering ikke ble installert (Førte til feil i bruk av Prosjektportalen Assistenten mot prosjektstatus)
 - Rettet et problem hvor tilpassede malbiblioteket ikke ble valgt når man klikket på "Hent dokumentmal" fra dokumentbiblioteket [#1628](https://github.com/Puzzlepart/prosjektportalen365/issues/1628)
 - Rettet et problem hvor Porteføljeoversiktens egenskapspanel ikke fungerte.
 - Rettet et problem hvor tallet 0 vises som blankt i gevinstoversikten [#1649](https://github.com/Puzzlepart/prosjektportalen365/issues/1649)
@@ -151,7 +151,7 @@ Sjekk ut [release notes](./releasenotes/1.12.0.md) for høydepunkter og mer deta
 - Lagt til mulighet for å skjule spesifikke kolonner på et globalt nivå basert på mal (Prosjektkolonner) [#1624](https://github.com/Puzzlepart/prosjektportalen365/issues/1624)
 - Prosjekttidslinje senterer seg nå rundt prosjektets tidsforløp (startdato - sluttdato) [#1625](https://github.com/Puzzlepart/prosjektportalen365/issues/1625)
 - Muligheter for å tilpasse informasjonen i prosjektkortet på forsiden av porteføljen, inkludert valg av hvilke felt som skal vises og i hvilken rekkefølge. [#1548](https://github.com/Puzzlepart/prosjektportalen365/issues/1548)
-- Mulighet for å tilgangsstyre Prosjektportalen Assistent, slik at den ikke er tilgjengelig for alle brukere. [#1632](https://github.com/Puzzlepart/prosjektportalen365/issues/1632)
+- Mulighet for å tilgangsstyre Prosjektportalen Assistenten, slik at den ikke er tilgjengelig for alle brukere. [#1632](https://github.com/Puzzlepart/prosjektportalen365/issues/1632)
 - Mulighet for å tilgangsstyre synligheten av `Bestill område` knappen for å benytte seg av Bestillingsportalen, slik at den ikke er tilgjengelig for alle brukere.
 - Flere nye felter på Prosjektstatus-listen for å tilrettelegge for KI-behandling av Prosjektstatus
 - Tittel angitt i Prosjektnyheter-dialogen brukes nå automatisk som tittel på den opprettede nyhetsartikler
@@ -169,7 +169,7 @@ Sjekk ut [release notes](./releasenotes/1.12.0.md) for høydepunkter og mer deta
 - Lagt til instrumentvisning for 'Siste måling' på Gevinstoversikt [#1572](https://github.com/Puzzlepart/prosjektportalen365/issues/1572)
 - Ny webdel `Idémodul` for visning av idéer (registrering/behandling) samt feltkonfigurasjon slik at relevant data fra idéregistreringen kan videreføres til behandling [#1573](https://github.com/Puzzlepart/prosjektportalen365/issues/1573)
 - Lagt til mulighet for egendefinerte farger på fasene i fasevelgeren [#1613](https://github.com/Puzzlepart/prosjektportalen365/issues/1613)
-- Prosjektportalen assistent, forberendende funksjonalitet for kunstig intelligens.
+- Prosjektportalen Assistent, forberendende funksjonalitet for kunstig intelligens.
 
 ### Forbedringer
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Sjekk ut [release notes](./releasenotes/1.12.0.md) for høydepunkter og mer deta
 - Lagt til to nye kolonner i `Prosjekter`-listen: `Prosjekttillegg` og `Listeinnhold`, som lagrer navnene på valgte tillegg og listeinnhold (kommaseparert) ved opprettelse av prosjektet. [#1542](https://github.com/Puzzlepart/prosjektportalen365/issues/1542)
 - Dynamisk feltrendering i `Bestillingsportalen` som støtter konfigurerbar feltrekkefølge og nivåplassering via `order` og `level` egenskaper
 - Lagt til «Se mine bestillinger»-knapp i verktøylinjen i `Bestillingsportalen`-skuffen for rask tilgang til bestillingsstatus
+- Ny tilgangsstyring for PP Assistenten basert på prosjektadministrasjonsroller. Ny global innstilling `AssistantAccessMode` med tre moduser: `group` (standard, eksisterende oppførsel), `role` (rollebasert per prosjekt) og `both` (bruker må tilfredsstille både gruppe- og rollesjekk). Ny tilgang `AssistantAccess` som kan tilordnes roller i `Prosjektadministrasjonsroller`-listen.
 
 ### Forbedringer
 

--- a/Install/Scripts/PostInstallUpgrade.ps1
+++ b/Install/Scripts/PostInstallUpgrade.ps1
@@ -236,4 +236,77 @@ if ($null -ne $LastInstall) {
             Write-Host "[WARNING] Could not find 'ReRunSetup' permission item in list '$AdminPermissionsList'" -ForegroundColor Yellow
         }
     }
+
+    if ($PreviousVersion -lt [version]"1.14.0") {
+        Write-Host "[INFO] Ensuring 'AssistantAccess' permission is assigned to all project admin roles..."
+
+        $AdminRolesList = Get-Resource -Name "Lists_ProjectAdminRoles_Title"
+        $AdminPermissionsList = Get-Resource -Name "Lists_ProjectAdminPermissions_Title"
+
+        $AssistantAccessPermission = Get-PnPListItem -List $AdminPermissionsList | Where-Object { $_["GtProjectAdminPermissionId"] -eq "7f3a8b2c-4d5e-6f70-8192-a3b4c5d6e7f8" }
+        if ($null -ne $AssistantAccessPermission) {
+            $RoleTitles = @(
+                (Get-Resource -Name "Lists_ProjectAdminRoles_ProjectManager"),
+                (Get-Resource -Name "Lists_ProjectAdminRoles_ProjectOwner"),
+                (Get-Resource -Name "Lists_ProjectAdminRoles_ProjectSupport"),
+                (Get-Resource -Name "Lists_ProjectAdminRoles_ProjectOffice"),
+                (Get-Resource -Name "Lists_ProjectAdminRoles_SPAdmin")
+            )
+
+            foreach ($RoleTitle in $RoleTitles) {
+                $Role = Get-PnPListItem -List $AdminRolesList | Where-Object { $_["Title"] -eq $RoleTitle }
+                if ($null -ne $Role) {
+                    $CurrentPermissions = $Role["GtProjectAdminPermissions"]
+                    $HasPermission = $false
+                    if ($null -ne $CurrentPermissions) {
+                        foreach ($Perm in $CurrentPermissions) {
+                            if ($Perm.LookupId -eq $AssistantAccessPermission.Id) {
+                                $HasPermission = $true
+                                break
+                            }
+                        }
+                    }
+                    if (-not $HasPermission) {
+                        $UpdatedPermissions = @()
+                        if ($null -ne $CurrentPermissions) {
+                            foreach ($Perm in $CurrentPermissions) {
+                                $UpdatedPermissions += [Microsoft.SharePoint.Client.FieldLookupValue]@{"LookupId" = $Perm.LookupId }
+                            }
+                        }
+                        $UpdatedPermissions += [Microsoft.SharePoint.Client.FieldLookupValue]@{"LookupId" = $AssistantAccessPermission.Id }
+                        $Role["GtProjectAdminPermissions"] = $UpdatedPermissions
+                        $Role.SystemUpdate()
+                        $Role.Context.ExecuteQuery()
+                        Write-Host "[INFO] Added 'AssistantAccess' permission to role '$RoleTitle'" -ForegroundColor Green
+                    } else {
+                        Write-Host "[INFO] Role '$RoleTitle' already has 'AssistantAccess' permission, skipping"
+                    }
+                } else {
+                    Write-Host "[WARNING] Could not find role '$RoleTitle' in list '$AdminRolesList'" -ForegroundColor Yellow
+                }
+            }
+        } else {
+            Write-Host "[WARNING] Could not find 'AssistantAccess' permission item in list '$AdminPermissionsList'" -ForegroundColor Yellow
+        }
+
+        Write-Host "[INFO] Ensuring 'AssistantAccessMode' global setting exists..."
+        $GlobalSettingsList = Get-Resource -Name "Lists_Global_Settings_Title"
+        $AssistantAccessModeSettingId = "{a2e4f6b8-1c3d-5e7f-9a0b-c4d6e8f0a2b4}"
+        $ExistingSetting = Get-PnPListItem -List $GlobalSettingsList | Where-Object { $_["GtSettingsId"] -eq $AssistantAccessModeSettingId }
+        if ($null -eq $ExistingSetting) {
+            $AssistantCategory = Get-Resource -Name "Lists_Global_Settings_Category_Assistant"
+            $SettingTitle = Get-Resource -Name "Lists_Global_Settings_Category_Assistant_AssistantAccessMode_Title"
+            Add-PnPListItem -List $GlobalSettingsList -Values @{
+                "GtSettingsId"       = $AssistantAccessModeSettingId
+                "Title"              = $SettingTitle
+                "GtSettingsKey"      = "AssistantAccessMode"
+                "GtSettingsValue"    = "group"
+                "GtSettingsEnabled"  = $true
+                "GtSettingsCategory" = $AssistantCategory
+            } | Out-Null
+            Write-Host "[INFO] Added 'AssistantAccessMode' global setting with default value 'group'" -ForegroundColor Green
+        } else {
+            Write-Host "[INFO] 'AssistantAccessMode' global setting already exists, skipping"
+        }
+    }
 }

--- a/Install/Scripts/PostInstallUpgrade.ps1
+++ b/Install/Scripts/PostInstallUpgrade.ps1
@@ -235,9 +235,7 @@ if ($null -ne $LastInstall) {
         } else {
             Write-Host "[WARNING] Could not find 'ReRunSetup' permission item in list '$AdminPermissionsList'" -ForegroundColor Yellow
         }
-    }
 
-    if ($PreviousVersion -lt [version]"1.14.0") {
         Write-Host "[INFO] Ensuring 'AssistantAccess' permission is assigned to all project admin roles..."
 
         $AdminRolesList = Get-Resource -Name "Lists_ProjectAdminRoles_Title"

--- a/SharePointFramework/PortfolioExtensions/src/data/SPDataAdapter.ts
+++ b/SharePointFramework/PortfolioExtensions/src/data/SPDataAdapter.ts
@@ -1,0 +1,5 @@
+import { SPDataAdapterBase } from 'pp365-shared-library/lib/data'
+
+class SPDataAdapter extends SPDataAdapterBase {}
+
+export default new SPDataAdapter()

--- a/SharePointFramework/PortfolioExtensions/src/extensions/footer/index.ts
+++ b/SharePointFramework/PortfolioExtensions/src/extensions/footer/index.ts
@@ -11,6 +11,11 @@ import '@pnp/sp/webs'
 import resource from 'SharedResources'
 import { Footer, IFooterProps } from 'components/Footer'
 import { PortalDataService } from 'pp365-shared-library/lib/services/PortalDataService'
+import {
+  createSpfiInstance,
+  isHubSite,
+  ProjectAdminPermission
+} from 'pp365-shared-library'
 import { createElement } from 'react'
 import { render } from 'react-dom'
 import {
@@ -60,7 +65,6 @@ export default class FooterApplicationCustomizer extends BaseApplicationCustomiz
       return Promise.resolve()
     }
 
-    const requireAssistantAccess = this._globalSettings.get('RequireAssistantAccess') === '1'
     const [installEntries, gitHubReleases, helpContent, links, favoriteProjects] =
       await Promise.all([
         this._fetchInstallationLogs(),
@@ -84,8 +88,7 @@ export default class FooterApplicationCustomizer extends BaseApplicationCustomiz
     const endpointUrl = this._globalSettings.get('EndpointUrl')
     this._assistantEndpointUrl = useBetaChannel && betaEndpointUrl ? betaEndpointUrl : endpointUrl
 
-    this._hasAssistantAccess =
-      !requireAssistantAccess || (await this._isUserInGroup(strings.AssistantGroupName))
+    this._hasAssistantAccess = await this._checkAssistantAccess()
     this.context.application.navigatedEvent.add(this, this._handleNavigatedEvent)
     return Promise.resolve()
   }
@@ -93,8 +96,12 @@ export default class FooterApplicationCustomizer extends BaseApplicationCustomiz
   private async _handleNavigatedEvent(): Promise<void> {
     if (!this._portalDataService?.isAvailable) return
 
-    const helpContent = await this._fetchHelpContent()
+    const [helpContent, hasAssistantAccess] = await Promise.all([
+      this._fetchHelpContent(),
+      this._checkAssistantAccess()
+    ])
     this._helpContent = helpContent
+    this._hasAssistantAccess = hasAssistantAccess
 
     this._renderFooter(PlaceholderName.Bottom, {
       installEntries: this._installEntries,
@@ -123,6 +130,38 @@ export default class FooterApplicationCustomizer extends BaseApplicationCustomiz
     } catch (error) {
       return false
     }
+  }
+
+  /**
+   * Check if the current user has access to the assistant based on the
+   * configured access mode (`AssistantAccessMode` global setting).
+   *
+   * Modes:
+   * - `group` (default): Check membership in the assistant users group (hub-level)
+   * - `role`: Check project admin roles on project sites, group check on hub
+   * - `both`: User must pass both group AND role check on project sites
+   */
+  private async _checkAssistantAccess(): Promise<boolean> {
+    const requireAccess = this._globalSettings.get('RequireAssistantAccess') === '1'
+    if (!requireAccess) return true
+
+    const accessMode = this._globalSettings.get('AssistantAccessMode') || 'group'
+    const onProjectSite = !isHubSite(this.context.pageContext)
+    const checkGroup = accessMode === 'group' || accessMode === 'both' || !onProjectSite
+    const checkRole = (accessMode === 'role' || accessMode === 'both') && onProjectSite
+
+    const groupResult = checkGroup
+      ? await this._isUserInGroup(strings.AssistantGroupName)
+      : true
+
+    const roleResult = checkRole
+      ? await this._portalDataService.checkProjectAdminPermission(
+          createSpfiInstance(this.context),
+          ProjectAdminPermission.AssistantAccess
+        )
+      : true
+
+    return groupResult && roleResult
   }
 
   /**

--- a/SharePointFramework/PortfolioExtensions/src/extensions/footer/index.ts
+++ b/SharePointFramework/PortfolioExtensions/src/extensions/footer/index.ts
@@ -12,10 +12,10 @@ import resource from 'SharedResources'
 import { Footer, IFooterProps } from 'components/Footer'
 import { PortalDataService } from 'pp365-shared-library/lib/services/PortalDataService'
 import {
-  createSpfiInstance,
   isHubSite,
   ProjectAdminPermission
 } from 'pp365-shared-library'
+import SPDataAdapter from '../../data/SPDataAdapter'
 import { createElement } from 'react'
 import { render } from 'react-dom'
 import {
@@ -46,9 +46,8 @@ export default class FooterApplicationCustomizer extends BaseApplicationCustomiz
    */
   public async onInit(): Promise<void> {
     await super.onInit()
-    this._portalDataService = await new PortalDataService().configure({
-      spfxContext: this.context
-    })
+    await SPDataAdapter.configure(this.context, {})
+    this._portalDataService = SPDataAdapter.portalDataService
     this._globalSettings = await this._portalDataService.getGlobalSettings()
 
     if (!this._portalDataService.isAvailable) {
@@ -155,8 +154,7 @@ export default class FooterApplicationCustomizer extends BaseApplicationCustomiz
       : true
 
     const roleResult = checkRole
-      ? await this._portalDataService.checkProjectAdminPermission(
-          createSpfiInstance(this.context),
+      ? await SPDataAdapter.checkProjectAdminPermissions(
           ProjectAdminPermission.AssistantAccess
         )
       : true

--- a/SharePointFramework/shared-library/src/data/SPDataAdapterBase/index.ts
+++ b/SharePointFramework/shared-library/src/data/SPDataAdapterBase/index.ts
@@ -142,17 +142,26 @@ export class SPDataAdapterBase<
    * Check project admin permissions.
    *
    * @param permission Permission to check
-   * @param properties Project properties
+   * @param properties Project properties (if not provided, tries to load from the project properties list)
    */
   public async checkProjectAdminPermissions(
     permission: ProjectAdminPermission,
-    properties: ItemFieldValues
+    properties?: ItemFieldValues
   ) {
     try {
       const { pageContext } = this.spfxContext
       if (!pageContext) return false
       if (!this.portalDataService?.isAvailable) {
         return await this.sp.web.currentUserHasPermissions(PermissionKind.ManageWeb)
+      }
+
+      if (!properties) {
+        const propertiesList = this.sp.web.lists.getByTitle(
+          resource.Lists_ProjectProperties_Title
+        )
+        const [propertiesItem] = await propertiesList.items.top(1)()
+        if (!propertiesItem) return false
+        properties = new ItemFieldValues(propertiesItem)
       }
 
       const permissions = await (async () => {

--- a/SharePointFramework/shared-library/src/data/SPDataAdapterBase/types.ts
+++ b/SharePointFramework/shared-library/src/data/SPDataAdapterBase/types.ts
@@ -33,7 +33,8 @@ export enum ProjectAdminPermission {
   ChangePhase = '75a08ae0-d69a-41b2-adf4-ae233c6bff9f',
   ProjectStatusAdmin = 'f6b875ae-fdb4-4ceb-bc75-ed853c2a2b0e',
   ChildProjectsAdmin = '2281c92a-f5ff-4d99-8814-e7b2f33d1ac9',
-  ReRunSetup = '5c2fd32e-0c8b-42be-9e0b-4fa6ff5d4774'
+  ReRunSetup = '5c2fd32e-0c8b-42be-9e0b-4fa6ff5d4774',
+  AssistantAccess = '7f3a8b2c-4d5e-6f70-8192-a3b4c5d6e7f8'
 }
 
 export enum ProjectPropertiesMapType {

--- a/SharePointFramework/shared-library/src/services/PortalDataService/PortalDataService.ts
+++ b/SharePointFramework/shared-library/src/services/PortalDataService/PortalDataService.ts
@@ -12,7 +12,6 @@ import { merge } from 'lodash'
 import strings from 'SharedLibraryStrings'
 import initJsom, { ExecuteJsomQuery as executeQuery } from 'spfx-jsom'
 import _ from 'underscore'
-import resource from 'SharedResources'
 import { createSpfiInstance, DefaultCaching, getItemFieldValues } from '../../data'
 import { ISPContentType } from '../../interfaces'
 import {
@@ -21,7 +20,6 @@ import {
   ItemFieldValues,
   PortfolioOverviewView,
   ProjectAdminRole,
-  ProjectAdminRoleType,
   ProjectColumn,
   ProjectColumnConfig,
   ProjectContentColumn,
@@ -1089,93 +1087,6 @@ export class PortalDataService extends DataService<IPortalDataServiceConfigurati
     } catch (error) {
       this._handleAvailabilityError(error, 'getProjectAdminRoles')
       return []
-    }
-  }
-
-  /**
-   * Check if the current user has a specific project admin permission for the current
-   * project site. This is used by the footer extension to check assistant access
-   * based on project admin roles.
-   *
-   * @param projectSp SPFI instance for the current project site
-   * @param permission Permission GUID to check (e.g. `ProjectAdminPermission.AssistantAccess`)
-   */
-  public async checkProjectAdminPermission(
-    projectSp: SPFI,
-    permission: string
-  ): Promise<boolean> {
-    if (!this.isAvailable) return false
-    try {
-      const propertiesList = projectSp.web.lists.getByTitle(
-        resource.Lists_ProjectProperties_Title
-      )
-      const [propertiesItem] = await propertiesList.items.top(1)()
-      if (!propertiesItem) return false
-
-      const rolesToCheck: string[] = propertiesItem.GtProjectAdminRoles
-      if (!Array.isArray(rolesToCheck) || rolesToCheck.length === 0) {
-        return await projectSp.web.currentUserHasPermissions(PermissionKind.ManageWeb)
-      }
-
-      const { data: currentUser } = await projectSp.web.ensureUser(
-        this._configuration.spfxContext.pageContext.user.loginName ??
-          this._configuration.spfxContext.pageContext.user.email
-      )
-
-      const allRoles = await this.getProjectAdminRoles()
-      const assignedRoles = allRoles.filter(
-        (role) => rolesToCheck.indexOf(role.title) !== -1
-      )
-
-      const userPermissions: string[] = []
-      for (const role of assignedRoles) {
-        switch (role.type) {
-          case ProjectAdminRoleType.SiteAdmin:
-            {
-              try {
-                if (await projectSp.web.currentUserHasPermissions(PermissionKind.ManageWeb))
-                  userPermissions.push(...role.permissions)
-              } catch {}
-            }
-            break
-          case ProjectAdminRoleType.ProjectProperty:
-            {
-              const fieldValue = propertiesItem[role.projectFieldName]
-              if (Array.isArray(fieldValue) && fieldValue.indexOf(currentUser.Id) !== -1)
-                userPermissions.push(...role.permissions)
-              if (fieldValue === currentUser.Id) userPermissions.push(...role.permissions)
-            }
-            break
-          case ProjectAdminRoleType.SharePointGroup:
-            {
-              let web: IWeb = null
-              if (role.groupLevel === resource.Lists_ProjectAdminRoles_GroupLevel_Project) {
-                web = projectSp.web
-              } else if (
-                role.groupLevel === resource.Lists_ProjectAdminRoles_GroupLevel_Portfolio
-              ) {
-                web = this.web
-              }
-              if (web) {
-                try {
-                  if (
-                    (
-                      await web.siteGroups
-                        .getByName(role.groupName)
-                        .users.filter(`Email eq '${currentUser.Email}'`)()
-                    ).length > 0
-                  )
-                    userPermissions.push(...role.permissions)
-                } catch {}
-              }
-            }
-            break
-        }
-      }
-
-      return _.unique(userPermissions).indexOf(permission) !== -1
-    } catch {
-      return false
     }
   }
 

--- a/SharePointFramework/shared-library/src/services/PortalDataService/PortalDataService.ts
+++ b/SharePointFramework/shared-library/src/services/PortalDataService/PortalDataService.ts
@@ -12,6 +12,7 @@ import { merge } from 'lodash'
 import strings from 'SharedLibraryStrings'
 import initJsom, { ExecuteJsomQuery as executeQuery } from 'spfx-jsom'
 import _ from 'underscore'
+import resource from 'SharedResources'
 import { createSpfiInstance, DefaultCaching, getItemFieldValues } from '../../data'
 import { ISPContentType } from '../../interfaces'
 import {
@@ -20,6 +21,7 @@ import {
   ItemFieldValues,
   PortfolioOverviewView,
   ProjectAdminRole,
+  ProjectAdminRoleType,
   ProjectColumn,
   ProjectColumnConfig,
   ProjectContentColumn,
@@ -1087,6 +1089,93 @@ export class PortalDataService extends DataService<IPortalDataServiceConfigurati
     } catch (error) {
       this._handleAvailabilityError(error, 'getProjectAdminRoles')
       return []
+    }
+  }
+
+  /**
+   * Check if the current user has a specific project admin permission for the current
+   * project site. This is used by the footer extension to check assistant access
+   * based on project admin roles.
+   *
+   * @param projectSp SPFI instance for the current project site
+   * @param permission Permission GUID to check (e.g. `ProjectAdminPermission.AssistantAccess`)
+   */
+  public async checkProjectAdminPermission(
+    projectSp: SPFI,
+    permission: string
+  ): Promise<boolean> {
+    if (!this.isAvailable) return false
+    try {
+      const propertiesList = projectSp.web.lists.getByTitle(
+        resource.Lists_ProjectProperties_Title
+      )
+      const [propertiesItem] = await propertiesList.items.top(1)()
+      if (!propertiesItem) return false
+
+      const rolesToCheck: string[] = propertiesItem.GtProjectAdminRoles
+      if (!Array.isArray(rolesToCheck) || rolesToCheck.length === 0) {
+        return await projectSp.web.currentUserHasPermissions(PermissionKind.ManageWeb)
+      }
+
+      const { data: currentUser } = await projectSp.web.ensureUser(
+        this._configuration.spfxContext.pageContext.user.loginName ??
+          this._configuration.spfxContext.pageContext.user.email
+      )
+
+      const allRoles = await this.getProjectAdminRoles()
+      const assignedRoles = allRoles.filter(
+        (role) => rolesToCheck.indexOf(role.title) !== -1
+      )
+
+      const userPermissions: string[] = []
+      for (const role of assignedRoles) {
+        switch (role.type) {
+          case ProjectAdminRoleType.SiteAdmin:
+            {
+              try {
+                if (await projectSp.web.currentUserHasPermissions(PermissionKind.ManageWeb))
+                  userPermissions.push(...role.permissions)
+              } catch {}
+            }
+            break
+          case ProjectAdminRoleType.ProjectProperty:
+            {
+              const fieldValue = propertiesItem[role.projectFieldName]
+              if (Array.isArray(fieldValue) && fieldValue.indexOf(currentUser.Id) !== -1)
+                userPermissions.push(...role.permissions)
+              if (fieldValue === currentUser.Id) userPermissions.push(...role.permissions)
+            }
+            break
+          case ProjectAdminRoleType.SharePointGroup:
+            {
+              let web: IWeb = null
+              if (role.groupLevel === resource.Lists_ProjectAdminRoles_GroupLevel_Project) {
+                web = projectSp.web
+              } else if (
+                role.groupLevel === resource.Lists_ProjectAdminRoles_GroupLevel_Portfolio
+              ) {
+                web = this.web
+              }
+              if (web) {
+                try {
+                  if (
+                    (
+                      await web.siteGroups
+                        .getByName(role.groupName)
+                        .users.filter(`Email eq '${currentUser.Email}'`)()
+                    ).length > 0
+                  )
+                    userPermissions.push(...role.permissions)
+                } catch {}
+              }
+            }
+            break
+        }
+      }
+
+      return _.unique(userPermissions).indexOf(permission) !== -1
+    } catch {
+      return false
     }
   }
 

--- a/Templates/Portfolio/Objects/Lists/Globale innstillinger.xml
+++ b/Templates/Portfolio/Objects/Lists/Globale innstillinger.xml
@@ -184,6 +184,14 @@
       <pnp:DataValue FieldName="GtSettingsEnabled">True</pnp:DataValue>
       <pnp:DataValue FieldName="GtSettingsCategory">{resource:Lists_Global_Settings_Category_Assistant}</pnp:DataValue>
     </pnp:DataRow>
+    <pnp:DataRow>
+      <pnp:DataValue FieldName="GtSettingsId">{a2e4f6b8-1c3d-5e7f-9a0b-c4d6e8f0a2b4}</pnp:DataValue>
+      <pnp:DataValue FieldName="Title">{resource:Lists_Global_Settings_Category_Assistant_AssistantAccessMode_Title}</pnp:DataValue>
+      <pnp:DataValue FieldName="GtSettingsKey">AssistantAccessMode</pnp:DataValue>
+      <pnp:DataValue FieldName="GtSettingsValue">group</pnp:DataValue>
+      <pnp:DataValue FieldName="GtSettingsEnabled">True</pnp:DataValue>
+      <pnp:DataValue FieldName="GtSettingsCategory">{resource:Lists_Global_Settings_Category_Assistant}</pnp:DataValue>
+    </pnp:DataRow>
   </pnp:DataRows>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="Objects/Lists/Security/DefaultSecurity.xml" />
 </pnp:ListInstance>

--- a/Templates/Portfolio/Objects/Lists/Prosjektadministrasjonsroller.xml
+++ b/Templates/Portfolio/Objects/Lists/Prosjektadministrasjonsroller.xml
@@ -67,31 +67,31 @@
         <pnp:DataRow>
             <pnp:DataValue FieldName="Title">{resource:Lists_ProjectAdminRoles_ProjectManager}</pnp:DataValue>
             <pnp:DataValue FieldName="GtProjectFieldName">GtProjectManager</pnp:DataValue>
-            <pnp:DataValue FieldName="GtProjectAdminPermissions">1,2,3</pnp:DataValue>
+            <pnp:DataValue FieldName="GtProjectAdminPermissions">1,2,3,6</pnp:DataValue>
             <pnp:DataValue FieldName="ContentTypeId">0x0100618197F7C782A0459EB2FA5EBF1BDDF201</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>
             <pnp:DataValue FieldName="Title">{resource:Lists_ProjectAdminRoles_ProjectOwner}</pnp:DataValue>
             <pnp:DataValue FieldName="GtProjectFieldName">GtProjectOwner</pnp:DataValue>
-            <pnp:DataValue FieldName="GtProjectAdminPermissions">1,2,3</pnp:DataValue>
+            <pnp:DataValue FieldName="GtProjectAdminPermissions">1,2,3,6</pnp:DataValue>
             <pnp:DataValue FieldName="ContentTypeId">0x0100618197F7C782A0459EB2FA5EBF1BDDF201</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>
             <pnp:DataValue FieldName="Title">{resource:Lists_ProjectAdminRoles_ProjectSupport}</pnp:DataValue>
             <pnp:DataValue FieldName="GtProjectFieldName">GtProjectSupport</pnp:DataValue>
-            <pnp:DataValue FieldName="GtProjectAdminPermissions">1,2,3</pnp:DataValue>
+            <pnp:DataValue FieldName="GtProjectAdminPermissions">1,2,3,6</pnp:DataValue>
             <pnp:DataValue FieldName="ContentTypeId">0x0100618197F7C782A0459EB2FA5EBF1BDDF201</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>
             <pnp:DataValue FieldName="Title">{resource:Lists_ProjectAdminRoles_ProjectOffice}</pnp:DataValue>
             <pnp:DataValue FieldName="GtGroupName">{resource:Lists_ProjectAdminRoles_ProjectOffice}</pnp:DataValue>
             <pnp:DataValue FieldName="GtGroupLevel">{resource:Lists_ProjectAdminRoles_GroupLevel_Project}</pnp:DataValue>
-            <pnp:DataValue FieldName="GtProjectAdminPermissions">1,2,3</pnp:DataValue>
+            <pnp:DataValue FieldName="GtProjectAdminPermissions">1,2,3,6</pnp:DataValue>
             <pnp:DataValue FieldName="ContentTypeId">0x0100618197F7C782A0459EB2FA5EBF1BDDF202</pnp:DataValue>
         </pnp:DataRow>
         <pnp:DataRow>
             <pnp:DataValue FieldName="Title">{resource:Lists_ProjectAdminRoles_SPAdmin}</pnp:DataValue>
-            <pnp:DataValue FieldName="GtProjectAdminPermissions">1,2,3,4,5</pnp:DataValue>
+            <pnp:DataValue FieldName="GtProjectAdminPermissions">1,2,3,4,5,6</pnp:DataValue>
             <pnp:DataValue FieldName="ContentTypeId">0x0100618197F7C782A0459EB2FA5EBF1BDDF203</pnp:DataValue>
         </pnp:DataRow>
     </pnp:DataRows>

--- a/Templates/Portfolio/Objects/Lists/Prosjektadministrasjonstilganger.xml
+++ b/Templates/Portfolio/Objects/Lists/Prosjektadministrasjonstilganger.xml
@@ -44,7 +44,13 @@
             <pnp:DataValue FieldName="GtProjectAdminPermission">ReRunSetup</pnp:DataValue>
             <pnp:DataValue FieldName="GtProjectAdminPermissionId">5c2fd32e-0c8b-42be-9e0b-4fa6ff5d4774</pnp:DataValue>
             <pnp:DataValue FieldName="ContentTypeId">0x010018DB532215EDE34C975F3AC3348948B1</pnp:DataValue>
-        </pnp:DataRow>  
+        </pnp:DataRow>
+        <pnp:DataRow>
+            <pnp:DataValue FieldName="Title">{resource:Lists_ProjectAdminPermissions_AssistantAccess}</pnp:DataValue>
+            <pnp:DataValue FieldName="GtProjectAdminPermission">AssistantAccess</pnp:DataValue>
+            <pnp:DataValue FieldName="GtProjectAdminPermissionId">7f3a8b2c-4d5e-6f70-8192-a3b4c5d6e7f8</pnp:DataValue>
+            <pnp:DataValue FieldName="ContentTypeId">0x010018DB532215EDE34C975F3AC3348948B1</pnp:DataValue>
+        </pnp:DataRow>
     </pnp:DataRows>
     <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="Objects/Lists/Security/DefaultSecurity.xml" />
 </pnp:ListInstance>

--- a/Templates/Portfolio/Resources.en-US.resx
+++ b/Templates/Portfolio/Resources.en-US.resx
@@ -1474,6 +1474,9 @@
   <data name="Lists_Global_Settings_Category_Assistant_RequireAssistantAccess_Title" xml:space="preserve">
     <value>Require access to use the assistant</value>
   </data>
+  <data name="Lists_Global_Settings_Category_Assistant_AssistantAccessMode_Title" xml:space="preserve">
+    <value>Access mode for assistant (group, role or both)</value>
+  </data>
   <data name="Lists_Global_Settings_Category_Assistant_UseAssistant_Title" xml:space="preserve">
     <value>Use the Project Portal assistant</value>
   </data>
@@ -1998,6 +2001,9 @@
   </data>
   <data name="Lists_ProjectAdminPermissions_ReRunSetup" xml:space="preserve">
     <value>Re-run setup wizard</value>
+  </data>
+  <data name="Lists_ProjectAdminPermissions_AssistantAccess" xml:space="preserve">
+    <value>Assistant access</value>
   </data>
   <data name="Lists_ProjectAdminPermissions_Title" xml:space="preserve">
     <value>Project Admin Permissions</value>

--- a/Templates/Portfolio/Resources.no-NB.resx
+++ b/Templates/Portfolio/Resources.no-NB.resx
@@ -1474,6 +1474,9 @@
   <data name="Lists_Global_Settings_Category_Assistant_RequireAssistantAccess_Title" xml:space="preserve">
     <value>Krev tilgang for å bruke assistenten</value>
   </data>
+  <data name="Lists_Global_Settings_Category_Assistant_AssistantAccessMode_Title" xml:space="preserve">
+    <value>Tilgangsmodus for assistenten (group, role eller both)</value>
+  </data>
   <data name="Lists_Global_Settings_Category_Assistant_UseAssistant_Title" xml:space="preserve">
     <value>Ta i bruk Prosjektportalen assistenten</value>
   </data>
@@ -1998,6 +2001,9 @@
   </data>
   <data name="Lists_ProjectAdminPermissions_ReRunSetup" xml:space="preserve">
     <value>Kjøre oppsettsveiviser på nytt</value>
+  </data>
+  <data name="Lists_ProjectAdminPermissions_AssistantAccess" xml:space="preserve">
+    <value>Assistenttilgang</value>
   </data>
   <data name="Lists_ProjectAdminPermissions_Title" xml:space="preserve">
     <value>Prosjektadministrasjonstilganger</value>


### PR DESCRIPTION
# Pull request (PR)

## Sjekklisten din

- [x] Legg ved beskrivelse i CHANGELOG, markert med **ID av issue** (dersom relevant) knyttet til PR-en
- [x] Angi korrekt `Milestone` på PR-en og issuet, samt tilegn deg selv PR-en og legg til `labels`

### Beskrivelse

Ny tilgangsstyring for PP Assistenten basert på prosjektadministrasjonsroller. Denne PR-en innfører muligheten for å styre tilgang til assistenten per prosjekt, i stedet for kun hub-bred gruppetilhørighet.

**Endringer:**
- Ny `AssistantAccess`-tilgang i `Prosjektadministrasjonstilganger`-listen
- Ny global innstilling `AssistantAccessMode` med tre moduser:
  - `group` (standard) – Eksisterende oppførsel via SharePoint-gruppen «Assistentbrukere»
  - `role` – Rollebasert tilgangskontroll per prosjekt via prosjektadministrasjonsroller
  - `both` – Bruker må tilfredsstille både gruppe- og rollesjekk
- Ny `checkProjectAdminPermission()`-metode i `PortalDataService`
- Oppdatert footer-extension med `_checkAssistantAccess()` og rekalkulering ved SPA-navigasjon
- Oppgraderingsskript i `PostInstallUpgrade.ps1` (v1.13.0-blokk) som tildeler `AssistantAccess` til alle eksisterende roller
- Ressursstrenger (NO/EN)

### Hvordan teste

1. **Installer/oppgrader Prosjektportalen** – Verifiser at `AssistantAccess`-tilgangen finnes i `Prosjektadministrasjonstilganger`-listen og at alle roller har fått den tildelt
2. **Sett `AssistantAccessMode` til `group`** i Globale innstillinger – Verifiser at assistenten oppfører seg som før (kun gruppesjekk)
3. **Sett `AssistantAccessMode` til `role`** – Verifiser at assistenten vises for brukere med en rolle som har `AssistantAccess`, og at den skjules for brukere uten slik rolle på prosjektsider. På hubområdet skal gruppesjekk fortsatt gjelde
4. **Sett `AssistantAccessMode` til `both`** – Verifiser at brukeren må være i gruppen OG ha en rolle med `AssistantAccess` for å se assistenten på prosjektsider
5. **Fjern `AssistantAccess` fra en rolle** i `Prosjektadministrasjonsroller`-listen – Verifiser at brukere med den rollen mister tilgang til assistenten (i `role`/`both`-modus)
6. **Naviger mellom hubområde og prosjektområde** – Verifiser at tilgangssjekken rekalkuleres korrekt ved SPA-navigasjon

### Relevante issues (hvis aktuelt)

-

## Sjekkliste for godkjenner

- [x] Sjekk at det er fylt ut testpunkter
- [x] Sjekk om det er nødvendig å nevne denne PR i release notes
- [x] Sjekk om det er nødvendig å oppdatere dokumentasjon for hjelpeinnhold
