### PR TITLE
fix: improve template selector folder path and navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ Sjekk ut [release notes](./releasenotes/1.12.0.md) for høydepunkter og mer deta
 - Forbedret stabilitet for Planner-operasjoner med automatisk gjenforsøk ved forbigående feil, samt bedre deduplisering av oppgaver og feillogging [#1733](https://github.com/Puzzlepart/prosjektportalen365/pull/1733)
 - Prosjektinformasjon (kolonner merket med `GtIsRefinable=true` i `Prosjektkolonner`) vises nå som filtre også i aggregerte oversikter (f.eks. Usikkerhetsoversikt, Gevinstoversikt), på linje med `Prosjekttidslinje`. Filtre fra prosjektinformasjon er gruppert under en egen seksjon `Prosjektinformasjon` i filterpanelet som er kollapset som standard
 - Ytelsesforbedring: `Prosjektutlisting`, `Prosjekttidslinje` og aggregerte oversikter på samme side deler nå en felles cache for prosjekt-data, slik at kall mot `Prosjekter`-lista og tilhørende søk kun gjøres én gang per side.
+- `Hent dokumentmal`-dialogen defaulter nå målmappen til den mappen brukeren befinner seg i, i stedet for roten av biblioteket. Mapper i målmappe-steget kan nå også navigeres med enkelt-klikk [#1738](https://github.com/Puzzlepart/prosjektportalen365/pull/1738)
 
 ### Fjernet
 

--- a/SharePointFramework/ProjectExtensions/src/components/DocumentTemplateDialog/TargetFolderScreen/columns.tsx
+++ b/SharePointFramework/ProjectExtensions/src/components/DocumentTemplateDialog/TargetFolderScreen/columns.tsx
@@ -11,7 +11,7 @@ import React from 'react'
 
 initializeFileTypeIcons()
 
-export default () =>
+export default ({ onFolderClick }: { onFolderClick: (folder: SPFolder) => void }) =>
   [
     {
       key: getId('icon'),
@@ -34,7 +34,7 @@ export default () =>
       minWidth: 200,
       onRender: (folder: SPFolder) => {
         return (
-          <Link>
+          <Link onClick={() => onFolderClick(folder)}>
             <span style={{ marginLeft: 4 }}>{folder.name}</span>
           </Link>
         )

--- a/SharePointFramework/ProjectExtensions/src/components/DocumentTemplateDialog/TargetFolderScreen/index.tsx
+++ b/SharePointFramework/ProjectExtensions/src/components/DocumentTemplateDialog/TargetFolderScreen/index.tsx
@@ -26,7 +26,9 @@ export const TargetFolderScreen: FC = () => {
   const context = useContext(TemplateSelectorContext)
   const [root, setRoot] = useState(context.currentLibrary)
   const [folders, setFolders] = useState(root.folders)
-  const [folder, setFolder] = useState(state.targetFolder)
+  const [folder, setFolder] = useState(
+    state.targetFolder || context.currentFolderUrl || ''
+  )
 
   useEffect(() => {
     if (folder === null) {

--- a/SharePointFramework/ProjectExtensions/src/components/DocumentTemplateDialog/TargetFolderScreen/index.tsx
+++ b/SharePointFramework/ProjectExtensions/src/components/DocumentTemplateDialog/TargetFolderScreen/index.tsx
@@ -30,6 +30,11 @@ export const TargetFolderScreen: FC = () => {
     state.targetFolder || context.currentFolderUrl || ''
   )
 
+  function onFolderClick(clickedFolder: SPFolder) {
+    if (clickedFolder.isLibrary) setRoot(clickedFolder)
+    setFolder(clickedFolder.url)
+  }
+
   useEffect(() => {
     if (folder === null) {
       setFolders(context.libraries)
@@ -63,14 +68,11 @@ export const TargetFolderScreen: FC = () => {
       ) : (
         <DetailsList
           items={folders.sort((a, b) => (a.name > b.name ? 1 : -1))}
-          columns={columns()}
+          columns={columns({ onFolderClick })}
           selectionMode={SelectionMode.none}
           layoutMode={DetailsListLayoutMode.justified}
           constrainMode={ConstrainMode.horizontalConstrained}
-          onItemInvoked={(folder: SPFolder) => {
-            if (folder.isLibrary) setRoot(folder)
-            setFolder(folder.url)
-          }}
+          onItemInvoked={onFolderClick}
         />
       )}
       <DialogFooter>

--- a/SharePointFramework/ProjectExtensions/src/extensions/templateSelector/context.ts
+++ b/SharePointFramework/ProjectExtensions/src/extensions/templateSelector/context.ts
@@ -22,6 +22,11 @@ export interface ITemplateSelectorContext {
    * Template library
    */
   templateLibrary?: { title: string; url: string }
+
+  /**
+   * Current folder URL (server relative) where the command was triggered
+   */
+  currentFolderUrl?: string
 }
 
 export const TemplateSelectorContext = createContext<ITemplateSelectorContext>(null)

--- a/SharePointFramework/ProjectExtensions/src/extensions/templateSelector/index.tsx
+++ b/SharePointFramework/ProjectExtensions/src/extensions/templateSelector/index.tsx
@@ -90,6 +90,10 @@ export default class TemplateSelectorCommand extends BaseListViewCommandSet<ITem
         )
         if (!this._ctxValue.currentLibrary)
           this._ctxValue.currentLibrary = first(this._ctxValue.libraries)
+        this._ctxValue.currentFolderUrl =
+          new URLSearchParams(window.location.search).get('id') ||
+          new URLSearchParams(window.location.search).get('RootFolder') ||
+          undefined
         this._onOpenTemplateSelector()
         break
     }


### PR DESCRIPTION
# Pull request (PR)

Sørg for at du ber om PR for din branch (høyre side). Sørg for at du gjør en PR mot riktig release-branch (venstre side). Sjekk commits og alle commit-meldingene.

## Sjekklisten din

Alle sjekkpunktene under må være sjekket av og godkjent for at vi skal kunne merge branchen din mot release-branch.

- [x] Legg ved beskrivelse i [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md), markert med **ID av issue** (dersom relevant) knyttet til PR-en
- [x] Angi korrekt `Milestone` på PR-en og issuet, samt tilegn deg selv PR-en og legg til `labels`

### Beskrivelse

Denne PR-en forbedrer templateSelector-utvidelsen (dokumentmaler) på to måter:

**1. Standard målmappe settes til nåværende mappe**

Når brukeren er inne i en undermappe i et dokumentbibliotek og klikker "Hent dokumentmal", så defaulter "kopier mal til"-steget nå til den mappen brukeren befinner seg i, i stedet for roten av biblioteket. Nåværende mappe-URL leses fra sidens URL-parametere (`id` / `RootFolder`) og sendes gjennom `TemplateSelectorContext` til dialogen.

**2. Enkelt-klikk mappenavigasjon i målmappe-steget**

Mapper i målmappe-steget kan nå navigeres med enkelt-klikk på mappenavnet. Tidligere krevde det dobbelt-klikk (via `onItemInvoked`), selv om mappenavnene var stylet som klikkbare lenker. Nå har `<Link>`-elementene `onClick`-handlere, som matcher mønsteret allerede brukt i mal-velger-steget (SelectScreen).

| Før | Etter |
| --- | ----- |
| Målmappe defaultet alltid til roten av biblioteket, uavhengig av hvor brukeren befant seg. | Målmappe defaulter til nåværende mappe når brukeren er i en undermappe. |
| Mapper i målmappe-steget krevde dobbelt-klikk for å navigere inn i. | Mapper navigeres med enkelt-klikk på mappenavnet. |

### Hvordan teste

1. **Naviger til en undermappe i et dokumentbibliotek og klikk "Hent dokumentmal"** — Verifiser at målmappen defaulter til undermappen brukeren befinner seg i.
2. **Utfør kommandoen fra roten av biblioteket** — Verifiser at det fortsatt defaulter til roten (eksisterende oppførsel).
3. **I målmappe-steget, klikk én gang på et mappenavn** — Verifiser at det navigerer inn i mappen uten å kreve dobbelt-klikk.
4. **Sjekk brødsmulenavigasjonen** — Verifiser at brødsmulene viser riktig sti når man starter fra en undermappe, og at man kan navigere tilbake via brødsmulene.
5. **Gå tilbake fra redigeringssteget til målmappe-steget** — Verifiser at den tidligere valgte mappen er bevart.

### Relevante issues (hvis aktuelt)

-

## Sjekkliste for godkjenner

Alle sjekkpunktene under må være sjekket av og godkjent av reviewers for at vi skal kunne merge branchen din mot dev.

- [x] Sjekk at det er fylt ut testpunkter
- [x] Sjekk om det er nødvendig å nevne denne PR i release notes
- [x] Sjekk om det er nødvendig å oppdatere dokumentasjon for hjelpeinnhold
  - Ta en titt på [Brukermanual for Prosjektportalen 365](https://puzzlepart.github.io/prosjektportalen-manual/) og vurder behovet for oppdateringer.