### PR TITLE
fix: Skip setup wizard on Teams channel sites (#1754)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Sjekk ut [release notes](./releasenotes/1.12.0.md) for høydepunkter og mer deta
 - Kolonner i porteføljeoversikten respekterer nå innstillingen `Vis i porteføljeoversikt` i `Prosjektkolonner` listen og fjerner de fra visningen, selv om kolonnen er definert i visningen i `Porteføljevisninger` listen. Tidligere lå disse kolonnene fortsatt i visningen, selv om kolonnen ikke var tilgjengelig i vis/skjul kolonner panelet, og dermed kunne aldri fjernes
 - Rettet en feil hvor `Hent dokumentmal` gjorde gjentatte kall mot hubområdet og `Malbibliotek` ved innlasting av dokumentbibliotek, selv om brukeren ikke åpnet dialogen [#1749](https://github.com/Puzzlepart/prosjektportalen365/pull/1749)
 - Rettet en feil i `Dynamisk Liste` hvor Ja/Nei verdier alltid viser som "Nei"
+- Rettet en feil i oppsettveiviseren hvor private og delte Teams-kanaler (som oppretter egne SharePoint-områder knyttet til huben) feilaktig trigget oppsettveiviseren. Områdene mangler en Microsoft 365-gruppe, noe som førte til feildialogen «Invalid object identifier 'null'.» ved hver sideinnlasting. Veiviseren oppdager nå kanalområder (`TEAMCHANNEL`) og fjernes stille uten å gjøre endringer på området [#1754](https://github.com/Puzzlepart/prosjektportalen365/issues/1754)
 
 ---
 

--- a/SharePointFramework/ProjectExtensions/src/extensions/projectSetup/deleteCustomizer.ts
+++ b/SharePointFramework/ProjectExtensions/src/extensions/projectSetup/deleteCustomizer.ts
@@ -5,22 +5,37 @@ import ProjectSetup from 'extensions/projectSetup'
 /**
  * Delete customizer for the specified project setup instance.
  *
+ * Best-effort: deleting a user custom action requires Full Control, so on sites
+ * where the current user lacks that permission (e.g. a non-owner member on a
+ * Teams channel site) the failure is logged and swallowed rather than surfaced
+ * as an error dialog. The leftover custom action is cleaned up the next time an
+ * owner visits.
+ *
  * @param instance Project setup instance
  */
 export async function deleteCustomizer(instance: ProjectSetup): Promise<void> {
-  const web = instance.sp.web as IWeb
-  const customActions = await web.userCustomActions<
-    { Id: string; ClientSideComponentId: string }[]
-  >()
-  for (let i = 0; i < customActions.length; i++) {
-    const customAction = customActions[i]
-    if (customAction.ClientSideComponentId === instance.componentId) {
-      Logger.log({
-        message: `(ProjectSetup) [_deleteCustomizer]: Deleting custom action ${customAction.Id}`,
-        level: LogLevel.Info
-      })
-      await web.userCustomActions.getById(customAction.Id).delete()
-      break
+  try {
+    const web = instance.sp.web as IWeb
+    const customActions = await web.userCustomActions<
+      { Id: string; ClientSideComponentId: string }[]
+    >()
+    for (let i = 0; i < customActions.length; i++) {
+      const customAction = customActions[i]
+      if (customAction.ClientSideComponentId === instance.componentId) {
+        Logger.log({
+          message: `(ProjectSetup) [deleteCustomizer]: Deleting custom action ${customAction.Id}`,
+          level: LogLevel.Info
+        })
+        await web.userCustomActions.getById(customAction.Id).delete()
+        break
+      }
     }
+  } catch (error) {
+    Logger.log({
+      message: `(ProjectSetup) [deleteCustomizer]: Could not delete custom action (likely insufficient permissions); ignoring. ${
+        error?.message ?? ''
+      }`,
+      level: LogLevel.Warning
+    })
   }
 }

--- a/SharePointFramework/ProjectExtensions/src/extensions/projectSetup/index.ts
+++ b/SharePointFramework/ProjectExtensions/src/extensions/projectSetup/index.ts
@@ -81,6 +81,14 @@ export default class ProjectSetup extends BaseApplicationCustomizer<IProjectSetu
             strings.NoGroupIdErrorStack
           )
         }
+        case ProjectSetupValidation.IsTeamChannel: {
+          Logger.write(
+            `(ProjectSetup) Site is a Teams channel (${this.context.pageContext.web.absoluteUrl}); removing setup customizer silently.`,
+            LogLevel.Info
+          )
+          await deleteCustomizer(this)
+          return
+        }
         case ProjectSetupValidation.InvalidWebLanguage: {
           await deleteCustomizer(this)
           throw new ProjectSetupError(
@@ -613,6 +621,16 @@ export default class ProjectSetup extends BaseApplicationCustomizer<IProjectSetu
   private async _validateProjectSetup(): Promise<ProjectSetupValidation> {
     const { isSiteAdmin, groupId, hubSiteId, siteId } = this.context.pageContext.legacyPageContext
 
+    // Teams private/shared channels create their own hub-associated SharePoint site
+    // (web template `TEAMCHANNEL`) which inherits the project site design but is not
+    // a project and has no M365 group. Detect and skip silently.
+    const { WebTemplate } = await this.sp.web.select('WebTemplate')()
+    if (WebTemplate === 'TEAMCHANNEL') return ProjectSetupValidation.IsTeamChannel
+
+    // Safety net: a site without an M365 group cannot be set up as a project and
+    // must not reach the `groups/{id}/members` call below with a null id.
+    if (!groupId) return ProjectSetupValidation.NoGroupId
+
     this._portalDataService = await new PortalDataService().configure({
       spfxContext: this.context
     })
@@ -622,7 +640,6 @@ export default class ProjectSetup extends BaseApplicationCustomizer<IProjectSetu
       return ProjectSetupValidation.UserNotGroupMember
     }
     if (!isSiteAdmin) return ProjectSetupValidation.NotSiteAdmin
-    if (!groupId) return ProjectSetupValidation.NoGroupId
     if (this.context.pageContext.web.language !== 1044) {
       const { Language } = await this._portalDataService.web.select('Language')()
       if (Language !== this.context.pageContext.web.language) {

--- a/SharePointFramework/ProjectExtensions/src/extensions/projectSetup/index.ts
+++ b/SharePointFramework/ProjectExtensions/src/extensions/projectSetup/index.ts
@@ -621,14 +621,12 @@ export default class ProjectSetup extends BaseApplicationCustomizer<IProjectSetu
   private async _validateProjectSetup(): Promise<ProjectSetupValidation> {
     const { isSiteAdmin, groupId, hubSiteId, siteId } = this.context.pageContext.legacyPageContext
 
-    // Teams private/shared channels create their own hub-associated SharePoint site
-    // (web template `TEAMCHANNEL`) which inherits the project site design but is not
-    // a project and has no M365 group. Detect and skip silently.
+    // `WebTemplate` returns the template name without its config number, so this
+    // matches both `TEAMCHANNEL#0` (private) and `TEAMCHANNEL#1` (shared) channels.
     const { WebTemplate } = await this.sp.web.select('WebTemplate')()
     if (WebTemplate === 'TEAMCHANNEL') return ProjectSetupValidation.IsTeamChannel
 
-    // Safety net: a site without an M365 group cannot be set up as a project and
-    // must not reach the `groups/{id}/members` call below with a null id.
+    // Must precede the `groups/{groupId}/members` call below, which fails on a null id.
     if (!groupId) return ProjectSetupValidation.NoGroupId
 
     this._portalDataService = await new PortalDataService().configure({

--- a/SharePointFramework/ProjectExtensions/src/extensions/projectSetup/types.ts
+++ b/SharePointFramework/ProjectExtensions/src/extensions/projectSetup/types.ts
@@ -171,8 +171,9 @@ export enum ProjectSetupValidation {
   /**
    * The site is a Teams private/shared channel site (web template
    * `TEAMCHANNEL`). Channel sites are hub-associated and inherit the project
-   * site design, but are not projects and have no M365 group. The wizard is
-   * removed silently without touching the site or involving the user.
+   * site design, but are not projects and have no M365 group. The setup
+   * customizer is removed silently (best-effort; see `deleteCustomizer`)
+   * without involving the user.
    */
   IsTeamChannel
 }

--- a/SharePointFramework/ProjectExtensions/src/extensions/projectSetup/types.ts
+++ b/SharePointFramework/ProjectExtensions/src/extensions/projectSetup/types.ts
@@ -166,5 +166,13 @@ export enum ProjectSetupValidation {
    * 365 group. This will cause issues
    * provisioning Planner resources.
    */
-  UserNotGroupMember
+  UserNotGroupMember,
+
+  /**
+   * The site is a Teams private/shared channel site (web template
+   * `TEAMCHANNEL`). Channel sites are hub-associated and inherit the project
+   * site design, but are not projects and have no M365 group. The wizard is
+   * removed silently without touching the site or involving the user.
+   */
+  IsTeamChannel
 }


### PR DESCRIPTION
## Sjekklisten din

- [x] Lagt ved beskrivelse i [CHANGELOG](https://github.com/Puzzlepart/prosjektportalen365/blob/dev/CHANGELOG.md), markert med **ID av issue** ([#1754](https://github.com/Puzzlepart/prosjektportalen365/issues/1754))
- [ ] Angi korrekt `Milestone` på PR-en og issuet, samt tilegn deg selv PR-en og legg til `labels`

### Beskrivelse

Når man oppretter en **privat eller delt kanal** i et Teams-team som er knyttet til Prosjektportalen, oppretter Microsoft et eget SharePoint-område bak kulissene for kanalen (områdemal `TEAMCHANNEL`). Fordi området er knyttet til huben, arver det prosjektområde-sitedesignet, og dermed aktiveres oppsettveiviseren (`ProjectSetup`-applikasjonstilpasningen).

Kanalområder er **ikke** prosjekter og har **ingen egen Microsoft 365-gruppe**, så `legacyPageContext.groupId` er `null`. Valideringen i veiviseren kalte Microsoft Graph for gruppemedlemmene **før** den sjekket om en gruppe-ID fantes:

```
GET https://graph.microsoft.com/v1.0/groups/null/members 400 (Bad Request)
→ dialog «Invalid object identifier 'null'.»
```

Graph-feilen boblet rett til `onInit`-feilhåndteringen, slik at veiviseren **aldri ble fjernet** (`deleteCustomizer` ble aldri nådd) og dialogen dukket opp ved **hver sideinnlasting**.

**Endring:** Veiviseren oppdager nå kanalområder via `TEAMCHANNEL`-områdemalen (dekker både private `TEAMCHANNEL#0` og delte `TEAMCHANNEL#1` kanaler) og fjerner oppsettveiviseren **stille** — uten Graph-kall, uten dialog, uten endringer på området og uten å involvere brukeren. I tillegg er `null`-sjekken for `groupId` flyttet foran Graph-kallet som et sikkerhetsnett.

Ingen visuelle endringer (feilen var en uønsket feildialog som nå forsvinner).

### Hvordan teste

1. **Opprett en privat kanal og en delt kanal** i et Teams-team som er knyttet til et Prosjektportalen-prosjekt — kanalens eget SharePoint-område opprettes automatisk.
2. **Åpne kanalens SharePoint-område** (f.eks. via «Åpne i SharePoint» fra Filer-fanen i kanalen). Forventet: ingen dialog med «Invalid object identifier 'null'.» dukker opp, og siden lastes normalt.
3. **Last siden på nytt.** Forventet: oppsettveiviseren dukker ikke opp igjen (den er fjernet), og kanalområdet er uendret (ingen prosjektmal er lagt på).
4. **Åpne et vanlig prosjektområde.** Forventet: oppsettveiviseren fungerer som før for nye prosjekter.

### Relevante issues

- [#1754](https://github.com/Puzzlepart/prosjektportalen365/issues/1754)