### PR TITLE
fix: hotfix for boolean values in DynamicList

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Sjekk ut [release notes](./releasenotes/1.12.0.md) for høydepunkter og mer deta
 - Kolonner i tidslinjelisten følger nå rekkefølgen som er definert på innholdstypen. Felt som er skjult på innholdstypen ekskluderes også fra kolonner og redigeringspanel
 - Kolonner i porteføljeoversikten respekterer nå innstillingen `Vis i porteføljeoversikt` i `Prosjektkolonner` listen og fjerner de fra visningen, selv om kolonnen er definert i visningen i `Porteføljevisninger` listen. Tidligere lå disse kolonnene fortsatt i visningen, selv om kolonnen ikke var tilgjengelig i vis/skjul kolonner panelet, og dermed kunne aldri fjernes
 - Rettet en feil hvor `Hent dokumentmal` gjorde gjentatte kall mot hubområdet og `Malbibliotek` ved innlasting av dokumentbibliotek, selv om brukeren ikke åpnet dialogen [#1749](https://github.com/Puzzlepart/prosjektportalen365/pull/1749)
+- Rettet en feil i `Dynamisk Liste` hvor Ja/Nei verdier alltid viser som "Nei"
 
 ---
 

--- a/SharePointFramework/ProjectWebParts/src/components/DynamicList/views/ListView/ListView.tsx
+++ b/SharePointFramework/ProjectWebParts/src/components/DynamicList/views/ListView/ListView.tsx
@@ -247,6 +247,7 @@ export const ListView: FC<IListViewProps> = ({
                   />
                   {columns.map((column, colIndex) => {
                     const isFirstColumn = colIndex === 0
+                    const isBoolean = typeof (item as any)[column.columnId] === 'boolean'
                     const cellContent = column.renderCell
                       ? column.renderCell(item)
                       : (item as any)[column.columnId]
@@ -278,7 +279,7 @@ export const ListView: FC<IListViewProps> = ({
                             )}
                           </TableCellLayout>
                         ) : (
-                          <TableCellLayout>{cellContent}</TableCellLayout>
+                          <TableCellLayout>{isBoolean ? (item[column.columnId] ? strings.Yes : strings.No) : cellContent}</TableCellLayout>
                         )}
                       </TableCell>
                     )


### PR DESCRIPTION
# Pull request (PR)

Sørg for at du ber om PR for din branch (høyre side). Sørg for at du gjør en PR mot riktig release-branch (venstre side). Sjekk commits og alle commit-meldingene.

## Sjekklisten din

Alle sjekkpunktene under må være sjekket av og godkjent for at vi skal kunne merge branchen din mot release-branch.

- [X] Legg ved beskrivelse i [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md), markert med **ID av issue** (dersom relevant) knyttet til PR-en
- [X] Angi korrekt `Milestone` på PR-en og issuet, samt tilegn deg selv PR-en og legg til `labels`

### Beskrivelse

Boolean verdier ble alltid rendret som "Nei." Lagt til en ekstra sjekk etter boolean felt. Hvis boolean felt sjekker vi verdi og rendrer `strings.Yes` eller `strings.No`

Dette er en hotfix, ikke er permanent løsning.

### Hvordan teste

Vennligst beskriv hvordan noen andre (en vanlig bruker uten kodeferdigheter) kan teste denne PR-en. Følg eksempelet under, punktene du legger ved vil bli brukt når vi tester neste versjon av Prosjektportalen

1. **Lag en dynamisk listevisning for en liste med Ja/Nei kolonne** 
2. **Sjekk at Ja/Nei verdiene vises som de skal**

### Relevante issues (hvis aktuelt)

- #1747 

## Sjekkliste for godkjenner

Alle sjekkpunktene under må være sjekket av og godkjent av reviewers for at vi skal kunne merge branchen din mot dev.

- [ ] Sjekk at det er fylt ut testpunkter
- [ ] Sjekk om det er nødvendig å nevne denne PR i release notes
- [ ] Sjekk om det er nødvendig å oppdatere dokumentasjon for hjelpeinnhold
  - Ta en titt på [Brukermanual for Prosjektportalen 365](https://puzzlepart.github.io/prosjektportalen-manual/) og vurder behovet for oppdateringer.
