### PR TITLE
fix: lazy-load document templates in command set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Sjekk ut [release notes](./releasenotes/1.12.0.md) for høydepunkter og mer deta
 
 ### Feilrettinger
 
+- Rettet en feil hvor `Hent dokumentmal` gjorde gjentatte kall mot hubområdet og `Malbibliotek` ved innlasting av dokumentbibliotek, selv om brukeren ikke åpnet dialogen [#1749](https://github.com/Puzzlepart/prosjektportalen365/pull/1749)
 - Rettet en feil hvor valgte filter for Ja/Nei verdier ikke var krysset av når man åpnet filterpanelet på nytt i porteføljeoversikten, selv om filtrene var lagt på korrekt
 - Rettet en feil i `Prosjekttidslinje` hvor skjulte SharePoint-systemfelt (f.eks. `Vedlegg`, `Rekkefølge`, `Navn`) feilaktig dukket opp som kolonner i tidslinjelisten og som felter i redigeringspanelet. Felt som er skjult på den valgte innholdstypen (eller på malens innholdstype) ekskluderes nå fra både kolonner og redigeringspanel
 - Kolonner i tidslinjelisten følger nå rekkefølgen som er definert på innholdstypen. Felt som er skjult på innholdstypen ekskluderes også fra kolonner og redigeringspanel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,11 @@ Sjekk ut [release notes](./releasenotes/1.12.0.md) for høydepunkter og mer deta
 
 ### Feilrettinger
 
-- Rettet en feil hvor `Hent dokumentmal` gjorde gjentatte kall mot hubområdet og `Malbibliotek` ved innlasting av dokumentbibliotek, selv om brukeren ikke åpnet dialogen [#1749](https://github.com/Puzzlepart/prosjektportalen365/pull/1749)
 - Rettet en feil hvor valgte filter for Ja/Nei verdier ikke var krysset av når man åpnet filterpanelet på nytt i porteføljeoversikten, selv om filtrene var lagt på korrekt
 - Rettet en feil i `Prosjekttidslinje` hvor skjulte SharePoint-systemfelt (f.eks. `Vedlegg`, `Rekkefølge`, `Navn`) feilaktig dukket opp som kolonner i tidslinjelisten og som felter i redigeringspanelet. Felt som er skjult på den valgte innholdstypen (eller på malens innholdstype) ekskluderes nå fra både kolonner og redigeringspanel
 - Kolonner i tidslinjelisten følger nå rekkefølgen som er definert på innholdstypen. Felt som er skjult på innholdstypen ekskluderes også fra kolonner og redigeringspanel
 - Kolonner i porteføljeoversikten respekterer nå innstillingen `Vis i porteføljeoversikt` i `Prosjektkolonner` listen og fjerner de fra visningen, selv om kolonnen er definert i visningen i `Porteføljevisninger` listen. Tidligere lå disse kolonnene fortsatt i visningen, selv om kolonnen ikke var tilgjengelig i vis/skjul kolonner panelet, og dermed kunne aldri fjernes
+- Rettet en feil hvor `Hent dokumentmal` gjorde gjentatte kall mot hubområdet og `Malbibliotek` ved innlasting av dokumentbibliotek, selv om brukeren ikke åpnet dialogen [#1749](https://github.com/Puzzlepart/prosjektportalen365/pull/1749)
 
 ---
 

--- a/SharePointFramework/ProjectExtensions/src/extensions/templateSelector/index.tsx
+++ b/SharePointFramework/ProjectExtensions/src/extensions/templateSelector/index.tsx
@@ -25,6 +25,8 @@ export default class TemplateSelectorCommand extends BaseListViewCommandSet<ITem
   private _ctxValue: ITemplateSelectorContext = {}
   private _placeholderIds = { DocumentTemplateDialog: getId('documenttemplatedialog') }
   private _hasAccessToTemplateLibrary: boolean = true
+  private _isDataLoaded: boolean = false
+  private _loadDataPromise: Promise<boolean> = null
 
   @override
   public async onInit() {
@@ -35,10 +37,6 @@ export default class TemplateSelectorCommand extends BaseListViewCommandSet<ITem
     })
     Logger.subscribe(ConsoleListener())
     Logger.activeLogLevel = sessionStorage.DEBUG || DEBUG ? LogLevel.Info : LogLevel.Warning
-    await SPDataAdapter.configure(this.context, {
-      siteId: this.context.pageContext.site.id.toString(),
-      webUrl: this.context.pageContext.web.absoluteUrl
-    })
     this._openCmd = this.tryGetCommand('OPEN_TEMPLATE_SELECTOR')
     if (!this._openCmd) return
 
@@ -50,36 +48,6 @@ export default class TemplateSelectorCommand extends BaseListViewCommandSet<ITem
       '%23'
     )}'/%3E%3C/svg%3E`
     this._openCmd.iconImageUrl = exportSvg
-
-    try {
-      const templateLib = this.properties.templateLibrary || resource.Lists_TemplateLibrary_Title
-      this._ctxValue.templateLibrary = {
-        title: templateLib,
-        url: `${SPDataAdapter.portalDataService.url}/${templateLib}`
-      }
-      this._hasAccessToTemplateLibrary = SPDataAdapter.portalDataService?.isAvailable ?? false
-      if (!this._hasAccessToTemplateLibrary) {
-        Logger.log({
-          message:
-            '(TemplateSelectorCommand) onInit: Hub is unavailable for current user. Command will be disabled.',
-          level: LogLevel.Info
-        })
-        return
-      }
-      this._ctxValue.templates = await SPDataAdapter.getDocumentTemplates(
-        templateLib,
-        '<View Scope="RecursiveAll"></View>'
-      )
-      Logger.log({
-        message: `(TemplateSelectorCommand) onInit: Retrieved ${this._ctxValue.templates.length} templates from the specified template library`,
-        level: LogLevel.Info
-      })
-    } catch (error) {
-      Logger.log({
-        message: '(TemplateSelectorCommand) onInit: Failed to initialize',
-        level: LogLevel.Warning
-      })
-    }
   }
 
   @override
@@ -94,10 +62,10 @@ export default class TemplateSelectorCommand extends BaseListViewCommandSet<ITem
 
   @override
   public async onExecute(event: IListViewCommandSetExecuteEventParameters): Promise<void> {
-    if (!this._hasAccessToTemplateLibrary) return
     // eslint-disable-next-line default-case
     switch (event.itemId) {
       case this._openCmd.id:
+        if (!(await this._ensureDataLoaded())) return
         this._ctxValue.libraries = await SPDataAdapter.getLibraries()
         this._ctxValue.currentLibrary = find(
           this._ctxValue.libraries,
@@ -111,6 +79,58 @@ export default class TemplateSelectorCommand extends BaseListViewCommandSet<ITem
           undefined
         this._onOpenTemplateSelector()
         break
+    }
+  }
+
+  private async _ensureDataLoaded(): Promise<boolean> {
+    if (this._isDataLoaded) return true
+    if (this._loadDataPromise) return this._loadDataPromise
+
+    this._loadDataPromise = this._loadData()
+    return this._loadDataPromise
+  }
+
+  private async _loadData(): Promise<boolean> {
+    try {
+      await SPDataAdapter.configure(this.context, {
+        siteId: this.context.pageContext.site.id.toString(),
+        webUrl: this.context.pageContext.web.absoluteUrl
+      })
+
+      const templateLib = this.properties.templateLibrary || resource.Lists_TemplateLibrary_Title
+      this._ctxValue.templateLibrary = {
+        title: templateLib,
+        url: `${SPDataAdapter.portalDataService.url}/${templateLib}`
+      }
+      this._hasAccessToTemplateLibrary = SPDataAdapter.portalDataService?.isAvailable ?? false
+      if (!this._hasAccessToTemplateLibrary) {
+        Logger.log({
+          message:
+            '(TemplateSelectorCommand) _loadData: Hub is unavailable for current user. Command will be disabled.',
+          level: LogLevel.Info
+        })
+        this.raiseOnChange()
+        return false
+      }
+      this._ctxValue.templates = await SPDataAdapter.getDocumentTemplates(
+        templateLib,
+        '<View Scope="RecursiveAll"></View>'
+      )
+      this._isDataLoaded = true
+      Logger.log({
+        message: `(TemplateSelectorCommand) _loadData: Retrieved ${this._ctxValue.templates.length} templates from the specified template library`,
+        level: LogLevel.Info
+      })
+      return true
+    } catch (error) {
+      this._loadDataPromise = null
+      this._hasAccessToTemplateLibrary = false
+      this.raiseOnChange()
+      Logger.log({
+        message: '(TemplateSelectorCommand) _loadData: Failed to initialize',
+        level: LogLevel.Warning
+      })
+      return false
     }
   }
 

--- a/SharePointFramework/shared-library/src/services/PortalDataService/PortalDataService.ts
+++ b/SharePointFramework/shared-library/src/services/PortalDataService/PortalDataService.ts
@@ -153,29 +153,35 @@ export class PortalDataService extends DataService<IPortalDataServiceConfigurati
       this.hubSiteId =
         this._configuration.spfxContext.pageContext?.legacyPageContext?.hubSiteId || ''
       try {
-        const response = await fetch(
-          `${
-            this._configuration.spfxContext.pageContext.web.absoluteUrl
-          }/_api/HubSites/GetById('${encodeURIComponent(this.hubSiteId)}')`,
-          {
-            method: 'GET',
-            headers: {
-              Accept: 'application/json;odata=nometadata'
-            },
-            credentials: 'include'
-          }
+        this.url = await new PnPClientStorage().local.getOrPut(
+          `hubsite_${(this.hubSiteId ?? '').replace(/-/g, '')}_url`,
+          async () => {
+            const response = await fetch(
+              `${
+                this._configuration.spfxContext.pageContext.web.absoluteUrl
+              }/_api/HubSites/GetById('${encodeURIComponent(this.hubSiteId)}')`,
+              {
+                method: 'GET',
+                headers: {
+                  Accept: 'application/json;odata=nometadata'
+                },
+                credentials: 'include'
+              }
+            )
+            if (!response.ok) {
+              throw new Error(
+                `HubSites/GetById responded with ${response.status} ${response.statusText}`
+              )
+            }
+            const contentType = response.headers.get('content-type') ?? ''
+            if (!contentType.includes('application/json')) {
+              throw new Error(`HubSites/GetById returned non-JSON content-type: ${contentType}`)
+            }
+            const hubSite = await response.json()
+            return hubSite?.SiteUrl ?? ''
+          },
+          expire
         )
-        if (!response.ok) {
-          throw new Error(
-            `HubSites/GetById responded with ${response.status} ${response.statusText}`
-          )
-        }
-        const contentType = response.headers.get('content-type') ?? ''
-        if (!contentType.includes('application/json')) {
-          throw new Error(`HubSites/GetById returned non-JSON content-type: ${contentType}`)
-        }
-        const hubSite = await response.json()
-        this.url = hubSite?.SiteUrl ?? ''
       } catch (error) {
         Logger.write(
           `(PortalDataService) (onInit) HubSites/GetById failed, falling back to search: ${


### PR DESCRIPTION
# Pull request (PR)

Sørg for at du ber om PR for din branch (høyre side). Sørg for at du gjør en PR mot riktig release-branch (venstre side). Sjekk commits og alle commit-meldingene.

## Sjekklisten din

Alle sjekkpunktene under må være sjekket av og godkjent for at vi skal kunne merge branchen din mot release-branch.

- [x] Legg ved beskrivelse i [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md), markert med **ID av issue** (dersom relevant) knyttet til PR-en
- [x] Angi korrekt `Milestone` på PR-en og issuet, samt tilegn deg selv PR-en og legg til `labels`

### Beskrivelse

Fikser unødvendige kall fra Malvelger (`TemplateSelectorCommand`) ved åpning av dokumentbibliotek.

Live-verifisering på testsiden viste at dokumentbiblioteket kjørte gjentatte kall ved lasting/navigasjon:

- `HubSites/GetById(...)` ble kalt 19 ganger i én reload-capture
- `Malbibliotek/getitems?$expand=File,Folder,FieldValuesAsText` ble kalt 18 ganger i samme capture
- Begge kallene kom fra `template-selector-command-set_...js`, med stack via `onInit` / `configure`

Rotårsaken var at kommandoen konfigurerte `SPDataAdapter` og hentet alle dokumentmaler allerede i `onInit()`. Det betyr at hvert SharePoint list-view-init forsøkte å slå opp hubområdet og lese malbiblioteket, selv om brukeren aldri klikket "Hent dokumentmal".

Denne PR-en flytter initiering av hub-/maldata til første faktiske klikk på kommandoen. Data lastes én gang og gjenbrukes så lenge command set-instansen lever. I tillegg caches vellykket `HubSites/GetById`-oppslag i `PortalDataService`, slik at andre komponenter som konfigurerer portaltjenesten slipper å slå opp samme hub-URL på nytt.

| Før | Etter |
| --- | ----- |
| Åpning/navigasjon i dokumentbibliotek trigget gjentatte kall til hub og `Malbibliotek`, uten at brukeren åpnet Malvelger. | Hub og dokumentmaler lastes først når brukeren klikker "Hent dokumentmal". |
| `HubSites/GetById` ble kjørt på nytt ved hver `PortalDataService`-initiering. | Vellykket hub URL-oppslag caches i localStorage på samme eksisterende cache-nøkkel som fallback-søk. |

### Hvordan teste

1. **Åpne et dokumentbibliotek med Malvelger aktivert** – Verifiser i Network-tabben at siden ikke gjør kall til `Malbibliotek/getitems` bare ved innlasting.
2. **Se etter hub-oppslag ved innlasting** – Verifiser at `HubSites/GetById` ikke gjentas fra `template-selector-command-set` ved vanlig listevisning/navigasjon.
3. **Klikk "Hent dokumentmal"** – Verifiser at dialogen åpnes og at dokumentmaler hentes først da.
4. **Klikk "Hent dokumentmal" på nytt i samme sideøkt** – Verifiser at samme command set-instans gjenbruker lastede maldata og ikke henter malene på nytt.
5. **Naviger til en mappe og åpne Malvelger** – Verifiser at eksisterende oppførsel med målmappe/default-mappecapture fortsatt fungerer.

### Relevante issues (hvis aktuelt)

-

## Sjekkliste for godkjenner

Alle sjekkpunktene under må være sjekket av og godkjent av reviewers for at vi skal kunne merge branchen din mot dev.

- [x] Sjekk at det er fylt ut testpunkter
- [x] Sjekk om det er nødvendig å nevne denne PR i release notes
- [x] Sjekk om det er nødvendig å oppdatere dokumentasjon for hjelpeinnhold
  - Ta en titt på [Brukermanual for Prosjektportalen 365](https://puzzlepart.github.io/prosjektportalen-manual/) og vurder behovet for oppdateringer.

### Verifisering utført

- `git diff --check`
- Live Network-capture mot testsite før fix: bekreftet at kallene kommer fra `template-selector-command-set` via `onInit` / `configure`
- Passiv 60 sekunders capture etter at siden var ferdig lastet: ingen steady-state SharePoint-polling observert

Build er ikke kjørt ferdig i ren worktree fordi checkouten mangler genererte `SharedResources` type-deklarasjoner. Med Node 16 kommer SPFx-builden forbi miljøsjekken, men stopper på eksisterende `Cannot find module 'SharedResources'`-feil før den når denne endringen.
