### PR TITLE
feat: Show project info panel button for Portfolio Insight members

### DIFF
--- a/SharePointFramework/PortfolioWebParts/src/components/List/ItemColumn/TitleColumn/index.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/List/ItemColumn/TitleColumn/index.tsx
@@ -1,7 +1,7 @@
 import strings from 'PortfolioWebPartsStrings'
 import { ProjectInformationPanel } from 'pp365-projectwebparts/lib/components/ProjectInformationPanel'
 import { SiteContext } from 'pp365-shared-library'
-import React, { FC, useContext } from 'react'
+import React, { FC, ReactNode, useContext } from 'react'
 import { ListContext } from '../../context'
 import { usePortfolioOverviewContext } from '../../../PortfolioOverview/context'
 import { ITitleColumnProps } from './types'
@@ -35,34 +35,44 @@ export const TitleColumn: FC<ITitleColumnProps> = (props) => {
     isUserInPortfolioManagerGroup || (isParentProject && showChildProjectInfoInProgram)
   const renderProjectInformationPanel = context?.props?.renderTitleProjectInformationPanel
 
+  /**
+   * Renders the title wrapped in a `ProjectInformationPanel` with a toggle button.
+   *
+   * @param children Title element shown in the cell and used as the panel trigger label
+   * @param webAbsoluteUrl Project web URL. Omitted for projects the user has no access to,
+   * in which case the panel falls back to the current (hub) web context — so for those
+   * projects it surfaces hub-side data only, not the project's own web data.
+   */
+  const renderPanel = (children: ReactNode, webAbsoluteUrl?: string) => (
+    <div style={{ display: 'flex', alignItems: 'center' }}>
+      <ProjectInformationPanel
+        {...SiteContext.create(context.props.webPartContext, props.item.SiteId, webAbsoluteUrl)}
+        title={props.item.Title}
+        page='Portfolio'
+        hideAllActions={true}
+        onRenderToggleElement={(onToggle) => (
+          <Tooltip
+            content={<>{strings.ProjectInformationPanelButton}</>}
+            relationship='description'
+            withArrow
+          >
+            <Button
+              appearance='transparent'
+              size='small'
+              icon={<Icons.PanelRight />}
+              onClick={onToggle}
+            />
+          </Tooltip>
+        )}
+      >
+        {children}
+      </ProjectInformationPanel>
+    </div>
+  )
+
   if (!url) {
     if (renderProjectInformationPanel && showPanelButtonWithoutUrl) {
-      return (
-        <div style={{ display: 'flex', alignItems: 'center' }}>
-          <ProjectInformationPanel
-            {...SiteContext.create(context.props.webPartContext, props.item.SiteId, url)}
-            title={props.item.Title}
-            page='Portfolio'
-            hideAllActions={true}
-            onRenderToggleElement={(onToggle) => (
-              <Tooltip
-                content={<>{strings.ProjectInformationPanelButton}</>}
-                relationship='description'
-                withArrow
-              >
-                <Button
-                  appearance='transparent'
-                  size='small'
-                  icon={<Icons.PanelRight />}
-                  onClick={onToggle}
-                />
-              </Tooltip>
-            )}
-          >
-            <Text size={200}>{props.item.Title}</Text>
-          </ProjectInformationPanel>
-        </div>
-      )
+      return renderPanel(<Text size={200}>{props.item.Title}</Text>)
     }
     return (
       <span>
@@ -84,34 +94,11 @@ export const TitleColumn: FC<ITitleColumnProps> = (props) => {
         {props.item.Title}
       </Link>
     )
-  } else {
-    return (
-      <div style={{ display: 'flex', alignItems: 'center' }}>
-        <ProjectInformationPanel
-          {...SiteContext.create(context.props.webPartContext, props.item.SiteId, url)}
-          title={props.item.Title}
-          page='Portfolio'
-          hideAllActions={true}
-          onRenderToggleElement={(onToggle) => (
-            <Tooltip
-              content={<>{strings.ProjectInformationPanelButton}</>}
-              relationship='description'
-              withArrow
-            >
-              <Button
-                appearance='transparent'
-                size='small'
-                icon={<Icons.PanelRight />}
-                onClick={onToggle}
-              />
-            </Tooltip>
-          )}
-        >
-          <Link href={url} rel='noopener noreferrer' target='_blank'>
-            {props.item.Title}
-          </Link>
-        </ProjectInformationPanel>
-      </div>
-    )
   }
+  return renderPanel(
+    <Link href={url} rel='noopener noreferrer' target='_blank'>
+      {props.item.Title}
+    </Link>,
+    url
+  )
 }

--- a/SharePointFramework/PortfolioWebParts/src/components/List/ItemColumn/TitleColumn/index.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/List/ItemColumn/TitleColumn/index.tsx
@@ -28,10 +28,15 @@ export const TitleColumn: FC<ITitleColumnProps> = (props) => {
   const url = props.item?.Path || props.item?.SPWebUrl
   const isUserInPortfolioManagerGroup =
     portfolioOverviewContext?.state?.isUserInPortfolioManagerGroup ?? false
+  const isParentProject = portfolioOverviewContext?.props?.isParentProject ?? false
+  const showChildProjectInfoInProgram =
+    portfolioOverviewContext?.state?.showChildProjectInfoInProgram ?? false
+  const showPanelButtonWithoutUrl =
+    isUserInPortfolioManagerGroup || (isParentProject && showChildProjectInfoInProgram)
   const renderProjectInformationPanel = context?.props?.renderTitleProjectInformationPanel
 
   if (!url) {
-    if (renderProjectInformationPanel && isUserInPortfolioManagerGroup) {
+    if (renderProjectInformationPanel && showPanelButtonWithoutUrl) {
       return (
         <div style={{ display: 'flex', alignItems: 'center' }}>
           <ProjectInformationPanel

--- a/SharePointFramework/PortfolioWebParts/src/components/List/ItemColumn/TitleColumn/index.tsx
+++ b/SharePointFramework/PortfolioWebParts/src/components/List/ItemColumn/TitleColumn/index.tsx
@@ -3,6 +3,7 @@ import { ProjectInformationPanel } from 'pp365-projectwebparts/lib/components/Pr
 import { SiteContext } from 'pp365-shared-library'
 import React, { FC, useContext } from 'react'
 import { ListContext } from '../../context'
+import { usePortfolioOverviewContext } from '../../../PortfolioOverview/context'
 import { ITitleColumnProps } from './types'
 import { Text, Button, Link, Tooltip } from '@fluentui/react-components'
 import {
@@ -23,9 +24,41 @@ const Icons = {
 
 export const TitleColumn: FC<ITitleColumnProps> = (props) => {
   const context = useContext(ListContext)
+  const portfolioOverviewContext = usePortfolioOverviewContext()
   const url = props.item?.Path || props.item?.SPWebUrl
+  const isUserInPortfolioManagerGroup =
+    portfolioOverviewContext?.state?.isUserInPortfolioManagerGroup ?? false
+  const renderProjectInformationPanel = context?.props?.renderTitleProjectInformationPanel
 
   if (!url) {
+    if (renderProjectInformationPanel && isUserInPortfolioManagerGroup) {
+      return (
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          <ProjectInformationPanel
+            {...SiteContext.create(context.props.webPartContext, props.item.SiteId, url)}
+            title={props.item.Title}
+            page='Portfolio'
+            hideAllActions={true}
+            onRenderToggleElement={(onToggle) => (
+              <Tooltip
+                content={<>{strings.ProjectInformationPanelButton}</>}
+                relationship='description'
+                withArrow
+              >
+                <Button
+                  appearance='transparent'
+                  size='small'
+                  icon={<Icons.PanelRight />}
+                  onClick={onToggle}
+                />
+              </Tooltip>
+            )}
+          >
+            <Text size={200}>{props.item.Title}</Text>
+          </ProjectInformationPanel>
+        </div>
+      )
+    }
     return (
       <span>
         <Text size={200}>{props.item.Title}</Text>
@@ -40,7 +73,7 @@ export const TitleColumn: FC<ITitleColumnProps> = (props) => {
       </span>
     )
   }
-  if (!context?.props?.renderTitleProjectInformationPanel) {
+  if (!renderProjectInformationPanel) {
     return (
       <Link href={url} target='_blank' rel='noopener noreferrer'>
         {props.item.Title}

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/hooks/useFetchData.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/hooks/useFetchData.ts
@@ -104,6 +104,12 @@ export const useFetchData = (context: IPortfolioOverviewContext) => {
         ) ?? Promise.resolve(false)
       ])
 
+      // Global toggle (default off) — only populated in program/parent context
+      // where `BaseProgramWebPart` configures `loadGlobalSettings: true`. In the
+      // flat portfolio overview `globalSettings` is undefined and this stays false.
+      const showChildProjectInfoInProgram =
+        context.props.dataAdapter.globalSettings?.get('ShowChildProjectInfoInProgram') === '1'
+
       let groupBy = currentView.groupBy
       if (hashState.has('groupBy') && !groupBy) {
         groupBy = _.find(
@@ -129,7 +135,8 @@ export const useFetchData = (context: IPortfolioOverviewContext) => {
           currentView,
           groupBy,
           managedProperties,
-          isUserInPortfolioManagerGroup
+          isUserInPortfolioManagerGroup,
+          showChildProjectInfoInProgram
         })
       )
     } catch (error) {

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/hooks/useFetchData.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/hooks/useFetchData.ts
@@ -6,6 +6,7 @@ import _ from 'lodash'
 import { PortfolioOverviewView } from 'pp365-shared-library/lib/models'
 import { parseUrlHash } from 'pp365-shared-library/lib/util/parseUrlHash'
 import { useEffect } from 'react'
+import resource from 'SharedResources'
 import { IPortfolioOverviewContext } from '../context'
 import { DATA_FETCH_ERROR, DATA_FETCHED, STARTING_DATA_FETCH } from '../reducer'
 import { PortfolioOverviewErrorMessage } from '../types'
@@ -78,32 +79,30 @@ export const useFetchData = (context: IPortfolioOverviewContext) => {
         context.props.portfolios &&
         context.props.portfolios.length > 1
 
-      let items: any[]
-      let managedProperties: string[]
+      const fetchViewData = shouldFetchMerged
+        ? context.props.dataAdapter.fetchMergedViewData(
+            currentView,
+            context.props.portfolios,
+            context.props.configuration
+          )
+        : context.props.isParentProject
+        ? context.props.dataAdapter.fetchDataForViewBatch(
+            currentView,
+            context.props.configuration,
+            context.props.configuration.hubSiteId
+          )
+        : context.props.dataAdapter.fetchDataForView(
+            currentView,
+            context.props.configuration,
+            context.props.configuration.hubSiteId
+          )
 
-      if (shouldFetchMerged) {
-        const result = await context.props.dataAdapter.fetchMergedViewData(
-          currentView,
-          context.props.portfolios,
-          context.props.configuration
-        )
-        items = result.items
-        managedProperties = result.managedProperties
-      } else {
-        const result = context.props.isParentProject
-          ? await context.props.dataAdapter.fetchDataForViewBatch(
-              currentView,
-              context.props.configuration,
-              context.props.configuration.hubSiteId
-            )
-          : await context.props.dataAdapter.fetchDataForView(
-              currentView,
-              context.props.configuration,
-              context.props.configuration.hubSiteId
-            )
-        items = result.items
-        managedProperties = result.managedProperties
-      }
+      const [{ items, managedProperties }, isUserInPortfolioManagerGroup] = await Promise.all([
+        fetchViewData,
+        context.props.dataAdapter.isUserInGroup?.(
+          resource.Security_SiteGroup_PortfolioInsight_Title
+        ) ?? Promise.resolve(false)
+      ])
 
       let groupBy = currentView.groupBy
       if (hashState.has('groupBy') && !groupBy) {
@@ -129,7 +128,8 @@ export const useFetchData = (context: IPortfolioOverviewContext) => {
           items,
           currentView,
           groupBy,
-          managedProperties
+          managedProperties,
+          isUserInPortfolioManagerGroup
         })
       )
     } catch (error) {

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/hooks/useFetchData.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/hooks/useFetchData.ts
@@ -104,9 +104,7 @@ export const useFetchData = (context: IPortfolioOverviewContext) => {
         ) ?? Promise.resolve(false)
       ])
 
-      // Global toggle (default off) — only populated in program/parent context
-      // where `BaseProgramWebPart` configures `loadGlobalSettings: true`. In the
-      // flat portfolio overview `globalSettings` is undefined and this stays false.
+      // `globalSettings` is only populated in program/parent context, so this stays false elsewhere.
       const showChildProjectInfoInProgram =
         context.props.dataAdapter.globalSettings?.get('ShowChildProjectInfoInProgram') === '1'
 

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/reducer/actions.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/reducer/actions.ts
@@ -23,6 +23,7 @@ export const DATA_FETCHED = createAction<{
   groupBy: ProjectColumn
   managedProperties: string[]
   isUserInPortfolioManagerGroup: boolean
+  showChildProjectInfoInProgram: boolean
 }>('DATA_FETCHED')
 
 /**

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/reducer/actions.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/reducer/actions.ts
@@ -22,6 +22,7 @@ export const DATA_FETCHED = createAction<{
   currentView: PortfolioOverviewView
   groupBy: ProjectColumn
   managedProperties: string[]
+  isUserInPortfolioManagerGroup: boolean
 }>('DATA_FETCHED')
 
 /**

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/reducer/index.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/reducer/index.ts
@@ -78,6 +78,7 @@ const $createReducer = (params: IPortfolioOverviewReducerParams) =>
         state.groupBy = payload.groupBy
         state.managedProperties = payload.managedProperties ?? []
         state.isUserInPortfolioManagerGroup = payload.isUserInPortfolioManagerGroup
+        state.showChildProjectInfoInProgram = payload.showChildProjectInfoInProgram
         state.loading = false
         state.error = null
         state.isChangingView = false

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/reducer/index.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/reducer/index.ts
@@ -77,6 +77,7 @@ const $createReducer = (params: IPortfolioOverviewReducerParams) =>
         state.columns = payload.currentView.columns
         state.groupBy = payload.groupBy
         state.managedProperties = payload.managedProperties ?? []
+        state.isUserInPortfolioManagerGroup = payload.isUserInPortfolioManagerGroup
         state.loading = false
         state.error = null
         state.isChangingView = false

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/types.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/types.ts
@@ -285,6 +285,13 @@ export interface IPortfolioOverviewState
    * Available managed properties for the current search query
    */
   managedProperties?: string[]
+
+  /**
+   * Whether the current user is a member of the Portfolio Insight site group.
+   * When true, the project information panel button is shown in `TitleColumn`
+   * even for projects where the user has no site access.
+   */
+  isUserInPortfolioManagerGroup?: boolean
 }
 
 export interface IPortfolioOverviewHashState {

--- a/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/types.ts
+++ b/SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/types.ts
@@ -292,6 +292,14 @@ export interface IPortfolioOverviewState
    * even for projects where the user has no site access.
    */
   isUserInPortfolioManagerGroup?: boolean
+
+  /**
+   * Value of the global setting `ShowChildProjectInfoInProgram`.
+   * When true and `isParentProject` is set, the project information panel
+   * button is shown in `TitleColumn` for all child projects of a program —
+   * including those the user has no site access to.
+   */
+  showChildProjectInfoInProgram?: boolean
 }
 
 export interface IPortfolioOverviewHashState {

--- a/SharePointFramework/PortfolioWebParts/src/data/types.ts
+++ b/SharePointFramework/PortfolioWebParts/src/data/types.ts
@@ -225,6 +225,14 @@ export interface IPortfolioWebPartsDataAdapter {
   isUserInGroup?(groupName: string): Promise<boolean>
 
   /**
+   * Global settings loaded from the portal site, indexed by `GtSettingsKey`.
+   * Only populated when the adapter was configured with `loadGlobalSettings: true`
+   * (currently true for `BaseProgramWebPart`, but not for the portfolio-side
+   * `DataAdapter`). Optional so consumers can read it null-safely.
+   */
+  globalSettings?: Map<string, string>
+
+  /**
    * Fetches data for the Projecttimeline project.
    *
    * @param timelineConfig Timeline configuration

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/data/useProjectInformationDataFetch.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/data/useProjectInformationDataFetch.ts
@@ -59,9 +59,8 @@ const fetchData: DataFetchFunction<
   try {
     const isFrontpage = context.props.page === 'Frontpage'
     const shouldFetchArchiveStatus = isFrontpage && !context.props.hideArchiveStatus
-    // Wrapped in `safeCall` so that users without read access to the project site
-    // (e.g. Portfolio Insight members opening the panel from a portfolio overview)
-    // still get the hub-side data instead of a hard error.
+    // Empty fallback for users without read access to the project site (e.g. the
+    // Portfolio Insight panel opened from a portfolio overview) instead of a hard error.
     const projectInformationData = await safeCall(
       () => SPDataAdapter.project.getProjectInformationData(),
       {

--- a/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/data/useProjectInformationDataFetch.ts
+++ b/SharePointFramework/ProjectWebParts/src/components/ProjectInformation/data/useProjectInformationDataFetch.ts
@@ -4,6 +4,7 @@ import { PermissionKind } from '@pnp/sp/presets/all'
 import strings from 'ProjectWebPartsStrings'
 import {
   CustomError,
+  ItemFieldValues,
   ListLogger,
   ProjectAdminPermission,
   ProjectInformationParentProject,
@@ -58,7 +59,18 @@ const fetchData: DataFetchFunction<
   try {
     const isFrontpage = context.props.page === 'Frontpage'
     const shouldFetchArchiveStatus = isFrontpage && !context.props.hideArchiveStatus
-    const projectInformationData = await SPDataAdapter.project.getProjectInformationData()
+    // Wrapped in `safeCall` so that users without read access to the project site
+    // (e.g. Portfolio Insight members opening the panel from a portfolio overview)
+    // still get the hub-side data instead of a hard error.
+    const projectInformationData = await safeCall(
+      () => SPDataAdapter.project.getProjectInformationData(),
+      {
+        fieldValues: new ItemFieldValues(),
+        fields: [],
+        propertiesListId: null,
+        templateParameters: {}
+      }
+    )
 
     let hubIsAvailable = SPDataAdapter.portalDataService?.isAvailable ?? false
     const columns = hubIsAvailable ? await SPDataAdapter.portalDataService.getProjectColumns() : []

--- a/Templates/Portfolio/Objects/Lists/Globale innstillinger.xml
+++ b/Templates/Portfolio/Objects/Lists/Globale innstillinger.xml
@@ -102,6 +102,14 @@
       <pnp:DataValue FieldName="GtSettingsCategory">{resource:Lists_Global_Settings_Category_General}</pnp:DataValue>
     </pnp:DataRow>
     <pnp:DataRow>
+      <pnp:DataValue FieldName="GtSettingsId">{a5c3bc29-758f-4a68-a668-e5cb894d2aa1}</pnp:DataValue>
+      <pnp:DataValue FieldName="Title">{resource:Lists_Global_Settings_Category_General_ShowChildProjectInfoInProgram_Title}</pnp:DataValue>
+      <pnp:DataValue FieldName="GtSettingsKey">ShowChildProjectInfoInProgram</pnp:DataValue>
+      <pnp:DataValue FieldName="GtSettingsValue">0</pnp:DataValue>
+      <pnp:DataValue FieldName="GtSettingsEnabled">True</pnp:DataValue>
+      <pnp:DataValue FieldName="GtSettingsCategory">{resource:Lists_Global_Settings_Category_General}</pnp:DataValue>
+    </pnp:DataRow>
+    <pnp:DataRow>
       <pnp:DataValue FieldName="GtSettingsId">{fb8cb873-ac5f-45e0-a091-1e14bfc7ea33}</pnp:DataValue>
       <pnp:DataValue FieldName="Title">{resource:Lists_Global_Settings_Category_General_MinimizeFooter_Title}</pnp:DataValue>
       <pnp:DataValue FieldName="GtSettingsKey">MinimizeFooter</pnp:DataValue>

--- a/Templates/Portfolio/Resources.en-US.resx
+++ b/Templates/Portfolio/Resources.en-US.resx
@@ -1501,6 +1501,9 @@
   <data name="Lists_Global_Settings_Category_General_ProjectNewsHubUrl_Title" xml:space="preserve">
     <value>URL for news publishing site</value>
   </data>
+  <data name="Lists_Global_Settings_Category_General_ShowChildProjectInfoInProgram_Title" xml:space="preserve">
+    <value>Show project information for all projects in programs and parent projects</value>
+  </data>
   <data name="Lists_Global_Settings_Category_General_ShowFooter_Title" xml:space="preserve">
     <value>Show/hide footer in Project Portal</value>
   </data>

--- a/Templates/Portfolio/Resources.no-NB.resx
+++ b/Templates/Portfolio/Resources.no-NB.resx
@@ -1501,6 +1501,9 @@
   <data name="Lists_Global_Settings_Category_General_ProjectNewsHubUrl_Title" xml:space="preserve">
     <value>URL til område for nyhetspublisering</value>
   </data>
+  <data name="Lists_Global_Settings_Category_General_ShowChildProjectInfoInProgram_Title" xml:space="preserve">
+    <value>Vis prosjektinformasjon for alle prosjekter i program og overordna prosjekter</value>
+  </data>
   <data name="Lists_Global_Settings_Category_General_ShowFooter_Title" xml:space="preserve">
     <value>Vis/skjul footer i Prosjektportalen</value>
   </data>

--- a/Templates/Portfolio/Resources.no-NB.resx
+++ b/Templates/Portfolio/Resources.no-NB.resx
@@ -1502,7 +1502,7 @@
     <value>URL til område for nyhetspublisering</value>
   </data>
   <data name="Lists_Global_Settings_Category_General_ShowChildProjectInfoInProgram_Title" xml:space="preserve">
-    <value>Vis prosjektinformasjon for alle prosjekter i program og overordna prosjekter</value>
+    <value>Vis prosjektinformasjon for alle prosjekter i program og overordnede prosjekter</value>
   </data>
   <data name="Lists_Global_Settings_Category_General_ShowFooter_Title" xml:space="preserve">
     <value>Vis/skjul footer i Prosjektportalen</value>


### PR DESCRIPTION
## Summary

To-trinns endring av prosjektinfo-panel-knappen i `TitleColumn`:

### Steg 1 — Porteføljeinnsyn-medlemmer ser alltid knappen (commit 4a0634c)

I dag vises `EyeOff`-ikon for rader uten `Path`/`SPWebUrl` (brukeren mangler site-tilgang). Men medlemmer av site-gruppen *Porteføljeinnsyn* har per definisjon tilgang til all prosjektinformasjon via hub-en. Endringen eksponerer `isUserInPortfolioManagerGroup` på `PortfolioOverviewContext` (hentes parallelt med data-fetch i `useFetchData`), og lar `TitleColumn` vise panel-knappen — tittelen blir ren tekst uten lenke (siden brukeren ikke kan åpne site-en).

For å unngå at panelet ender i en feiltilstand når prosjekt-siten faktisk er utilgjengelig, er `SPDataAdapter.project.getProjectInformationData()` wrappet i den eksisterende `safeCall`-helperen med tom `ItemFieldValues`-fallback. Hub-data hentes som før.

### Steg 2 — Ny global innstilling for program-medlemmer (commit 6688199)

Ny opt-in-innstilling i lista *Globale innstillinger* (kategori `General`, default `0`):

- **Nøkkel:** `ShowChildProjectInfoInProgram`
- **GUID:** `{a5c3bc29-758f-4a68-a668-e5cb894d2aa1}`
- **Tittel (nb-NO):** "Vis prosjektinformasjon for alle prosjekter i program og overordna prosjekter"
- **Tittel (en-US):** "Show project information for all projects in programs and parent projects"

Når aktivert: alle medlemmer av et program-område (= alle som kan laste program-siten) ser panel-knappen for samtlige barneprosjekter i "Oversikt over underområder", uavhengig av site-tilgang. Når av (default): dagens `EyeOff`-oppførsel bevares for ikke-Porteføljeinnsyn-brukere.

Innstillingen leses fra `dataAdapter.globalSettings` (lastes allerede av `BaseProgramWebPart`), plumbes gjennom `DATA_FETCHED`, og kombineres med Porteføljeinnsyn-flagget i `TitleColumn`:

```ts
showPanelButtonWithoutUrl =
  isUserInPortfolioManagerGroup
    || (isParentProject && showChildProjectInfoInProgram)
```

Porteføljeinnsyn-medlemmer trumfer alltid — de ser knappen uavhengig av innstillingen.

## Affected files

```
Templates/Portfolio/Objects/Lists/Globale innstillinger.xml
Templates/Portfolio/Resources.no-NB.resx
Templates/Portfolio/Resources.en-US.resx
SharePointFramework/PortfolioWebParts/src/data/types.ts
SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/types.ts
SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/reducer/actions.ts
SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/reducer/index.ts
SharePointFramework/PortfolioWebParts/src/components/PortfolioOverview/hooks/useFetchData.ts
SharePointFramework/PortfolioWebParts/src/components/List/ItemColumn/TitleColumn/index.tsx
SharePointFramework/ProjectWebParts/src/components/ProjectInformation/data/useProjectInformationDataFetch.ts
```

Ingen endringer i data-adaptrene (`DataAdapter.ts`/`SPDataAdapter.ts`), `IListProps`, eller `ListContext`.

## Test plan

### Steg 1 (Porteføljeinnsyn)

- [ ] Build kjører rent i `SharePointFramework/PortfolioWebParts` og `SharePointFramework/ProjectWebParts`.
- [ ] **Porteføljeinnsyn-bruker:** Naviger til et program-område med "Oversikt over underområder". Alle rader — inkludert de som tidligere viste `EyeOff` — viser panel-knappen.
- [ ] **Porteføljeinnsyn-bruker uten site-tilgang:** Klikk knappen for et utilgjengelig prosjekt. Panelet åpnes og viser hub-data uten hel-side-feilmelding.
- [ ] **Porteføljeinnsyn-bruker, flat porteføljeoversikt:** Samme oppførsel som over.
- [ ] **Bruker uten Porteføljeinnsyn (innstilling AV):** Prosjekter uten site-tilgang viser fortsatt `EyeOff` — ingen regresjon.

### Steg 2 (global innstilling)

- [ ] **Provisjonering:** Etter install/upgrade — bekreft at den nye raden vises i lista *Globale innstillinger* under `General`, med tittelen "Vis prosjektinformasjon for alle prosjekter i program og overordna prosjekter" og `GtSettingsValue=0`.
- [ ] **Innstilling AV (default), program-medlem uten Porteføljeinnsyn:** Prosjekter uten site-tilgang viser `EyeOff` (uendret).
- [ ] **Innstilling PÅ, samme bruker:** Alle rader viser panel-knappen. Klikk på et utilgjengelig prosjekt — panelet åpnes og degraderer pent.
- [ ] **Innstilling PÅ, bruker MED Porteføljeinnsyn:** Uendret — knappen vises uansett.
- [ ] **Innstilling PÅ, flat porteføljeoversikt (`isParentProject=false`)** for bruker uten Porteføljeinnsyn: ingen effekt — innstillingen sjekkes kun i program-grenen.

### Regresjon

- [ ] **PortfolioAggregation:** rader rendres som før (tittel + ev. `EyeOff`); `usePortfolioOverviewContext()` returnerer `null` utenfor `PortfolioOverview`.
- [ ] **Flat PortfolioOverview** for porteføljeadmin med insight: uendret for prosjekter som allerede har URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)