### PR TITLE
fix: retry site creation with fresh token on permission error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Sjekk ut [release notes](./releasenotes/1.12.0.md) for høydepunkter og mer deta
 - Rettet en logisk feil i `Prosjekttidslinje` hvor prosjektelementer ikke ble vist dersom `Vis på portefølje` var satt til nei, fordi visningen feilaktig var betinget av portefølje-/programflagg i stedet for kun å sjekke om konfigurasjon eksisterer
 - Rettet en feil i `Porteføljeoversikt` hvor gruppering på brukerfelt viste rå SharePoint-verdier (e-post, claim-streng) i stedet for visningsnavn
 - Rettet en feil ved eksport til Excel hvor brukerfelt, oppslag og beregnede kolonner ble eksportert med rå SharePoint-verdier i stedet for visningsnavn
+- Rettet en feil hvor installasjon til en ny tenant feilet med 403 ved opprettelse av område fordi MSAL-tokenet ikke inneholdt nylig innvilgede tillatelser. Installasjonsskriptet prøver nå automatisk på nytt med en ny tilkobling
 - Rettet en feil i filterpanelet hvor beregnede kolonner og brukerfelt viste rå SharePoint-verdier i stedet for visningsnavn.
 - Rettet en feil i `Prosjektlisten` hvor listevisningen krasjet dersom prosjektdata ikke var ferdig lastet
 - Rettet en visuell feil i `Bestillingsportalen` hvor en advarsel/feilmelding blinket kort i skjemaet etter innsending, forårsaket av at skjemadata ble nullstilt før panelet ble lukket

--- a/Install/Build-Release.ps1
+++ b/Install/Build-Release.ps1
@@ -36,7 +36,7 @@ $global:ACTION_INDEX = 1
 <#
 If running in CI mode, set the number of actions to 11. This is used to display the progress of the script.
 #>
-if($CI.IsPresent) {
+if ($CI.IsPresent) {
     $global:ACTIONS_COUNT = 11
 }
 
@@ -136,7 +136,7 @@ if ($CI.IsPresent) {
     EndAction
 }
 else {
-    if(-not $SkipImportModule.IsPresent) {
+    if (-not $SkipImportModule.IsPresent) {
         Import-Module $PNP_BUNDLE_PATH/$PNP_VERSION/PnP.PowerShell.psd1 -DisableNameChecking -ErrorAction SilentlyContinue
     }
 }

--- a/Install/Install.ps1
+++ b/Install/Install.ps1
@@ -201,7 +201,17 @@ if (-not $SkipSiteCreation.IsPresent -and -not $Upgrade.IsPresent) {
         $PortfolioSite = Get-PnPTenantSite -Url $Uri.AbsoluteUri -ErrorAction SilentlyContinue
         if ($null -eq $PortfolioSite) {
             StartAction("Creating portfolio site at $($Uri.AbsoluteUri)")
-            $PortfolioSite = New-PnPSite -Type TeamSite -Title $Title -Alias $Alias -IsPublic:$true -ErrorAction Stop -Lcid $LanguageId -Wait -HideGroupInOutlook -WelcomeEmailDisabled
+            Try {
+                $PortfolioSite = New-PnPSite -Type TeamSite -Title $Title -Alias $Alias -IsPublic:$true -ErrorAction Stop -Lcid $LanguageId -Wait -HideGroupInOutlook -WelcomeEmailDisabled
+            }
+            Catch {
+                Write-Host "[WARNING] Failed to create site: $($_.Exception.Message)" -ForegroundColor Yellow
+                Write-Host "[INFO] Reconnecting with a fresh session and retrying. This can happen when app permissions were recently granted on a new tenant." -ForegroundColor Yellow
+                Disconnect-PnPOnline -ErrorAction SilentlyContinue
+                Start-Sleep -Seconds 10
+                Connect-SharePoint -Url $AdminSiteUrl -ConnectionInfo $ConnectionInfo
+                $PortfolioSite = New-PnPSite -Type TeamSite -Title $Title -Alias $Alias -IsPublic:$true -ErrorAction Stop -Lcid $LanguageId -Wait -HideGroupInOutlook -WelcomeEmailDisabled
+            }
             EndAction
         }
     }


### PR DESCRIPTION
When installing to a new tenant, the cached MSAL token may lack newly granted permissions, causing New-PnPSite to fail with 403. This adds a retry that disconnects and reconnects to get a fresh token, matching the manual workaround of Disconnect-PnPOnline.

# Pull request (PR)

Sørg for at du ber om PR for din branch (høyre side). Sørg for at du gjør en PR mot riktig release-branch (venstre side). Sjekk commits og alle commit-meldingene.

## Sjekklisten din

Alle sjekkpunktene under må være sjekket av og godkjent for at vi skal kunne merge branchen din mot release-branch.

- [X] Legg ved beskrivelse i [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md), markert med **ID av issue** (dersom relevant) knyttet til PR-en
- [X] Angi korrekt `Milestone` på PR-en og issuet, samt tilegn deg selv PR-en og legg til `labels`

### Beskrivelse

- When installing to a new tenant, the cached MSAL token may lack newly granted permissions, causing New-PnPSite to fail with a 403 "Insufficient privileges" error
- Adds automatic retry logic that disconnects PnP Online (clearing the MSAL token cache), waits 10 seconds for Entra ID permission propagation, reconnects with a fresh token, and retries site creation
- This automates the manual workaround of running Disconnect-PnPOnline and rerunning the script
- Test plan
-  Install to a new tenant where the multi-tenant app hasn't been consented before — script should succeed automatically (possibly showing the retry warning)
-  Install on a tenant where the app is already consented — should work as before with no extra prompts or delays
-  Verify that genuine failures (e.g., invalid alias) still exit with an error after the retry attempt

## Sjekkliste for godkjenner

Alle sjekkpunktene under må være sjekket av og godkjent av reviewers for at vi skal kunne merge branchen din mot dev.

- [x] Sjekk at det er fylt ut testpunkter
- [x] Sjekk om det er nødvendig å nevne denne PR i release notes
- [x] Sjekk om det er nødvendig å oppdatere dokumentasjon for hjelpeinnhold
  - Ta en titt på [Brukermanual for Prosjektportalen 365](https://puzzlepart.github.io/prosjektportalen-manual/) og vurder behovet for oppdateringer.
